### PR TITLE
Only check requirements in `configure.py`

### DIFF
--- a/ppdet/core/config/schema.py
+++ b/ppdet/core/config/schema.py
@@ -23,32 +23,13 @@ import re
 try:
     from docstring_parser import parse as doc_parse
 except Exception:
-
     def doc_parse(*args):
-        if not doc_parse.__warning_sent__:
-            from ppdet.utils.cli import ColorTTY
-            color_tty = ColorTTY()
-            message = "docstring_parser is not installed, " \
-                + "argument description is not available"
-            print(color_tty.yellow(message))
-            doc_parse.__warning_sent__ = True
-
-    doc_parse.__warning_sent__ = False
-
+        pass
 try:
     from typeguard import check_type
 except Exception:
-
     def check_type(*args):
-        if not check_type.__warning_sent__:
-            from ppdet.utils.cli import ColorTTY
-            color_tty = ColorTTY()
-            message = "typeguard is not installed," \
-                + "type checking is not available"
-            print(color_tty.yellow(message))
-            check_type.__warning_sent__ = True
-
-    check_type.__warning_sent__ = False
+        pass
 
 __all__ = ['SchemaValue', 'SchemaDict', 'SharedConfig', 'extract_schema']
 

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -24,6 +24,20 @@ from ppdet.utils.cli import ColorTTY, print_total_cfg
 
 color_tty = ColorTTY()
 
+try:
+    from docstring_parser import parse as doc_parse
+except Exception:
+    message = "docstring_parser is not installed, " \
+        + "argument description is not available"
+    print(color_tty.yellow(message))
+
+try:
+    from typeguard import check_type
+except Exception:
+    message = "typeguard is not installed," \
+        + "type checking is not available"
+    print(color_tty.yellow(message))
+
 MISC_CONFIG = {
     "architecture": "<value>",
     "max_iters": "<value>",


### PR DESCRIPTION
to avoid cycle import when required packages are not installed