### PR TITLE
[WIP] Polish Reader

### DIFF
--- a/configs2/faster_loader.yml
+++ b/configs2/faster_loader.yml
@@ -1,0 +1,75 @@
+TrainLoader:
+  inputs_def:
+    image_shape: [3,800,1333]
+    fields: ['image', 'im_info', 'im_id', 'gt_bbox', 'gt_class', 'is_crowd']
+  dataset:
+    !COCODataSet
+    image_dir: val2017
+    anno_path: annotations/instances_val2017.json
+    dataset_dir: dataset/coco
+    sample_num: 10
+  sample_transforms:
+  - !DecodeImage
+    to_rgb: true
+    with_mixup: false
+  - !RandomFlipImage
+    is_mask_flip: false
+    is_normalized: false
+    prob: 0.5
+  - !NormalizeImage
+    is_channel_first: false
+    is_scale: true
+    mean: [0.485,0.456,0.406]
+    std: [0.229, 0.224,0.225]
+  - !ResizeImage
+    interp: 1
+    max_size: 1333
+    target_size: 800
+    use_cv2: true
+  - !Permute
+    channel_first: true
+    to_bgr: false
+  batch_transforms:
+  - !PadBatch
+    pad_to_stride: 32
+    use_padded_im_info: false
+  batch_size: 1
+  shuffle: true
+  worker_num: 2
+  drop_last: false
+  use_process: false
+
+EvalLoader:
+  inputs_def:
+    image_shape: [3,800,1333]
+    fields: ['image', 'im_info', 'im_id']
+  dataset:
+    !COCODataSet
+    image_dir: val2017
+    anno_path: annotations/instances_val2017.json
+    dataset_dir: dataset/coco
+    sample_num: 10
+  sample_transforms:
+  - !DecodeImage
+    to_rgb: true
+    with_mixup: false
+  - !NormalizeImage
+    is_channel_first: false
+    is_scale: true
+    mean: [0.485,0.456,0.406]
+    std: [0.229, 0.224,0.225]
+  - !ResizeImage
+    interp: 1
+    max_size: 1333
+    target_size: 800
+    use_cv2: true
+  - !Permute
+    channel_first: true
+    to_bgr: false
+  batch_transforms:
+  - !PadBatch
+    pad_to_stride: 32
+    use_padded_im_info: true
+  batch_size: 1
+  shuffle: false
+  drop_last: false

--- a/configs2/faster_rcnn_r50_1x.yml
+++ b/configs2/faster_rcnn_r50_1x.yml
@@ -1,0 +1,96 @@
+architecture: FasterRCNN
+use_gpu: true
+max_iters: 180000
+log_smooth_window: 20
+save_dir: output
+snapshot_iter: 10000
+pretrain_weights: https://paddle-imagenet-models-name.bj.bcebos.com/ResNet50_cos_pretrained.tar
+metric: COCO
+weights: output/faster_rcnn_r50_1x/model_final
+num_classes: 81
+
+FasterRCNN:
+  backbone: ResNet
+  rpn_head: RPNHead
+  roi_extractor: RoIAlign
+  bbox_head: BBoxHead
+  bbox_assigner: BBoxAssigner
+
+ResNet:
+  norm_type: affine_channel
+  depth: 50
+  feature_maps: 4
+  freeze_at: 2
+
+ResNetC5:
+  depth: 50
+  norm_type: affine_channel
+
+RPNHead:
+  anchor_generator:
+    anchor_sizes: [32, 64, 128, 256, 512]
+    aspect_ratios: [0.5, 1.0, 2.0]
+    stride: [16.0, 16.0]
+    variance: [1.0, 1.0, 1.0, 1.0]
+  rpn_target_assign:
+    rpn_batch_size_per_im: 256
+    rpn_fg_fraction: 0.5
+    rpn_negative_overlap: 0.3
+    rpn_positive_overlap: 0.7
+    rpn_straddle_thresh: 0.0
+    use_random: true
+  train_proposal:
+    min_size: 0.0
+    nms_thresh: 0.7
+    pre_nms_top_n: 12000
+    post_nms_top_n: 2000
+  test_proposal:
+    min_size: 0.0
+    nms_thresh: 0.7
+    pre_nms_top_n: 6000
+    post_nms_top_n: 1000
+
+RoIAlign:
+  resolution: 14
+  sampling_ratio: 0
+  spatial_scale: 0.0625
+
+BBoxAssigner:
+  batch_size_per_im: 512
+  bbox_reg_weights: [0.1, 0.1, 0.2, 0.2]
+  bg_thresh_hi: 0.5
+  bg_thresh_lo: 0.0
+  fg_fraction: 0.25
+  fg_thresh: 0.5
+
+BBoxHead:
+  head: ResNetC5
+  nms:
+    keep_top_k: 100
+    nms_threshold: 0.5
+    score_threshold: 0.05
+
+LearningRate:
+  base_lr: 0.01
+  schedulers:
+  - !PiecewiseDecay
+    gamma: 0.1
+    milestones: [120000, 160000]
+  - !LinearWarmup
+    start_factor: 0.3333333333333333
+    steps: 500
+
+OptimizerBuilder:
+  optimizer:
+    momentum: 0.9
+    type: Momentum
+  regularizer:
+    factor: 0.0001
+    type: L2
+
+_LOADER_: 'faster_loader.yml'
+TrainLoader:
+  inputs_def:
+    image_shape: [3,800,800]
+    fields: ['image', 'im_info', 'im_id', 'gt_bbox', 'gt_class', 'is_crowd']
+  batch_size: 3

--- a/ppdet/data2/__init__.py
+++ b/ppdet/data2/__init__.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#from .operators import BaseOperator, registered_ops
+from . import operators
+from . import batch_operators
+from . import loader
+from . import coco
+from . import voc
+
+from .operators import *
+from .batch_operators import *
+from .loader import *
+from .coco import *
+from .voc import *
+
+__all__ = []
+
+#for nm in registered_ops:
+#    op = getattr(BaseOperator, nm)
+#    locals()[nm] = op
+
+__all__ += registered_ops
+
+print(__all__)

--- a/ppdet/data2/batch_operators.py
+++ b/ppdet/data2/batch_operators.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+import cv2
+import numpy as np
+
+from .operators import register_op, BaseOperator
+
+logger = logging.getLogger(__name__)
+
+
+@register_op
+class PadBatch(BaseOperator):
+    """
+    Pad a batch of samples to same dimensions.
+    The layout of each image should be 'CHW'.
+
+    Args:
+        pad_to_stride (int): pad to multiple of strides, e.g., 32
+    """
+
+    def __init__(self, pad_to_stride=0, use_padded_im_info=True):
+        super(PadBatch, self).__init__()
+        self.pad_to_stride = pad_to_stride
+        self.use_padded_im_info = use_padded_im_info
+
+    def __call__(self, samples, context=None):
+        """
+        Args:
+            samples (list): a batch of sample, each is dict.
+        """
+        coarsest_stride = self.pad_to_stride
+        if len(samples) == 1 and coarsest_stride == 0:
+            return samples
+        max_shape = np.array([data['image'].shape for data in samples]).max(
+            axis=0)
+
+        if coarsest_stride > 0:
+            max_shape[1] = int(
+                np.ceil(max_shape[1] / coarsest_stride) * coarsest_stride)
+            max_shape[2] = int(
+                np.ceil(max_shape[2] / coarsest_stride) * coarsest_stride)
+
+        padding_batch = []
+        for data in samples:
+            im = data['image']
+            im_c, im_h, im_w = im.shape[:]
+            padding_im = np.zeros(
+                (im_c, max_shape[1], max_shape[2]), dtype=np.float32)
+            padding_im[:, :im_h, :im_w] = im
+            data['image'] = padding_im
+
+            if self.use_padded_im_info:
+                data['im_info'][:2] = max_shape[1:3]
+        return samples
+
+
+@register_op
+class RandomShape(BaseOperator):
+    """
+    Randomly reshape a batch
+
+    Args:
+        sizes (list): list of int, random choose a size from these
+    """
+
+    def __init__(self, sizes=[]):
+        super(RandomShape, self).__init__()
+        self.sizes = sizes
+
+    def __call__(self, samples, context=None):
+        # For YOLO: gt_bbox is normalized, is scale invariant.
+        shape = np.random.choice(self.sizes)
+        scaled_batch = []
+        h, w = samples[0]['image'].shape[1:3]
+        scale_x = float(shape) / w
+        scale_y = float(shape) / h
+        for data in samples:
+            im = cv2.resize(
+                data['image'].transpose((1, 2, 0)),
+                None,
+                None,
+                fx=scale_x,
+                fy=scale_y,
+                interpolation=cv2.INTER_NEAREST)
+            data['image'] = im
+        return samples
+
+
+@register_op
+class PadMultiScaleTest(BaseOperator):
+    """
+    Padding for multi-scale test
+ 
+    Args:
+        pad_to_stride (int): pad to multiple of strides, e.g., 32
+    """
+
+    def __init__(self, pad_to_stride=0):
+        super(PadMultiScaleTest, self).__init__()
+        self.pad_to_stride = pad_to_stride
+
+    def __call__(self, samples, context=None):
+        if len(samples) != 1:
+            raise ValueError("Batch size must be 1 when using multiscale test, "
+                             "but now batch size is {}".format(len(samples)))
+        coarsest_stride = self.pad_to_stride
+        if coarsest_stride == 0:
+            return samples
+
+        data = samples[0]
+        assert 'multi_scales_image' in data
+        for i in range(len(samples['multi_scales_image'])):
+            im = data['multi_scales_image'][i]['image']
+            im_c, im_h, im_w = im.shape
+            max_h = int(np.ceil(im_h / coarsest_stride) * coarsest_stride)
+            max_w = int(np.ceil(im_w / coarsest_stride) * coarsest_stride)
+            padding_im = np.zeros((im_c, max_h, max_w), dtype=np.float32)
+
+            padding_im[:, :im_h, :im_w] = im
+            data['multi_scales_image'][i]['image'] = padding_im
+            # update im_info
+            data['multi_scales_image'][i]['im_info'][:2] = [max_h, max_w]
+        samples[0] = data
+        return samples

--- a/ppdet/data2/batch_operators.py
+++ b/ppdet/data2/batch_operators.py
@@ -87,20 +87,20 @@ class RandomShape(BaseOperator):
     def __call__(self, samples, context=None):
         # For YOLO: gt_bbox is normalized, is scale invariant.
         shape = np.random.choice(self.sizes)
-        scaled_batch = []
         h, w = samples[0]['image'].shape[1:3]
         scale_x = float(shape) / w
         scale_y = float(shape) / h
+        out_samples = []
         for data in samples:
             im = cv2.resize(
-                data['image'].transpose((1, 2, 0)),
+                data['image'],
                 None,
                 None,
                 fx=scale_x,
                 fy=scale_y,
                 interpolation=cv2.INTER_NEAREST)
-            data['image'] = im
-        return samples
+            out_samples.append(data)
+        return out_samples
 
 
 @register_op

--- a/ppdet/data2/coco.py
+++ b/ppdet/data2/coco.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import numpy as np
+from pycocotools.coco import COCO
+
+from dataset import DataSet
+from ppdet.core.workspace import register, serializable
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+@register
+@serializable
+class COCODataSet(DataSet):
+    """
+    Load COCO records with annotations in json file 'anno_path'
+
+    Args:
+        anno_path (str): json file path
+        sample_num (int): number of samples to load, -1 means all
+        with_background (bool): whether load background as a class.
+                                if True, total class number will
+                                be 81. default True
+
+    Returns:
+        (records, cname2cid)
+        'records' is list of dict whose structure is:
+        {
+            'im_file': im_fname, # image file name
+            'im_id': img_id, # image id
+            'h': im_h, # height of image
+            'w': im_w, # width
+            'is_crowd': is_crowd,
+            'gt_score': gt_score,
+            'gt_class': gt_class,
+            'gt_bbox': gt_bbox,
+            'gt_poly': gt_poly,
+        }
+        'cname2cid' is a dict used to map category name to class id
+    """
+
+    def __init__(self,
+                 image_dir,
+                 anno_path,
+                 sample_num=-1,
+                 with_background=True,
+                 dataset_dir=None):
+        self.anno_path = anno_path
+        self.sample_num = sample_num
+        self.with_background = with_background
+        self.image_dir = image_dir
+        if dataset_dir:
+            self.image_dir = os.path.join(dataset_dir, image_dir)
+        self.roidbs = None
+        self.cname2cid = None
+
+    def get_roidb(self):
+        if not self.roidbs:
+            self.roidbs, self.cname2cid = self.load_roidb()
+        return self.roidbs
+
+    def get_cname2cid(self):
+        if not self.cname2cid:
+            self.roidbs, self.cname2cid = self.load_roidb()
+        return self.cname2cid
+
+    def load_roidb(self):
+        assert self.anno_path.endswith('.json'), \
+            'invalid coco annotation file: ' + anno_path
+        coco = COCO(self.anno_path)
+        img_ids = coco.getImgIds()
+        cat_ids = coco.getCatIds()
+        records = []
+        ct = 0
+
+        # when with_background = True, mapping category to classid, like:
+        #   background:0, first_class:1, second_class:2, ...
+        catid2clsid = dict({
+            catid: i + int(self.with_background)
+            for i, catid in enumerate(cat_ids)
+        })
+        cname2cid = dict({
+            coco.loadCats(catid)[0]['name']: clsid
+            for catid, clsid in catid2clsid.items()
+        })
+
+        for img_id in img_ids:
+            img_anno = coco.loadImgs(img_id)[0]
+            im_fname = img_anno['file_name']
+            im_w = float(img_anno['width'])
+            im_h = float(img_anno['height'])
+
+            ins_anno_ids = coco.getAnnIds(imgIds=img_id, iscrowd=False)
+            instances = coco.loadAnns(ins_anno_ids)
+
+            bboxes = []
+            for inst in instances:
+                x, y, box_w, box_h = inst['bbox']
+                x1 = max(0, x)
+                y1 = max(0, y)
+                x2 = min(im_w - 1, x1 + max(0, box_w - 1))
+                y2 = min(im_h - 1, y1 + max(0, box_h - 1))
+                if inst['area'] > 0 and x2 >= x1 and y2 >= y1:
+                    inst['clean_bbox'] = [x1, y1, x2, y2]
+                    bboxes.append(inst)
+                else:
+                    logger.warn(
+                        'Found an invalid bbox in annotations: im_id: {}, '
+                        'area: {} x1: {}, y1: {}, x2: {}, y2: {}.'.format(
+                            img_id, float(inst['area']), x1, y1, x2, y2))
+            num_bbox = len(bboxes)
+
+            gt_bbox = np.zeros((num_bbox, 4), dtype=np.float32)
+            gt_class = np.zeros((num_bbox, 1), dtype=np.int32)
+            gt_score = np.ones((num_bbox, 1), dtype=np.float32)
+            is_crowd = np.zeros((num_bbox, 1), dtype=np.int32)
+            difficult = np.zeros((num_bbox, 1), dtype=np.int32)
+            gt_poly = [None] * num_bbox
+
+            for i, box in enumerate(bboxes):
+                catid = box['category_id']
+                gt_class[i][0] = catid2clsid[catid]
+                gt_bbox[i, :] = box['clean_bbox']
+                is_crowd[i][0] = box['iscrowd']
+                if 'segmentation' in box:
+                    gt_poly[i] = box['segmentation']
+
+            im_fname = os.path.join(self.image_dir,
+                                    im_fname) if self.image_dir else im_fname
+            coco_rec = {
+                'im_file': im_fname,
+                'im_id': np.array([img_id]),
+                'h': im_h,
+                'w': im_w,
+                'is_crowd': is_crowd,
+                'gt_class': gt_class,
+                'gt_bbox': gt_bbox,
+                'gt_score': gt_score,
+                'gt_poly': gt_poly,
+                'difficult': difficult
+            }
+
+            logger.debug('Load file: {}, im_id: {}, h: {}, w: {}.'.format(
+                im_fname, img_id, im_h, im_w))
+            records.append(coco_rec)
+            ct += 1
+            if self.sample_num > 0 and ct >= self.sample_num:
+                break
+        assert len(records) > 0, 'not found any coco record in %s' % (
+            self.anno_path)
+        logger.info('{} samples in file {}'.format(ct, self.anno_path))
+        return records, cname2cid

--- a/ppdet/data2/coco.py
+++ b/ppdet/data2/coco.py
@@ -65,6 +65,7 @@ class COCODataSet(DataSet):
         self.image_dir = image_dir
         if dataset_dir:
             self.image_dir = os.path.join(dataset_dir, image_dir)
+            self.anno_path = os.path.join(dataset_dir, anno_path)
         self.roidbs = None
         self.cname2cid = None
 

--- a/ppdet/data2/dataset.py
+++ b/ppdet/data2/dataset.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ppdet.core.workspace import register, serializable
+
+
+@serializable
+class DataSet(object):
+    """
+    Dataset, e.g., coco, pascal voc
+
+    Args:
+        annotation (str): annotation file path
+        image_dir (str): directory where image files are stored
+        shuffle (bool): shuffle samples
+    """
+    __source__ = 'RoiDbSource'
+
+    def __init__(self,
+                 annotation,
+                 image_dir=None,
+                 dataset_dir=None,
+                 use_default_label=None,
+                 data_dir=None):
+        super(DataSet, self).__init__()
+        self.annotation = annotation
+        self.image_dir = image_dir
+        self.dataset_dir = dataset_dir
+        self.use_default_label = use_default_label
+
+    def get_roidb(self):
+        """get dataset dict in this dataset"""
+        raise NotImplementedError('%s.get_roidb not available' %
+                                  (self.__class__.__name__))
+
+    def get_cname2cid(self):
+        """get mapping between category to classid in this dataset"""
+        raise NotImplementedError('%s.get_cname2cid not available' %
+                                  (self.__class__.__name__))

--- a/ppdet/data2/loader.py
+++ b/ppdet/data2/loader.py
@@ -1,0 +1,269 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import copy
+import functools
+import collections
+import traceback
+import numpy as np
+import logging
+
+from ppdet.core.workspace import register, serializable
+
+from .parallel import ParallelMap
+from .dataset import DataSet
+
+__all__ = ['Loader', 'create_reader']
+
+logger = logging.getLogger(__name__)
+
+
+class Compose(object):
+    def __init__(self, transforms):
+        self.transforms = transforms
+
+    def __call__(self, data):
+        ctx = {}
+        for f in self.transforms:
+            try:
+                data = f(data, ctx)
+            except Exception as e:
+                stack_info = traceback.format_exc()
+                logger.info("fail to map op [{}] with error: {} and stack:\n{}".
+                            format(f, e, str(stack_info)))
+                raise e
+        return data
+
+
+def _calc_img_weights(roidbs):
+    """ calculate the probabilities of each sample
+    """
+    imgs_cls = []
+    num_per_cls = {}
+    img_weights = []
+    for i, roidb in enumerate(roidbs):
+        img_cls = set([k for cls in roidbs[i]['gt_class'] for k in cls])
+        imgs_cls.append(img_cls)
+        for c in img_cls:
+            if c not in num_per_cls:
+                num_per_cls[c] = 1
+            else:
+                num_per_cls[c] += 1
+
+    for i in range(len(roidbs)):
+        weights = 0
+        for c in imgs_cls[i]:
+            weights += 1 / num_per_cls[c]
+        img_weights.append(weights)
+    # probabilities sum to 1
+    img_weights = img_weights / np.sum(img_weights)
+    return img_weights
+
+
+def has_empty(items):
+    def empty(x):
+        if isinstance(x, np.ndarray) and x.size == 0:
+            return True
+        elif isinstance(x, collections.Sequence) and len(x) == 0:
+            return True
+        else:
+            return False
+
+    if any(x is None for x in items):
+        return True
+    if any(empty(x) for x in items):
+        return True
+    return False
+
+
+@register
+@serializable
+class Loader(object):
+    def __init__(self,
+                 dataset=None,
+                 sample_transforms=None,
+                 batch_transforms=None,
+                 batch_size=None,
+                 shuffle=False,
+                 drop_last=False,
+                 drop_empty=True,
+                 mixup_epoch=-1,
+                 class_aware_sampling=False,
+                 worker_num=-1,
+                 use_process=False,
+                 bufsize=100,
+                 memsize='3G'):
+        self._dataset = dataset
+        self._roidbs = self._dataset.get_roidb()
+        # transform
+        self._sample_transforms = Compose(sample_transforms)
+        self._batch_transforms = None
+        if batch_transforms:
+            self._batch_transforms = Compose(batch_transforms)
+
+        # data
+        self._batch_size = batch_size
+        self._shuffle = shuffle
+        self._drop_last = drop_last
+        self._drop_empty = drop_empty
+
+        # sampling
+        self._mixup_epoch = mixup_epoch
+        self._class_aware_sampling = class_aware_sampling
+
+        self._load_img = False
+        self._sample_num = len(self._roidbs)
+
+        if self._class_aware_sampling:
+            self.img_weights = _calc_img_weights(self._roidbs)
+        self._indexes = None
+
+        self._pos = -1
+        self._epoch = -1
+        self._drained = False
+
+        # multi-process
+        self._worker_num = worker_num
+        if self._worker_num > -1:
+            task = functools.partial(self.worker, self._drop_empty)
+            self._parallel = ParallelMap(self, task, worker_num, bufsize,
+                                         use_process, memsize)
+
+    def __call__(self):
+        if self._worker_num > -1:
+            return self._parallel
+        else:
+            return self
+
+    def __iter__(self):
+        return self
+
+    def reset(self):
+        """implementation of Dataset.reset
+        """
+        self.indexes = [i for i in range(self.size())]
+        if self._class_aware_sampling:
+            self.indexes = np.random.choice(
+                self._sample_num,
+                self._sample_num,
+                replace=False,
+                p=self.img_weights)
+
+        if self._shuffle:
+            np.random.shuffle(self.indexes)
+
+        if self._drop_last:
+            self.indexes = self.indexes[0:self.size() // self._batch_size *
+                                        self._batch_size]
+
+        if self._epoch < 0:
+            self._epoch = 0
+        else:
+            self._epoch += 1
+
+        self._pos = 0
+        self._drained = False
+
+    def __next__(self):
+        return self.next()
+
+    def next(self):
+        if self._epoch < 0:
+            self.reset()
+        if self.drained():
+            raise StopIteration('There is no more data in %s.' % (str(self)))
+        batch = self._load_batch()
+        if self._worker_num > -1:
+            return batch
+        else:
+            return self.worker(self._drop_empty, batch)
+
+    def _load_batch(self):
+        batch = []
+        for i in range(self._batch_size):
+            if self._pos >= self.size():
+                break
+            pos = self.indexes[self._pos]
+            sample = copy.deepcopy(self._roidbs[pos])
+
+            if self._load_img:
+                sample['image'] = self._load_image(sample['im_file'])
+
+            if self._epoch < self._mixup_epoch:
+                num = len(self.indexes)
+                mix_idx = random.randint(1, num - 1)
+                mix_idx = (mix_idx + pos) % num
+                sample['mixup'] = copy.deepcopy(roidbs[mix_idx])
+                if self._load_img:
+                    sample['mixup']['image'] = self._load_image(sample['mixup'][
+                        'im_file'])
+
+            batch.append(sample)
+            self._pos += 1
+        return batch
+
+    def worker(self, drop_empty=True, batch_samples=None):
+        """
+        sample transform and data transform.
+        """
+        batch = []
+        for sample in batch_samples:
+            sample = self._sample_transforms(sample)
+            if self._drop_empty and has_empty(sample):
+                continue
+            batch.append(sample)
+        if len(batch) > 0 and self._batch_transforms:
+            batch = self._batch_transforms(batch)
+        return batch
+
+    def size(self):
+        """ implementation of Dataset.size
+        """
+        return self._sample_num
+
+    def drained(self):
+        """ implementation of Dataset.drained
+        """
+        assert self._epoch >= 0, 'The first epoch has not begin!'
+        return self._pos >= self.size()
+
+
+def create_reader(cfg, max_iter=0):
+    """
+    Return iterable data reader.
+
+    Args:
+        max_iter (int): number of iterations.
+    """
+    if not isinstance(cfg, dict):
+        raise TypeError("The config should be a dict when creating reader.")
+
+    def _reader():
+        reader = Loader(**cfg)()
+        n = 0
+        while True:
+            for _batch in reader:
+                yield _batch
+                n += 1
+                if max_iter > 0 and n == max_iter:
+                    return
+            reader.reset()
+            if max_iter <= 0:
+                return
+
+    return _reader

--- a/ppdet/data2/op_helper.py
+++ b/ppdet/data2/op_helper.py
@@ -1,0 +1,389 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# this file contains helper methods for BBOX processing
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import random
+import math
+import cv2
+
+
+def meet_emit_constraint(src_bbox, sample_bbox):
+    center_x = (src_bbox[2] + src_bbox[0]) / 2
+    center_y = (src_bbox[3] + src_bbox[1]) / 2
+    if center_x >= sample_bbox[0] and \
+            center_x <= sample_bbox[2] and \
+            center_y >= sample_bbox[1] and \
+            center_y <= sample_bbox[3]:
+        return True
+    return False
+
+
+def clip_bbox(src_bbox):
+    src_bbox[0] = max(min(src_bbox[0], 1.0), 0.0)
+    src_bbox[1] = max(min(src_bbox[1], 1.0), 0.0)
+    src_bbox[2] = max(min(src_bbox[2], 1.0), 0.0)
+    src_bbox[3] = max(min(src_bbox[3], 1.0), 0.0)
+    return src_bbox
+
+
+def bbox_area(src_bbox):
+    if src_bbox[2] < src_bbox[0] or src_bbox[3] < src_bbox[1]:
+        return 0.
+    else:
+        width = src_bbox[2] - src_bbox[0]
+        height = src_bbox[3] - src_bbox[1]
+        return width * height
+
+
+def is_overlap(object_bbox, sample_bbox):
+    if object_bbox[0] >= sample_bbox[2] or \
+       object_bbox[2] <= sample_bbox[0] or \
+       object_bbox[1] >= sample_bbox[3] or \
+       object_bbox[3] <= sample_bbox[1]:
+        return False
+    else:
+        return True
+
+
+def filter_and_process(sample_bbox, bboxes, labels, scores=None):
+    new_bboxes = []
+    new_labels = []
+    new_scores = []
+    for i in range(len(bboxes)):
+        new_bbox = [0, 0, 0, 0]
+        obj_bbox = [bboxes[i][0], bboxes[i][1], bboxes[i][2], bboxes[i][3]]
+        if not meet_emit_constraint(obj_bbox, sample_bbox):
+            continue
+        if not is_overlap(obj_bbox, sample_bbox):
+            continue
+        sample_width = sample_bbox[2] - sample_bbox[0]
+        sample_height = sample_bbox[3] - sample_bbox[1]
+        new_bbox[0] = (obj_bbox[0] - sample_bbox[0]) / sample_width
+        new_bbox[1] = (obj_bbox[1] - sample_bbox[1]) / sample_height
+        new_bbox[2] = (obj_bbox[2] - sample_bbox[0]) / sample_width
+        new_bbox[3] = (obj_bbox[3] - sample_bbox[1]) / sample_height
+        new_bbox = clip_bbox(new_bbox)
+        if bbox_area(new_bbox) > 0:
+            new_bboxes.append(new_bbox)
+            new_labels.append([labels[i][0]])
+            if scores is not None:
+                new_scores.append([scores[i][0]])
+    bboxes = np.array(new_bboxes)
+    labels = np.array(new_labels)
+    scores = np.array(new_scores)
+    return bboxes, labels, scores
+
+
+def bbox_area_sampling(bboxes, labels, scores, target_size, min_size):
+    new_bboxes = []
+    new_labels = []
+    new_scores = []
+    for i, bbox in enumerate(bboxes):
+        w = float((bbox[2] - bbox[0]) * target_size)
+        h = float((bbox[3] - bbox[1]) * target_size)
+        if w * h < float(min_size * min_size):
+            continue
+        else:
+            new_bboxes.append(bbox)
+            new_labels.append(labels[i])
+            if scores is not None and scores.size != 0:
+                new_scores.append(scores[i])
+    bboxes = np.array(new_bboxes)
+    labels = np.array(new_labels)
+    scores = np.array(new_scores)
+    return bboxes, labels, scores
+
+
+def generate_sample_bbox(sampler):
+    scale = np.random.uniform(sampler[2], sampler[3])
+    aspect_ratio = np.random.uniform(sampler[4], sampler[5])
+    aspect_ratio = max(aspect_ratio, (scale**2.0))
+    aspect_ratio = min(aspect_ratio, 1 / (scale**2.0))
+    bbox_width = scale * (aspect_ratio**0.5)
+    bbox_height = scale / (aspect_ratio**0.5)
+    xmin_bound = 1 - bbox_width
+    ymin_bound = 1 - bbox_height
+    xmin = np.random.uniform(0, xmin_bound)
+    ymin = np.random.uniform(0, ymin_bound)
+    xmax = xmin + bbox_width
+    ymax = ymin + bbox_height
+    sampled_bbox = [xmin, ymin, xmax, ymax]
+    return sampled_bbox
+
+
+def generate_sample_bbox_square(sampler, image_width, image_height):
+    scale = np.random.uniform(sampler[2], sampler[3])
+    aspect_ratio = np.random.uniform(sampler[4], sampler[5])
+    aspect_ratio = max(aspect_ratio, (scale**2.0))
+    aspect_ratio = min(aspect_ratio, 1 / (scale**2.0))
+    bbox_width = scale * (aspect_ratio**0.5)
+    bbox_height = scale / (aspect_ratio**0.5)
+    if image_height < image_width:
+        bbox_width = bbox_height * image_height / image_width
+    else:
+        bbox_height = bbox_width * image_width / image_height
+    xmin_bound = 1 - bbox_width
+    ymin_bound = 1 - bbox_height
+    xmin = np.random.uniform(0, xmin_bound)
+    ymin = np.random.uniform(0, ymin_bound)
+    xmax = xmin + bbox_width
+    ymax = ymin + bbox_height
+    sampled_bbox = [xmin, ymin, xmax, ymax]
+    return sampled_bbox
+
+
+def data_anchor_sampling(bbox_labels, image_width, image_height, scale_array,
+                         resize_width):
+    num_gt = len(bbox_labels)
+    # np.random.randint range: [low, high)
+    rand_idx = np.random.randint(0, num_gt) if num_gt != 0 else 0
+
+    if num_gt != 0:
+        norm_xmin = bbox_labels[rand_idx][0]
+        norm_ymin = bbox_labels[rand_idx][1]
+        norm_xmax = bbox_labels[rand_idx][2]
+        norm_ymax = bbox_labels[rand_idx][3]
+
+        xmin = norm_xmin * image_width
+        ymin = norm_ymin * image_height
+        wid = image_width * (norm_xmax - norm_xmin)
+        hei = image_height * (norm_ymax - norm_ymin)
+        range_size = 0
+
+        area = wid * hei
+        for scale_ind in range(0, len(scale_array) - 1):
+            if area > scale_array[scale_ind] ** 2 and area < \
+                    scale_array[scale_ind + 1] ** 2:
+                range_size = scale_ind + 1
+                break
+
+        if area > scale_array[len(scale_array) - 2]**2:
+            range_size = len(scale_array) - 2
+
+        scale_choose = 0.0
+        if range_size == 0:
+            rand_idx_size = 0
+        else:
+            # np.random.randint range: [low, high)
+            rng_rand_size = np.random.randint(0, range_size + 1)
+            rand_idx_size = rng_rand_size % (range_size + 1)
+
+        if rand_idx_size == range_size:
+            min_resize_val = scale_array[rand_idx_size] / 2.0
+            max_resize_val = min(2.0 * scale_array[rand_idx_size],
+                                 2 * math.sqrt(wid * hei))
+            scale_choose = random.uniform(min_resize_val, max_resize_val)
+        else:
+            min_resize_val = scale_array[rand_idx_size] / 2.0
+            max_resize_val = 2.0 * scale_array[rand_idx_size]
+            scale_choose = random.uniform(min_resize_val, max_resize_val)
+
+        sample_bbox_size = wid * resize_width / scale_choose
+
+        w_off_orig = 0.0
+        h_off_orig = 0.0
+        if sample_bbox_size < max(image_height, image_width):
+            if wid <= sample_bbox_size:
+                w_off_orig = np.random.uniform(xmin + wid - sample_bbox_size,
+                                               xmin)
+            else:
+                w_off_orig = np.random.uniform(xmin,
+                                               xmin + wid - sample_bbox_size)
+
+            if hei <= sample_bbox_size:
+                h_off_orig = np.random.uniform(ymin + hei - sample_bbox_size,
+                                               ymin)
+            else:
+                h_off_orig = np.random.uniform(ymin,
+                                               ymin + hei - sample_bbox_size)
+
+        else:
+            w_off_orig = np.random.uniform(image_width - sample_bbox_size, 0.0)
+            h_off_orig = np.random.uniform(image_height - sample_bbox_size, 0.0)
+
+        w_off_orig = math.floor(w_off_orig)
+        h_off_orig = math.floor(h_off_orig)
+
+        # Figure out top left coordinates.
+        w_off = float(w_off_orig / image_width)
+        h_off = float(h_off_orig / image_height)
+
+        sampled_bbox = [
+            w_off, h_off, w_off + float(sample_bbox_size / image_width),
+            h_off + float(sample_bbox_size / image_height)
+        ]
+        return sampled_bbox
+    else:
+        return 0
+
+
+def jaccard_overlap(sample_bbox, object_bbox):
+    if sample_bbox[0] >= object_bbox[2] or \
+        sample_bbox[2] <= object_bbox[0] or \
+        sample_bbox[1] >= object_bbox[3] or \
+        sample_bbox[3] <= object_bbox[1]:
+        return 0
+    intersect_xmin = max(sample_bbox[0], object_bbox[0])
+    intersect_ymin = max(sample_bbox[1], object_bbox[1])
+    intersect_xmax = min(sample_bbox[2], object_bbox[2])
+    intersect_ymax = min(sample_bbox[3], object_bbox[3])
+    intersect_size = (intersect_xmax - intersect_xmin) * (
+        intersect_ymax - intersect_ymin)
+    sample_bbox_size = bbox_area(sample_bbox)
+    object_bbox_size = bbox_area(object_bbox)
+    overlap = intersect_size / (
+        sample_bbox_size + object_bbox_size - intersect_size)
+    return overlap
+
+
+def intersect_bbox(bbox1, bbox2):
+    if bbox2[0] > bbox1[2] or bbox2[2] < bbox1[0] or \
+        bbox2[1] > bbox1[3] or bbox2[3] < bbox1[1]:
+        intersection_box = [0.0, 0.0, 0.0, 0.0]
+    else:
+        intersection_box = [
+            max(bbox1[0], bbox2[0]), max(bbox1[1], bbox2[1]),
+            min(bbox1[2], bbox2[2]), min(bbox1[3], bbox2[3])
+        ]
+    return intersection_box
+
+
+def bbox_coverage(bbox1, bbox2):
+    inter_box = intersect_bbox(bbox1, bbox2)
+    intersect_size = bbox_area(inter_box)
+
+    if intersect_size > 0:
+        bbox1_size = bbox_area(bbox1)
+        return intersect_size / bbox1_size
+    else:
+        return 0.
+
+
+def satisfy_sample_constraint(sampler,
+                              sample_bbox,
+                              gt_bboxes,
+                              satisfy_all=False):
+    if sampler[6] == 0 and sampler[7] == 0:
+        return True
+    satisfied = []
+    for i in range(len(gt_bboxes)):
+        object_bbox = [
+            gt_bboxes[i][0], gt_bboxes[i][1], gt_bboxes[i][2], gt_bboxes[i][3]
+        ]
+        overlap = jaccard_overlap(sample_bbox, object_bbox)
+        if sampler[6] != 0 and \
+                overlap < sampler[6]:
+            satisfied.append(False)
+            continue
+        if sampler[7] != 0 and \
+                overlap > sampler[7]:
+            satisfied.append(False)
+            continue
+        satisfied.append(True)
+        if not satisfy_all:
+            return True
+
+    if satisfy_all:
+        return np.all(satisfied)
+    else:
+        return False
+
+
+def satisfy_sample_constraint_coverage(sampler, sample_bbox, gt_bboxes):
+    if sampler[6] == 0 and sampler[7] == 0:
+        has_jaccard_overlap = False
+    else:
+        has_jaccard_overlap = True
+    if sampler[8] == 0 and sampler[9] == 0:
+        has_object_coverage = False
+    else:
+        has_object_coverage = True
+
+    if not has_jaccard_overlap and not has_object_coverage:
+        return True
+    found = False
+    for i in range(len(gt_bboxes)):
+        object_bbox = [
+            gt_bboxes[i][0], gt_bboxes[i][1], gt_bboxes[i][2], gt_bboxes[i][3]
+        ]
+        if has_jaccard_overlap:
+            overlap = jaccard_overlap(sample_bbox, object_bbox)
+            if sampler[6] != 0 and \
+                    overlap < sampler[6]:
+                continue
+            if sampler[7] != 0 and \
+                    overlap > sampler[7]:
+                continue
+            found = True
+        if has_object_coverage:
+            object_coverage = bbox_coverage(object_bbox, sample_bbox)
+            if sampler[8] != 0 and \
+                    object_coverage < sampler[8]:
+                continue
+            if sampler[9] != 0 and \
+                    object_coverage > sampler[9]:
+                continue
+            found = True
+        if found:
+            return True
+    return found
+
+
+def crop_image_sampling(img, sample_bbox, image_width, image_height,
+                        target_size):
+    # no clipping here
+    xmin = int(sample_bbox[0] * image_width)
+    xmax = int(sample_bbox[2] * image_width)
+    ymin = int(sample_bbox[1] * image_height)
+    ymax = int(sample_bbox[3] * image_height)
+
+    w_off = xmin
+    h_off = ymin
+    width = xmax - xmin
+    height = ymax - ymin
+    cross_xmin = max(0.0, float(w_off))
+    cross_ymin = max(0.0, float(h_off))
+    cross_xmax = min(float(w_off + width - 1.0), float(image_width))
+    cross_ymax = min(float(h_off + height - 1.0), float(image_height))
+    cross_width = cross_xmax - cross_xmin
+    cross_height = cross_ymax - cross_ymin
+
+    roi_xmin = 0 if w_off >= 0 else abs(w_off)
+    roi_ymin = 0 if h_off >= 0 else abs(h_off)
+    roi_width = cross_width
+    roi_height = cross_height
+
+    roi_y1 = int(roi_ymin)
+    roi_y2 = int(roi_ymin + roi_height)
+    roi_x1 = int(roi_xmin)
+    roi_x2 = int(roi_xmin + roi_width)
+
+    cross_y1 = int(cross_ymin)
+    cross_y2 = int(cross_ymin + cross_height)
+    cross_x1 = int(cross_xmin)
+    cross_x2 = int(cross_xmin + cross_width)
+
+    sample_img = np.zeros((height, width, 3))
+    sample_img[roi_y1: roi_y2, roi_x1: roi_x2] = \
+        img[cross_y1: cross_y2, cross_x1: cross_x2]
+
+    sample_img = cv2.resize(
+        sample_img, (target_size, target_size), interpolation=cv2.INTER_AREA)
+
+    return sample_img

--- a/ppdet/data2/operators.py
+++ b/ppdet/data2/operators.py
@@ -25,6 +25,7 @@ import logging
 import random
 import math
 import numpy as np
+import collections
 import cv2
 from PIL import Image, ImageEnhance
 
@@ -891,17 +892,27 @@ class Permute(BaseOperator):
             raise TypeError("{}: input type is invalid.".format(self))
 
     def __call__(self, sample, context=None):
-        assert 'image' in sample, "image data not found"
-        for k in sample.keys():
-            if 'image' in k:
-                im = sample[k]
-                if self.channel_first:
-                    im = np.swapaxes(im, 1, 2)
-                    im = np.swapaxes(im, 1, 0)
-                if self.to_bgr:
-                    im = im[[2, 1, 0], :, :]
-                sample[k] = im
-        return sample
+        samples = sample
+        batch_input = True
+        if not isinstance(samples, collections.Sequence):
+            batch_input = False
+            samples = [samples]
+        out_samples = []
+        for sample in samples:
+            assert 'image' in sample, "image data not found"
+            for k in sample.keys():
+                if 'image' in k:
+                    im = sample[k]
+                    if self.channel_first:
+                        im = np.swapaxes(im, 1, 2)
+                        im = np.swapaxes(im, 1, 0)
+                    if self.to_bgr:
+                        im = im[[2, 1, 0], :, :]
+                    sample[k] = im
+            out_samples.append(sample)
+        if not batch_input:
+            out_samples = out_samples[0]
+        return out_samples
 
 
 @register_op
@@ -992,3 +1003,61 @@ class RandomInterpImage(BaseOperator):
         """Resise the image numpy by random resizer."""
         resizer = random.choice(self.resizers)
         return resizer(sample, context)
+
+
+@register_op
+class PadBboxes(BaseOperator):
+    def __init__(self, num_max_boxes=50):
+        """
+        Args:
+            num_max_boxes (int): the max size of bboxes
+        """
+        self.num_max_boxes = num_max_boxes
+        super(PadBboxes, self).__init__()
+
+    def __call__(self, sample, context=None):
+        assert 'gt_bbox' in sample and 'image' in sample
+        im = sample['image']
+        bbox = sample['gt_bbox']
+        gt_num = min(self.num_max_boxes, len(bbox))
+        num_max = self.num_max_boxes
+        if gt_num > 0:
+            bbox = sample['gt_bbox']
+            pad_bbox = np.zeros((num_max, 4), dtype=im.dtype)
+            pad_bbox[:gt_num, :] = bbox[:gt_num, :]
+            sample['gt_bbox'] = pad_bbox
+        if 'gt_class' in sample:
+            pad_class = np.zeros((num_max), dtype=np.int32)
+            pad_class[:gt_num] = sample['gt_class'][:gt_num, 0]
+            sample['gt_class'] = pad_class
+        if 'gt_score' in sample:
+            pad_score = np.zeros((num_max), dtype=np.int32)
+            pad_score[:gt_num] = sample['gt_score'][:gt_num, 0]
+            sample['gt_score'] = pad_score
+        # in training, for example in op ExpandImage,
+        # the bbox and gt_class is expandded, but the difficult is not,
+        # so, judging by it's length
+        #print(sample['gt_class'].shape, sample['pad_score'].shape)
+        if 'difficult' in sample and sample['difficult'].shape[0] > gt_num:
+            pad_diff = np.zeros((num_max), dtype=np.int32)
+            pad_diff[:gt_num] = sample['difficult'][:gt_num, 0]
+            sample['difficult'] = pad_diff
+        return sample
+
+
+@register_op
+class BoxXYXY2BoxXYWH(BaseOperator):
+    def __init__(self):
+        """
+        Args:
+            num_max_boxes (int): the max size of bboxes
+        """
+        super(BoxXYXY2BoxXYWH, self).__init__()
+
+    def __call__(self, sample, context=None):
+        assert 'gt_bbox' in sample
+        bbox = sample['gt_bbox']
+        bbox[:, 2:4] = bbox[:, 2:4] - bbox[:, :2]
+        bbox[:, :2] = bbox[:, :2] + bbox[:, 2:4] / 2.
+        sample['gt_bbox'] = bbox
+        return sample

--- a/ppdet/data2/operators.py
+++ b/ppdet/data2/operators.py
@@ -1,0 +1,994 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# function:
+#    operators to process sample,
+#    eg: decode/resize/crop image
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+
+import uuid
+import logging
+import random
+import math
+import numpy as np
+import cv2
+from PIL import Image, ImageEnhance
+
+from ppdet.core.workspace import serializable
+
+from .op_helper import (satisfy_sample_constraint, filter_and_process,
+                        generate_sample_bbox, clip_bbox, data_anchor_sampling,
+                        satisfy_sample_constraint_coverage, crop_image_sampling,
+                        generate_sample_bbox_square, bbox_area_sampling)
+
+logger = logging.getLogger(__name__)
+
+registered_ops = []
+
+
+def register_op(cls):
+    registered_ops.append(cls.__name__)
+    if not hasattr(BaseOperator, cls.__name__):
+        setattr(BaseOperator, cls.__name__, cls)
+    else:
+        raise KeyError("The {} class has been registered.".format(cls.__name__))
+    return serializable(cls)
+
+
+class BboxError(ValueError):
+    pass
+
+
+class ImageError(ValueError):
+    pass
+
+
+class BaseOperator(object):
+    def __init__(self, name=None):
+        if name is None:
+            name = self.__class__.__name__
+        self._id = name + '_' + str(uuid.uuid4())[-6:]
+
+    def __call__(self, sample, context=None):
+        """ Process a sample.
+        Args:
+            sample (dict): a dict of sample, eg: {'image':xx, 'label': xxx}
+            context (dict): info about this sample processing
+        Returns:
+            result (dict): a processed sample
+        """
+        return sample
+
+    def __str__(self):
+        return str(self._id)
+
+
+@register_op
+class DecodeImage(BaseOperator):
+    def __init__(self, to_rgb=True, with_mixup=False):
+        """ Transform the image data to numpy format.
+
+        Args:
+            to_rgb (bool): whether to convert BGR to RGB
+            with_mixup (bool): whether or not to mixup image and gt_bbbox/gt_score
+        """
+
+        super(DecodeImage, self).__init__()
+        self.to_rgb = to_rgb
+        self.with_mixup = with_mixup
+        if not isinstance(self.to_rgb, bool):
+            raise TypeError("{}: input type is invalid.".format(self))
+        if not isinstance(self.with_mixup, bool):
+            raise TypeError("{}: input type is invalid.".format(self))
+
+    def __call__(self, sample, context=None):
+        """ load image if 'im_file' field is not empty but 'image' is"""
+        if 'image' not in sample:
+            with open(sample['im_file'], 'rb') as f:
+                sample['image'] = f.read()
+
+        im = sample['image']
+        data = np.frombuffer(im, dtype='uint8')
+        im = cv2.imdecode(data, 1)  # BGR mode, but need RGB mode
+        if self.to_rgb:
+            im = cv2.cvtColor(im, cv2.COLOR_BGR2RGB)
+        sample['image'] = im
+
+        if 'h' not in sample:
+            sample['h'] = im.shape[0]
+        if 'w' not in sample:
+            sample['w'] = im.shape[1]
+        # make default im_info with [h, w, 1]
+        sample['im_info'] = np.array(
+            [im.shape[0], im.shape[1], 1.], dtype=np.float32)
+        # decode mixup image
+        if self.with_mixup and 'mixup' in sample:
+            self.__call__(sample['mixup'], context)
+        return sample
+
+
+@register_op
+class MultiscaleTestResize(BaseOperator):
+    def __init__(self,
+                 origin_target_size=800,
+                 origin_max_size=1333,
+                 target_size=[],
+                 max_size=2000,
+                 interp=cv2.INTER_LINEAR,
+                 use_flip=True):
+        """
+        Rescale image to the each size in target size, and capped at max_size.
+
+        Args:
+            origin_target_size(int): original target size of image's short side.
+            origin_max_size(int): original max size of image.
+            target_size (list): A list of target sizes of image's short side.
+            max_size (int): the max size of image.
+            interp (int): the interpolation method.
+            use_flip (bool): whether use flip augmentation.
+        """
+        super(MultiscaleTestResize, self).__init__()
+        self.origin_target_size = int(origin_target_size)
+        self.origin_max_size = int(origin_max_size)
+        self.max_size = int(max_size)
+        self.interp = int(interp)
+        self.use_flip = use_flip
+
+        if not isinstance(target_size, list):
+            raise TypeError(
+                "Type of target_size is invalid. Must be List, now is {}".
+                format(type(target_size)))
+        self.target_size = target_size
+        if not (isinstance(self.origin_target_size, int) and isinstance(
+                self.origin_max_size, int) and isinstance(self.max_size, int)
+                and isinstance(self.interp, int)):
+            raise TypeError("{}: input type is invalid.".format(self))
+
+    def __call__(self, sample, context=None):
+        """ Resize the image numpy for multi-scale test.
+        """
+        origin_ims = {}
+        im = sample['image']
+        if not isinstance(im, np.ndarray):
+            raise TypeError("{}: image type is not numpy.".format(self))
+        if len(im.shape) != 3:
+            raise ImageError('{}: image is not 3-dimensional.'.format(self))
+        im_shape = im.shape
+        im_size_min = np.min(im_shape[0:2])
+        im_size_max = np.max(im_shape[0:2])
+        if float(im_size_min) == 0:
+            raise ZeroDivisionError('{}: min size of image is 0'.format(self))
+        base_name_list = ['image']
+        origin_ims['image'] = im
+        if self.use_flip:
+            sample['flip_image'] = im[:, ::-1, :]
+            base_name_list.append('flip_image')
+            origin_ims['flip_image'] = sample['flip_image']
+
+        ms_samples = []
+
+        for base_name in base_name_list:
+            im_scale = float(self.origin_target_size) / float(im_size_min)
+            # Prevent the biggest axis from being more than max_size
+            if np.round(im_scale * im_size_max) > self.origin_max_size:
+                im_scale = float(self.origin_max_size) / float(im_size_max)
+            im_scale_x = im_scale
+            im_scale_y = im_scale
+
+            resize_w = np.round(im_scale_x * float(im_shape[1]))
+            resize_h = np.round(im_scale_y * float(im_shape[0]))
+            im_resize = cv2.resize(
+                origin_ims[base_name],
+                None,
+                None,
+                fx=im_scale_x,
+                fy=im_scale_y,
+                interpolation=self.interp)
+
+            im_info = [resize_h, resize_w, im_scale]
+            ms_samples.append([{'image': im_resize, 'im_info': im_info}])
+
+            for i, size in enumerate(self.target_size):
+                im_scale = float(size) / float(im_size_min)
+                if np.round(im_scale * im_size_max) > self.max_size:
+                    im_scale = float(self.max_size) / float(im_size_max)
+                im_scale_x = im_scale
+                im_scale_y = im_scale
+                resize_w = np.round(im_scale_x * float(im_shape[1]))
+                resize_h = np.round(im_scale_y * float(im_shape[0]))
+                im_resize = cv2.resize(
+                    origin_ims[base_name],
+                    None,
+                    None,
+                    fx=im_scale_x,
+                    fy=im_scale_y,
+                    interpolation=self.interp)
+                im_info = [resize_h, resize_w, im_scale]
+                ms_samples.append([{'image': im_resize, 'im_info': im_info}])
+        sample['multi_scales_image'] = ms_samples
+        return sample
+
+
+@register_op
+class ResizeImage(BaseOperator):
+    def __init__(self,
+                 target_size=0,
+                 max_size=0,
+                 interp=cv2.INTER_LINEAR,
+                 use_cv2=True):
+        """
+        Rescale image to the specified target size, and capped at max_size
+        if max_size != 0.
+        If target_size is list, selected a scale randomly as the specified
+        target size.
+
+        Args:
+            target_size (int|list): the target size of image's short side, 
+                multi-scale training is adopted when type is list.
+            max_size (int): the max size of image
+            interp (int): the interpolation method
+            use_cv2 (bool): use the cv2 interpolation method or use PIL 
+                interpolation method
+        """
+        super(ResizeImage, self).__init__()
+        self.max_size = int(max_size)
+        self.interp = int(interp)
+        self.use_cv2 = use_cv2
+        if not (isinstance(target_size, int) or isinstance(target_size, list)):
+            raise TypeError(
+                "Type of target_size is invalid. Must be Integer or List, now is {}".
+                format(type(target_size)))
+        self.target_size = target_size
+        if not (isinstance(self.max_size, int) and isinstance(self.interp,
+                                                              int)):
+            raise TypeError("{}: input type is invalid.".format(self))
+
+    def __call__(self, sample, context=None):
+        """ Resize the image numpy.
+        """
+        im = sample['image']
+        if not isinstance(im, np.ndarray):
+            raise TypeError("{}: image type is not numpy.".format(self))
+        if len(im.shape) != 3:
+            raise ImageError('{}: image is not 3-dimensional.'.format(self))
+        im_shape = im.shape
+        im_size_min = np.min(im_shape[0:2])
+        im_size_max = np.max(im_shape[0:2])
+        if isinstance(self.target_size, list):
+            # Case for multi-scale training
+            selected_size = random.choice(self.target_size)
+        else:
+            selected_size = self.target_size
+        if float(im_size_min) == 0:
+            raise ZeroDivisionError('{}: min size of image is 0'.format(self))
+        if self.max_size != 0:
+            im_scale = float(selected_size) / float(im_size_min)
+            # Prevent the biggest axis from being more than max_size
+            if np.round(im_scale * im_size_max) > self.max_size:
+                im_scale = float(self.max_size) / float(im_size_max)
+            im_scale_x = im_scale
+            im_scale_y = im_scale
+
+            resize_w = np.round(im_scale_x * float(im_shape[1]))
+            resize_h = np.round(im_scale_y * float(im_shape[0]))
+            im_info = [resize_h, resize_w, im_scale]
+            if 'im_info' in sample and sample['im_info'][2] != 1.:
+                sample['im_info'] = np.append(
+                    list(sample['im_info']), im_info).astype(np.float32)
+            else:
+                sample['im_info'] = np.array(im_info).astype(np.float32)
+        else:
+            im_scale_x = float(selected_size) / float(im_shape[1])
+            im_scale_y = float(selected_size) / float(im_shape[0])
+
+            resize_w = selected_size
+            resize_h = selected_size
+
+        if self.use_cv2:
+            im = cv2.resize(
+                im,
+                None,
+                None,
+                fx=im_scale_x,
+                fy=im_scale_y,
+                interpolation=self.interp)
+        else:
+            im = Image.fromarray(im)
+            im = im.resize((resize_w, resize_h), self.interp)
+            im = np.array(im)
+
+        sample['image'] = im
+        return sample
+
+
+@register_op
+class RandomFlipImage(BaseOperator):
+    def __init__(self, prob=0.5, is_normalized=False, is_mask_flip=False):
+        """
+        Args:
+            prob (float): the probability of flipping image
+            is_normalized (bool): whether the bbox scale to [0,1]
+            is_mask_flip (bool): whether flip the segmentation
+        """
+        super(RandomFlipImage, self).__init__()
+        self.prob = prob
+        self.is_normalized = is_normalized
+        self.is_mask_flip = is_mask_flip
+        if not (isinstance(self.prob, float) and
+                isinstance(self.is_normalized, bool) and
+                isinstance(self.is_mask_flip, bool)):
+            raise TypeError("{}: input type is invalid.".format(self))
+
+    def flip_segms(self, segms, height, width):
+        def _flip_poly(poly, width):
+            flipped_poly = np.array(poly)
+            flipped_poly[0::2] = width - np.array(poly[0::2]) - 1
+            return flipped_poly.tolist()
+
+        def _flip_rle(rle, height, width):
+            if 'counts' in rle and type(rle['counts']) == list:
+                rle = mask_util.frPyObjects([rle], height, width)
+            mask = mask_util.decode(rle)
+            mask = mask[:, ::-1, :]
+            rle = mask_util.encode(np.array(mask, order='F', dtype=np.uint8))
+            return rle
+
+        def is_poly(segm):
+            assert isinstance(segm, (list, dict)), \
+                "Invalid segm type: {}".format(type(segm))
+            return isinstance(segm, list)
+
+        flipped_segms = []
+        for segm in segms:
+            if is_poly(segm):
+                # Polygon format
+                flipped_segms.append([_flip_poly(poly, width) for poly in segm])
+            else:
+                # RLE format
+                import pycocotools.mask as mask_util
+                flipped_segms.append(_flip_rle(segm, height, width))
+        return flipped_segms
+
+    def __call__(self, sample, context=None):
+        """Filp the image and bounding box.
+        Operators:
+            1. Flip the image numpy.
+            2. Transform the bboxes' x coordinates.
+              (Must judge whether the coordinates are normalized!)
+            3. Transform the segmentations' x coordinates.
+              (Must judge whether the coordinates are normalized!)
+        Output:
+            sample: the image, bounding box and segmentation part
+                    in sample are flipped.
+        """
+        gt_bbox = sample['gt_bbox']
+        im = sample['image']
+        if not isinstance(im, np.ndarray):
+            raise TypeError("{}: image is not a numpy array.".format(self))
+        if len(im.shape) != 3:
+            raise ImageError("{}: image is not 3-dimensional.".format(self))
+        height, width, _ = im.shape
+        if np.random.uniform(0, 1) < self.prob:
+            im = im[:, ::-1, :]
+            if gt_bbox.shape[0] == 0:
+                return sample
+            oldx1 = gt_bbox[:, 0].copy()
+            oldx2 = gt_bbox[:, 2].copy()
+            if self.is_normalized:
+                gt_bbox[:, 0] = 1 - oldx2
+                gt_bbox[:, 2] = 1 - oldx1
+            else:
+                gt_bbox[:, 0] = width - oldx2 - 1
+                gt_bbox[:, 2] = width - oldx1 - 1
+            if gt_bbox.shape[0] != 0 and (gt_bbox[:, 2] < gt_bbox[:, 0]).all():
+                m = "{}: invalid box, x2 should be greater than x1".format(self)
+                raise BboxError(m)
+            sample['gt_bbox'] = gt_bbox
+            if self.is_mask_flip and len(sample['gt_poly']) != 0:
+                sample['gt_poly'] = self.flip_segms(sample['gt_poly'], height,
+                                                    width)
+            sample['flipped'] = True
+            sample['image'] = im
+        return sample
+
+
+@register_op
+class NormalizeImage(BaseOperator):
+    def __init__(self,
+                 mean=[0.485, 0.456, 0.406],
+                 std=[1, 1, 1],
+                 is_scale=True,
+                 is_channel_first=True):
+        """
+        Args:
+            mean (list): the pixel mean
+            std (list): the pixel variance
+        """
+        super(NormalizeImage, self).__init__()
+        self.mean = mean
+        self.std = std
+        self.is_scale = is_scale
+        self.is_channel_first = is_channel_first
+        if not (isinstance(self.mean, list) and isinstance(self.std, list) and
+                isinstance(self.is_scale, bool)):
+            raise TypeError("{}: input type is invalid.".format(self))
+        from functools import reduce
+        if reduce(lambda x, y: x * y, self.std) == 0:
+            raise ValueError('{}: std is invalid!'.format(self))
+
+    def __call__(self, sample, context=None):
+        """Normalize the image.
+        Operators:
+            1.(optional) Scale the image to [0,1]
+            2. Each pixel minus mean and is divided by std
+        """
+        for k in sample.keys():
+            if 'image' in k:
+                im = sample[k]
+                im = im.astype(np.float32, copy=False)
+                if self.is_channel_first:
+                    mean = np.array(self.mean)[:, np.newaxis, np.newaxis]
+                    std = np.array(self.std)[:, np.newaxis, np.newaxis]
+                else:
+                    mean = np.array(self.mean)[np.newaxis, np.newaxis, :]
+                    std = np.array(self.std)[np.newaxis, np.newaxis, :]
+                if self.is_scale:
+                    im = im / 255.0
+                im -= mean
+                im /= std
+                sample[k] = im
+        return sample
+
+
+@register_op
+class RandomDistort(BaseOperator):
+    def __init__(self,
+                 brightness_lower=0.5,
+                 brightness_upper=1.5,
+                 contrast_lower=0.5,
+                 contrast_upper=1.5,
+                 saturation_lower=0.5,
+                 saturation_upper=1.5,
+                 hue_lower=-18,
+                 hue_upper=18,
+                 brightness_prob=0.5,
+                 contrast_prob=0.5,
+                 saturation_prob=0.5,
+                 hue_prob=0.5,
+                 count=4,
+                 is_order=False):
+        """
+        Args:
+            brightness_lower/ brightness_upper (float): the brightness
+                between brightness_lower and brightness_upper
+            contrast_lower/ contrast_upper (float): the contrast between
+                contrast_lower and contrast_lower
+            saturation_lower/ saturation_upper (float): the saturation
+                between saturation_lower and saturation_upper
+            hue_lower/ hue_upper (float): the hue between
+                hue_lower and hue_upper
+            brightness_prob (float): the probability of changing brightness
+            contrast_prob (float): the probability of changing contrast
+            saturation_prob (float): the probability of changing saturation
+            hue_prob (float): the probability of changing hue
+            count (int): the kinds of doing distrot
+            is_order (bool): whether determine the order of distortion
+        """
+        super(RandomDistort, self).__init__()
+        self.brightness_lower = brightness_lower
+        self.brightness_upper = brightness_upper
+        self.contrast_lower = contrast_lower
+        self.contrast_upper = contrast_upper
+        self.saturation_lower = saturation_lower
+        self.saturation_upper = saturation_upper
+        self.hue_lower = hue_lower
+        self.hue_upper = hue_upper
+        self.brightness_prob = brightness_prob
+        self.contrast_prob = contrast_prob
+        self.saturation_prob = saturation_prob
+        self.hue_prob = hue_prob
+        self.count = count
+        self.is_order = is_order
+
+    def random_brightness(self, img):
+        brightness_delta = np.random.uniform(self.brightness_lower,
+                                             self.brightness_upper)
+        prob = np.random.uniform(0, 1)
+        if prob < self.brightness_prob:
+            img = ImageEnhance.Brightness(img).enhance(brightness_delta)
+        return img
+
+    def random_contrast(self, img):
+        contrast_delta = np.random.uniform(self.contrast_lower,
+                                           self.contrast_upper)
+        prob = np.random.uniform(0, 1)
+        if prob < self.contrast_prob:
+            img = ImageEnhance.Contrast(img).enhance(contrast_delta)
+        return img
+
+    def random_saturation(self, img):
+        saturation_delta = np.random.uniform(self.saturation_lower,
+                                             self.saturation_upper)
+        prob = np.random.uniform(0, 1)
+        if prob < self.saturation_prob:
+            img = ImageEnhance.Color(img).enhance(saturation_delta)
+        return img
+
+    def random_hue(self, img):
+        hue_delta = np.random.uniform(self.hue_lower, self.hue_upper)
+        prob = np.random.uniform(0, 1)
+        if prob < self.hue_prob:
+            img = np.array(img.convert('HSV'))
+            img[:, :, 0] = img[:, :, 0] + hue_delta
+            img = Image.fromarray(img, mode='HSV').convert('RGB')
+        return img
+
+    def __call__(self, sample, context):
+        """random distort the image"""
+        ops = [
+            self.random_brightness, self.random_contrast,
+            self.random_saturation, self.random_hue
+        ]
+        if self.is_order:
+            prob = np.random.uniform(0, 1)
+            if prob < 0.5:
+                ops = [
+                    self.random_brightness,
+                    self.random_saturation,
+                    self.random_hue,
+                    self.random_contrast,
+                ]
+        else:
+            ops = random.sample(ops, self.count)
+        assert 'image' in sample, "image data not found"
+        im = sample['image']
+        im = Image.fromarray(im)
+        for id in range(self.count):
+            im = ops[id](im)
+        im = np.asarray(im)
+        sample['image'] = im
+        return sample
+
+
+@register_op
+class ExpandImage(BaseOperator):
+    def __init__(self, max_ratio, prob, mean=[127.5, 127.5, 127.5]):
+        """
+        Args:
+            max_ratio (float): the ratio of expanding
+            prob (float): the probability of expanding image
+            mean (list): the pixel mean
+        """
+        super(ExpandImage, self).__init__()
+        self.max_ratio = max_ratio
+        self.mean = mean
+        self.prob = prob
+
+    def __call__(self, sample, context):
+        """
+        Expand the image and modify bounding box.
+        Operators:
+            1. Scale the image width and height.
+            2. Construct new images with new height and width.
+            3. Fill the new image with the mean.
+            4. Put original imge into new image.
+            5. Rescale the bounding box.
+            6. Determine if the new bbox is satisfied in the new image.
+        Returns:
+            sample: the image, bounding box are replaced.
+        """
+
+        prob = np.random.uniform(0, 1)
+        assert 'image' in sample, 'not found image data'
+        im = sample['image']
+        gt_bbox = sample['gt_bbox']
+        gt_class = sample['gt_class']
+        im_width = sample['w']
+        im_height = sample['h']
+        if prob < self.prob:
+            if self.max_ratio - 1 >= 0.01:
+                expand_ratio = np.random.uniform(1, self.max_ratio)
+                height = int(im_height * expand_ratio)
+                width = int(im_width * expand_ratio)
+                h_off = math.floor(np.random.uniform(0, height - im_height))
+                w_off = math.floor(np.random.uniform(0, width - im_width))
+                expand_bbox = [
+                    -w_off / im_width, -h_off / im_height,
+                    (width - w_off) / im_width, (height - h_off) / im_height
+                ]
+                expand_im = np.ones((height, width, 3))
+                expand_im = np.uint8(expand_im * np.squeeze(self.mean))
+                expand_im = Image.fromarray(expand_im)
+                im = Image.fromarray(im)
+                expand_im.paste(im, (int(w_off), int(h_off)))
+                expand_im = np.asarray(expand_im)
+                gt_bbox, gt_class, _ = filter_and_process(expand_bbox, gt_bbox,
+                                                          gt_class)
+                sample['image'] = expand_im
+                sample['gt_bbox'] = gt_bbox
+                sample['gt_class'] = gt_class
+                sample['w'] = width
+                sample['h'] = height
+
+        return sample
+
+
+@register_op
+class CropImage(BaseOperator):
+    def __init__(self, batch_sampler, satisfy_all=False, avoid_no_bbox=True):
+        """
+        Args:
+            batch_sampler (list): Multiple sets of different
+                                  parameters for cropping.
+            satisfy_all (bool): whether all boxes must satisfy.
+            e.g.[[1, 1, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0],
+                 [1, 50, 0.3, 1.0, 0.5, 2.0, 0.1, 1.0],
+                 [1, 50, 0.3, 1.0, 0.5, 2.0, 0.3, 1.0],
+                 [1, 50, 0.3, 1.0, 0.5, 2.0, 0.5, 1.0],
+                 [1, 50, 0.3, 1.0, 0.5, 2.0, 0.7, 1.0],
+                 [1, 50, 0.3, 1.0, 0.5, 2.0, 0.9, 1.0],
+                 [1, 50, 0.3, 1.0, 0.5, 2.0, 0.0, 1.0]]
+           [max sample, max trial, min scale, max scale,
+            min aspect ratio, max aspect ratio,
+            min overlap, max overlap]
+            avoid_no_bbox (bool): whether to to avoid the 
+                                  situation where the box does not appear.
+        """
+        super(CropImage, self).__init__()
+        self.batch_sampler = batch_sampler
+        self.satisfy_all = satisfy_all
+        self.avoid_no_bbox = avoid_no_bbox
+
+    def __call__(self, sample, context):
+        """
+        Crop the image and modify bounding box.
+        Operators:
+            1. Scale the image width and height.
+            2. Crop the image according to a radom sample.
+            3. Rescale the bounding box.
+            4. Determine if the new bbox is satisfied in the new image.
+        Returns:
+            sample: the image, bounding box are replaced.
+        """
+        assert 'image' in sample, "image data not found"
+        im = sample['image']
+        gt_bbox = sample['gt_bbox']
+        gt_class = sample['gt_class']
+        im_width = sample['w']
+        im_height = sample['h']
+        gt_score = None
+        if 'gt_score' in sample:
+            gt_score = sample['gt_score']
+        sampled_bbox = []
+        gt_bbox = gt_bbox.tolist()
+        for sampler in self.batch_sampler:
+            found = 0
+            for i in range(sampler[1]):
+                if found >= sampler[0]:
+                    break
+                sample_bbox = generate_sample_bbox(sampler)
+                if satisfy_sample_constraint(sampler, sample_bbox, gt_bbox,
+                                             self.satisfy_all):
+                    sampled_bbox.append(sample_bbox)
+                    found = found + 1
+        im = np.array(im)
+        while sampled_bbox:
+            idx = int(np.random.uniform(0, len(sampled_bbox)))
+            sample_bbox = sampled_bbox.pop(idx)
+            sample_bbox = clip_bbox(sample_bbox)
+            crop_bbox, crop_class, crop_score = \
+                filter_and_process(sample_bbox, gt_bbox, gt_class, gt_score)
+            if self.avoid_no_bbox:
+                if len(crop_bbox) < 1:
+                    continue
+            xmin = int(sample_bbox[0] * im_width)
+            xmax = int(sample_bbox[2] * im_width)
+            ymin = int(sample_bbox[1] * im_height)
+            ymax = int(sample_bbox[3] * im_height)
+            im = im[ymin:ymax, xmin:xmax]
+            sample['image'] = im
+            sample['gt_bbox'] = crop_bbox
+            sample['gt_class'] = crop_class
+            sample['gt_score'] = crop_score
+            return sample
+        return sample
+
+
+@register_op
+class CropImageWithDataAchorSampling(BaseOperator):
+    def __init__(self,
+                 batch_sampler,
+                 anchor_sampler=None,
+                 target_size=None,
+                 das_anchor_scales=[16, 32, 64, 128],
+                 sampling_prob=0.5,
+                 min_size=8.,
+                 avoid_no_bbox=True):
+        """
+        Args:
+            anchor_sampler (list): anchor_sampling sets of different
+                                  parameters for cropping.
+            batch_sampler (list): Multiple sets of different
+                                  parameters for cropping.
+              e.g.[[1, 10, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.2, 0.0]]
+                  [[1, 50, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0],
+                   [1, 50, 0.3, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0],
+                   [1, 50, 0.3, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0],
+                   [1, 50, 0.3, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0],
+                   [1, 50, 0.3, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0]]
+              [max sample, max trial, min scale, max scale,
+               min aspect ratio, max aspect ratio,
+               min overlap, max overlap, min coverage, max coverage]
+            target_size (bool): target image size.
+            das_anchor_scales (list[float]): a list of anchor scales in data
+                anchor smapling.
+            min_size (float): minimum size of sampled bbox.
+            avoid_no_bbox (bool): whether to to avoid the
+                                  situation where the box does not appear.
+        """
+        super(CropImageWithDataAchorSampling, self).__init__()
+        self.anchor_sampler = anchor_sampler
+        self.batch_sampler = batch_sampler
+        self.target_size = target_size
+        self.sampling_prob = sampling_prob
+        self.min_size = min_size
+        self.avoid_no_bbox = avoid_no_bbox
+        self.das_anchor_scales = np.array(das_anchor_scales)
+
+    def __call__(self, sample, context):
+        """
+        Crop the image and modify bounding box.
+        Operators:
+            1. Scale the image width and height.
+            2. Crop the image according to a radom sample.
+            3. Rescale the bounding box.
+            4. Determine if the new bbox is satisfied in the new image.
+        Returns:
+            sample: the image, bounding box are replaced.
+        """
+        assert 'image' in sample, "image data not found"
+        im = sample['image']
+        gt_bbox = sample['gt_bbox']
+        gt_class = sample['gt_class']
+        image_width = sample['w']
+        image_height = sample['h']
+        gt_score = None
+        if 'gt_score' in sample:
+            gt_score = sample['gt_score']
+        sampled_bbox = []
+        gt_bbox = gt_bbox.tolist()
+
+        prob = np.random.uniform(0., 1.)
+        if prob > self.sampling_prob:  # anchor sampling
+            assert self.anchor_sampler
+            for sampler in self.anchor_sampler:
+                found = 0
+                for i in range(sampler[1]):
+                    if found >= sampler[0]:
+                        break
+                    sample_bbox = data_anchor_sampling(
+                        gt_bbox, image_width, image_height,
+                        self.das_anchor_scales, self.target_size)
+                    if sample_bbox == 0:
+                        break
+                    if satisfy_sample_constraint_coverage(sampler, sample_bbox,
+                                                          gt_bbox):
+                        sampled_bbox.append(sample_bbox)
+                        found = found + 1
+            im = np.array(im)
+            while sampled_bbox:
+                idx = int(np.random.uniform(0, len(sampled_bbox)))
+                sample_bbox = sampled_bbox.pop(idx)
+
+                crop_bbox, crop_class, crop_score = filter_and_process(
+                    sample_bbox, gt_bbox, gt_class, gt_score)
+                crop_bbox, crop_class, crop_score = bbox_area_sampling(
+                    crop_bbox, crop_class, crop_score, self.target_size,
+                    self.min_size)
+
+                if self.avoid_no_bbox:
+                    if len(crop_bbox) < 1:
+                        continue
+                im = crop_image_sampling(im, sample_bbox, image_width,
+                                         image_height, self.target_size)
+                sample['image'] = im
+                sample['gt_bbox'] = crop_bbox
+                sample['gt_class'] = crop_class
+                sample['gt_score'] = crop_score
+                return sample
+            return sample
+
+        else:
+            for sampler in self.batch_sampler:
+                found = 0
+                for i in range(sampler[1]):
+                    if found >= sampler[0]:
+                        break
+                    sample_bbox = generate_sample_bbox_square(
+                        sampler, image_width, image_height)
+                    if satisfy_sample_constraint_coverage(sampler, sample_bbox,
+                                                          gt_bbox):
+                        sampled_bbox.append(sample_bbox)
+                        found = found + 1
+            im = np.array(im)
+            while sampled_bbox:
+                idx = int(np.random.uniform(0, len(sampled_bbox)))
+                sample_bbox = sampled_bbox.pop(idx)
+                sample_bbox = clip_bbox(sample_bbox)
+
+                crop_bbox, crop_class, crop_score = filter_and_process(
+                    sample_bbox, gt_bbox, gt_class, gt_score)
+                # sampling bbox according the bbox area
+                crop_bbox, crop_class, crop_score = bbox_area_sampling(
+                    crop_bbox, crop_class, crop_score, self.target_size,
+                    self.min_size)
+
+                if self.avoid_no_bbox:
+                    if len(crop_bbox) < 1:
+                        continue
+                xmin = int(sample_bbox[0] * image_width)
+                xmax = int(sample_bbox[2] * image_width)
+                ymin = int(sample_bbox[1] * image_height)
+                ymax = int(sample_bbox[3] * image_height)
+                im = im[ymin:ymax, xmin:xmax]
+                sample['image'] = im
+                sample['gt_bbox'] = crop_bbox
+                sample['gt_class'] = crop_class
+                sample['gt_score'] = crop_score
+                return sample
+            return sample
+
+
+@register_op
+class NormalizeBox(BaseOperator):
+    """Transform the bounding box's coornidates to [0,1]."""
+
+    def __init__(self):
+        super(NormalizeBox, self).__init__()
+
+    def __call__(self, sample, context):
+        gt_bbox = sample['gt_bbox']
+        width = sample['w']
+        height = sample['h']
+        for i in range(gt_bbox.shape[0]):
+            gt_bbox[i][0] = gt_bbox[i][0] / width
+            gt_bbox[i][1] = gt_bbox[i][1] / height
+            gt_bbox[i][2] = gt_bbox[i][2] / width
+            gt_bbox[i][3] = gt_bbox[i][3] / height
+        sample['gt_bbox'] = gt_bbox
+        return sample
+
+
+@register_op
+class Permute(BaseOperator):
+    def __init__(self, to_bgr=True, channel_first=True):
+        """
+        Change the channel.
+        Args:
+            to_bgr (bool): confirm whether to convert RGB to BGR
+            channel_first (bool): confirm whether to change channel
+
+        """
+        super(Permute, self).__init__()
+        self.to_bgr = to_bgr
+        self.channel_first = channel_first
+        if not (isinstance(self.to_bgr, bool) and
+                isinstance(self.channel_first, bool)):
+            raise TypeError("{}: input type is invalid.".format(self))
+
+    def __call__(self, sample, context=None):
+        assert 'image' in sample, "image data not found"
+        for k in sample.keys():
+            if 'image' in k:
+                im = sample[k]
+                if self.channel_first:
+                    im = np.swapaxes(im, 1, 2)
+                    im = np.swapaxes(im, 1, 0)
+                if self.to_bgr:
+                    im = im[[2, 1, 0], :, :]
+                sample[k] = im
+        return sample
+
+
+@register_op
+class MixupImage(BaseOperator):
+    def __init__(self, alpha=1.5, beta=1.5):
+        """ Mixup image and gt_bbbox/gt_score
+        Args:
+            alpha (float): alpha parameter of beta distribute
+            beta (float): beta parameter of beta distribute
+        """
+        super(MixupImage, self).__init__()
+        self.alpha = alpha
+        self.beta = beta
+        if self.alpha <= 0.0:
+            raise ValueError("alpha shold be positive in {}".format(self))
+        if self.beta <= 0.0:
+            raise ValueError("beta shold be positive in {}".format(self))
+
+    def _mixup_img(self, img1, img2, factor):
+        h = max(img1.shape[0], img2.shape[0])
+        w = max(img1.shape[1], img2.shape[1])
+        img = np.zeros((h, w, img1.shape[2]), 'float32')
+        img[:img1.shape[0], :img1.shape[1], :] = \
+            img1.astype('float32') * factor
+        img[:img2.shape[0], :img2.shape[1], :] += \
+            img2.astype('float32') * (1.0 - factor)
+        return img.astype('uint8')
+
+    def __call__(self, sample, context=None):
+        if 'mixup' not in sample:
+            return sample
+        factor = np.random.beta(self.alpha, self.beta)
+        factor = max(0.0, min(1.0, factor))
+        if factor >= 1.0:
+            sample.pop('mixup')
+            return sample
+        if factor <= 0.0:
+            return sample['mixup']
+        im = self._mixup_img(sample['image'], sample['mixup']['image'], factor)
+        gt_bbox1 = sample['gt_bbox']
+        gt_bbox2 = sample['mixup']['gt_bbox']
+        gt_bbox = np.concatenate((gt_bbox1, gt_bbox2), axis=0)
+        gt_class1 = sample['gt_class']
+        gt_class2 = sample['mixup']['gt_class']
+        gt_class = np.concatenate((gt_class1, gt_class2), axis=0)
+
+        gt_score1 = sample['gt_score']
+        gt_score2 = sample['mixup']['gt_score']
+        gt_score = np.concatenate(
+            (gt_score1 * factor, gt_score2 * (1. - factor)), axis=0)
+        sample['image'] = im
+        sample['gt_bbox'] = gt_bbox
+        sample['gt_score'] = gt_score
+        sample['gt_class'] = gt_class
+        sample['h'] = im.shape[0]
+        sample['w'] = im.shape[1]
+        sample.pop('mixup')
+        return sample
+
+
+@register_op
+class RandomInterpImage(BaseOperator):
+    def __init__(self, target_size=0, max_size=0):
+        """
+        Random reisze image by multiply interpolate method.
+        Args:
+            target_size (int): the taregt size of image's short side
+            max_size (int): the max size of image
+        """
+        super(RandomInterpImage, self).__init__()
+        self.target_size = target_size
+        self.max_size = max_size
+        if not (isinstance(self.target_size, int) and
+                isinstance(self.max_size, int)):
+            raise TypeError('{}: input type is invalid.'.format(self))
+        interps = [
+            cv2.INTER_NEAREST,
+            cv2.INTER_LINEAR,
+            cv2.INTER_AREA,
+            cv2.INTER_CUBIC,
+            cv2.INTER_LANCZOS4,
+        ]
+        self.resizers = []
+        for interp in interps:
+            self.resizers.append(ResizeImage(target_size, max_size, interp))
+
+    def __call__(self, sample, context=None):
+        """Resise the image numpy by random resizer."""
+        resizer = random.choice(self.resizers)
+        return resizer(sample, context)

--- a/ppdet/data2/parallel.py
+++ b/ppdet/data2/parallel.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# function:
+#   transform samples in 'source' using 'worker'
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import sys
+import six
+import uuid
+import logging
+import signal
+import threading
+import traceback
+
+logger = logging.getLogger(__name__)
+
+
+class EndSignal(object):
+    def __init__(self, errno=0, errmsg=''):
+        self.errno = errno
+        self.errmsg = errmsg
+
+
+class ParallelMap(object):
+    """
+    Transform samples to mapped samples which is similar to 'basic.MappedDataset',
+    but multiple workers (threads or processes) will be used
+
+    Notes:
+        this class is not thread-safe
+    """
+
+    def __init__(self,
+                 source,
+                 worker,
+                 worker_num,
+                 bufsize=100,
+                 use_process=False,
+                 memsize='4G'):
+        self._worker_num = worker_num
+        self._bufsize = bufsize
+        self._use_process = use_process
+        if self._use_process and type(memsize) is str:
+            assert memsize[-1].lower() == 'g', \
+                "invalid param for memsize[%s], should be ended with 'G' or 'g'" % (memsize)
+            gb = memsize[:-1]
+            self._memsize = int(gb) * 1024**3
+
+        self._started = False
+        self._source = source
+        self._worker = worker
+        self._exit = False
+        self._setup()
+        self._souce_drained = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        self.next()
+
+    def _setup(self):
+        """setup input/output queues and workers """
+        use_process = self._use_process
+        if use_process and sys.platform == "win32":
+            logger.info("Use multi-thread reader instead of "
+                        "multi-process reader on Windows.")
+            use_process = False
+
+        bufsize = self._bufsize
+        if use_process:
+            #from .shared_queue import SharedQueue as Queue
+            from multiprocessing import Queue
+            from multiprocessing import Process as Worker
+            from multiprocessing import Event
+            memsize = self._memsize
+            self._inq = Queue(bufsize)
+            #self._outq = Queue(bufsize, memsize=memsize)
+            self._outq = Queue(bufsize)
+        else:
+            if six.PY3:
+                from queue import Queue
+            else:
+                from Queue import Queue
+            from threading import Thread as Worker
+            from threading import Event
+            self._inq = Queue(bufsize)
+            self._outq = Queue(bufsize)
+
+        consumer_num = self._worker_num
+        id = str(uuid.uuid4())[-3:]
+        self._producer = threading.Thread(
+            target=self._produce,
+            args=('producer-' + id, self._source, self._inq))
+        self._producer.daemon = True
+
+        self._consumers = []
+        for i in range(consumer_num):
+            p = Worker(
+                target=self._consume,
+                args=('consumer-' + id + '_' + str(i), self._inq, self._outq,
+                      self._worker))
+            self._consumers.append(p)
+            p.daemon = True
+
+        self._epoch = -1
+        self._feeding_ev = Event()
+        self._produced = 0  # produced sample in self._produce
+        self._consumed = 0  # consumed sample in self.next
+        self._stopped_consumers = 0
+
+    def _produce(self, id, source, inq):
+        """Fetch data from source and feed it to 'inq' queue"""
+        while True:
+            self._feeding_ev.wait()
+            if self._exit:
+                break
+            try:
+                s = source.next()
+                inq.put(s)
+                self._produced += 1
+            except StopIteration:
+                self._souce_drained = True
+                self._feeding_ev.clear()
+                self._feeding_ev.wait()  # wait other guy to wake up me
+                logger.debug("producer[{}] starts new epoch".format(id))
+            except Exception as e:
+                msg = "producer[{}] failed with error: {}".format(id, str(e))
+                inq.put(EndSignal(-1, msg))
+                break
+
+        logger.debug("producer[{}] exits".format(id))
+
+    def _consume(self, id, inq, outq, worker):
+        """Fetch data from 'inq', process it and put result to 'outq'"""
+        while True:
+            sample = inq.get()
+            if isinstance(sample, EndSignal):
+                sample.errmsg += "[consumer[{}] exits]".format(id)
+                outq.put(sample)
+                logger.debug("end signal received, " +
+                             "consumer[{}] exits".format(id))
+                break
+
+            try:
+                result = worker(sample)
+                outq.put(result)
+            except Exception as e:
+                stack_info = traceback.format_exc()
+                msg = 'failed to map consumer[%s], error: {}'.format(id, str(e))
+                outq.put(EndSignal(-1, msg))
+                break
+
+    def drained(self):
+        assert self._epoch >= 0, "first epoch has not started yet"
+        return self._source.drained() and self._produced == self._consumed
+
+    def stop(self):
+        """ notify to exit
+        """
+        self._exit = True
+        self._feeding_ev.set()
+        for _ in range(len(self._consumers)):
+            self._inq.put(EndSignal(0, "notify consumers to exit"))
+
+    def next(self):
+        """ get next transformed sample
+        """
+        if self._epoch < 0:
+            self.reset()
+
+        if self.drained():
+            raise StopIteration()
+
+        while True:
+            sample = self._outq.get()
+            if isinstance(sample, EndSignal):
+                self._stopped_consumers += 1
+                if sample.errno != 0:
+                    logger.warn("consumer failed with error: {}".format(
+                        sample.errmsg))
+
+                if self._stopped_consumers < len(self._consumers):
+                    self._inq.put(sample)
+                else:
+                    raise ValueError("all consumers exited, no more samples")
+            else:
+                self._consumed += 1
+                return sample
+
+    def reset(self):
+        """ reset for a new epoch of samples
+        """
+        if self._epoch < 0:
+            self._epoch = 0
+            for p in self._consumers:
+                p.start()
+            self._producer.start()
+        else:
+            if not self.drained():
+                logger.warn("do not reset before epoch[%d] finishes".format(
+                    self._epoch))
+                self._produced = self._produced - self._consumed
+            else:
+                self._produced = 0
+
+            self._epoch += 1
+
+        assert self._stopped_consumers == 0, "some consumers already exited," \
+            + " cannot start another epoch"
+
+        self._source.reset()
+        self._souce_drained = False
+        self._consumed = 0
+        self._feeding_ev.set()
+
+
+# FIXME(dengkaipeng): fix me if you have better impliment
+# handle terminate reader process, do not print stack frame
+def _reader_exit(signum, frame):
+    logger.debug("Reader process exit.")
+    sys.exit()
+
+
+signal.signal(signal.SIGTERM, _reader_exit)

--- a/ppdet/data2/tests/test_loader.py
+++ b/ppdet/data2/tests/test_loader.py
@@ -1,0 +1,105 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import os
+
+from ppdet.data2.coco import COCODataSet
+from ppdet.data2.loader import Loader
+from ppdet.utils.download import get_path
+from ppdet.utils.download import DATASET_HOME
+
+from ppdet.data2.operators import DecodeImage, ResizeImage, Permute
+from ppdet.data2.batch_operators import PadBatch
+
+COCO_VAL_URL = 'http://images.cocodataset.org/zips/val2017.zip'
+COCO_VAL_MD5SUM = '442b8da7639aecaf257c1dceb8ba8c80'
+COCO_ANNO_URL = 'http://images.cocodataset.org/annotations/annotations_trainval2017.zip'
+COCO_ANNO_MD5SUM = 'f4bbac642086de4f52a3fdda2de5fa2c'
+
+
+class TestLoader(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """ setup
+        """
+        root_path = os.path.join(DATASET_HOME, 'coco')
+        image_path, _ = get_path(COCO_VAL_URL, root_path, COCO_VAL_MD5SUM)
+
+        anno_path, _ = get_path(COCO_ANNO_URL, root_path, COCO_ANNO_MD5SUM)
+
+        # json data
+        cls.anno_path = os.path.join(anno_path, 'instances_val2017.json')
+        cls.image_dir = image_path
+
+    @classmethod
+    def tearDownClass(cls):
+        """ tearDownClass """
+        pass
+
+    def test_loader(self):
+        coco_loader = COCODataSet(self.image_dir, self.anno_path, 10)
+        sample_trans = [
+            DecodeImage(to_rgb=True), ResizeImage(
+                target_size=800, max_size=1333, interp=1), Permute(to_bgr=False)
+        ]
+        batch_trans = [PadBatch(pad_to_stride=32, use_padded_im_info=True), ]
+
+        data_loader = Loader(
+            coco_loader,
+            sample_transforms=sample_trans,
+            batch_transforms=batch_trans,
+            batch_size=2,
+            shuffle=True,
+            drop_empty=True)
+
+        for i in range(2):
+            for samples in data_loader:
+                for sample in samples:
+                    shape = sample['image'].shape
+                    self.assertEqual(shape[0], 3)
+                    self.assertEqual(shape[1] % 32, 0)
+                    self.assertEqual(shape[2] % 32, 0)
+
+    def test_loader_multi_threads(self):
+        coco_loader = COCODataSet(self.image_dir, self.anno_path, 10)
+        sample_trans = [
+            DecodeImage(to_rgb=True), ResizeImage(
+                target_size=800, max_size=1333, interp=1), Permute(to_bgr=False)
+        ]
+        batch_trans = [PadBatch(pad_to_stride=32, use_padded_im_info=True), ]
+
+        data_loader = Loader(
+            coco_loader,
+            sample_transforms=sample_trans,
+            batch_transforms=batch_trans,
+            batch_size=2,
+            shuffle=True,
+            drop_empty=True,
+            worker_num=2,
+            use_process=False,
+            bufsize=8)()
+        for i in range(2):
+            for samples in data_loader:
+                for sample in samples:
+                    shape = sample['image'].shape
+                    self.assertEqual(shape[0], 3)
+                    self.assertEqual(shape[1] % 32, 0)
+                    self.assertEqual(shape[2] % 32, 0)
+
+            data_loader.reset()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ppdet/data2/tests/test_loader.py
+++ b/ppdet/data2/tests/test_loader.py
@@ -61,16 +61,42 @@ class TestLoader(unittest.TestCase):
             sample_transforms=sample_trans,
             batch_transforms=batch_trans,
             batch_size=2,
+            fields=[
+                'image', 'im_info', 'im_id', 'gt_bbox', 'gt_class', 'is_crowd',
+                'gt_mask'
+            ],
             shuffle=True,
             drop_empty=True)
 
         for i in range(2):
             for samples in data_loader:
                 for sample in samples:
-                    shape = sample['image'].shape
-                    self.assertEqual(shape[0], 3)
-                    self.assertEqual(shape[1] % 32, 0)
-                    self.assertEqual(shape[2] % 32, 0)
+                    im_shape = sample[0].shape
+                    self.assertEqual(im_shape[0], 3)
+                    self.assertEqual(im_shape[1] % 32, 0)
+                    self.assertEqual(im_shape[2] % 32, 0)
+
+                    im_info_shape = sample[1].shape
+                    self.assertEqual(im_info_shape[-1], 3)
+
+                    im_id_shape = sample[2].shape
+                    self.assertEqual(im_id_shape[-1], 1)
+
+                    gt_bbox_shape = sample[3].shape
+                    self.assertEqual(gt_bbox_shape[-1], 4)
+
+                    gt_class_shape = sample[4].shape
+                    self.assertEqual(gt_class_shape[-1], 1)
+                    self.assertEqual(gt_class_shape[0], gt_bbox_shape[0])
+
+                    is_crowd_shape = sample[5].shape
+                    self.assertEqual(is_crowd_shape[-1], 1)
+                    self.assertEqual(is_crowd_shape[0], gt_bbox_shape[0])
+
+                    mask = sample[6]
+                    self.assertEqual(len(mask), gt_bbox_shape[0])
+                    self.assertEqual(mask[0][0].shape[-1], 2)
+            data_loader.reset()
 
     def test_loader_multi_threads(self):
         coco_loader = COCODataSet(self.image_dir, self.anno_path, 10)
@@ -85,6 +111,10 @@ class TestLoader(unittest.TestCase):
             sample_transforms=sample_trans,
             batch_transforms=batch_trans,
             batch_size=2,
+            fields=[
+                'image', 'im_info', 'im_id', 'gt_bbox', 'gt_class', 'is_crowd',
+                'gt_mask'
+            ],
             shuffle=True,
             drop_empty=True,
             worker_num=2,
@@ -93,11 +123,31 @@ class TestLoader(unittest.TestCase):
         for i in range(2):
             for samples in data_loader:
                 for sample in samples:
-                    shape = sample['image'].shape
-                    self.assertEqual(shape[0], 3)
-                    self.assertEqual(shape[1] % 32, 0)
-                    self.assertEqual(shape[2] % 32, 0)
+                    im_shape = sample[0].shape
+                    self.assertEqual(im_shape[0], 3)
+                    self.assertEqual(im_shape[1] % 32, 0)
+                    self.assertEqual(im_shape[2] % 32, 0)
 
+                    im_info_shape = sample[1].shape
+                    self.assertEqual(im_info_shape[-1], 3)
+
+                    im_id_shape = sample[2].shape
+                    self.assertEqual(im_id_shape[-1], 1)
+
+                    gt_bbox_shape = sample[3].shape
+                    self.assertEqual(gt_bbox_shape[-1], 4)
+
+                    gt_class_shape = sample[4].shape
+                    self.assertEqual(gt_class_shape[-1], 1)
+                    self.assertEqual(gt_class_shape[0], gt_bbox_shape[0])
+
+                    is_crowd_shape = sample[5].shape
+                    self.assertEqual(is_crowd_shape[-1], 1)
+                    self.assertEqual(is_crowd_shape[0], gt_bbox_shape[0])
+
+                    mask = sample[6]
+                    self.assertEqual(len(mask), gt_bbox_shape[0])
+                    self.assertEqual(mask[0][0].shape[-1], 2)
             data_loader.reset()
 
 

--- a/ppdet/data2/tests/test_loader_yaml.py
+++ b/ppdet/data2/tests/test_loader_yaml.py
@@ -1,0 +1,87 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import os
+import yaml
+import logging
+
+from ppdet.utils.download import get_path
+from ppdet.utils.download import DATASET_HOME
+from ppdet.core.workspace import load_config, merge_config
+
+from ppdet.data2.loader import create_reader
+
+COCO_VAL_URL = 'http://images.cocodataset.org/zips/val2017.zip'
+COCO_VAL_MD5SUM = '442b8da7639aecaf257c1dceb8ba8c80'
+COCO_ANNO_URL = 'http://images.cocodataset.org/annotations/annotations_trainval2017.zip'
+COCO_ANNO_MD5SUM = 'f4bbac642086de4f52a3fdda2de5fa2c'
+
+FORMAT = '[%(asctime)s-%(filename)s-%(levelname)s:%(message)s]'
+logging.basicConfig(level=logging.INFO, format=FORMAT)
+logger = logging.getLogger(__name__)
+
+
+class TestLoaderYAML(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """ setup
+        """
+        root_path = os.path.join(DATASET_HOME, 'coco')
+        image_path, _ = get_path(COCO_VAL_URL, root_path, COCO_VAL_MD5SUM)
+
+        anno_path, _ = get_path(COCO_ANNO_URL, root_path, COCO_ANNO_MD5SUM)
+
+        # json data
+        cls.anno_path = os.path.join(anno_path, 'instances_val2017.json')
+        cls.image_dir = image_path
+
+    @classmethod
+    def tearDownClass(cls):
+        """ tearDownClass """
+        pass
+
+    def test_loader_yaml(self):
+        cfg_file = 'ppdet/data2/tests/test.yml'
+        cfg = load_config(cfg_file)
+        data_cfg = '[!COCODataSet {{image_dir: {0}, dataset_dir: null, ' \
+            'anno_path: {1}, sample_num: 10}}]'.format(
+                self.image_dir, self.anno_path)
+        dataset_ins = yaml.load(data_cfg, Loader=yaml.Loader)
+        update_train_cfg = {'TrainLoader': {'dataset': dataset_ins[0]}}
+        update_test_cfg = {'EvalLoader': {'dataset': dataset_ins[0]}}
+        merge_config(update_train_cfg)
+        merge_config(update_test_cfg)
+
+        #reader = Loader(**cfg['TrainLoader'])()
+        reader = create_reader(cfg['TrainLoader'], 10)()
+        for samples in reader:
+            for sample in samples:
+                shape = sample['image'].shape
+                self.assertEqual(shape[0], 3)
+                self.assertEqual(shape[1] % 32, 0)
+                self.assertEqual(shape[2] % 32, 0)
+
+        #reader = Loader(**cfg['EvalLoader'])()
+        reader = create_reader(cfg['EvalLoader'], 10)()
+        for samples in reader:
+            for sample in samples:
+                shape = sample['image'].shape
+                self.assertEqual(shape[0], 3)
+                self.assertEqual(shape[1] % 32, 0)
+                self.assertEqual(shape[2] % 32, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ppdet/data2/voc.py
+++ b/ppdet/data2/voc.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import numpy as np
+
+import xml.etree.ElementTree as ET
+
+from ppdet.core.workspace import register, serializable
+
+from dataset import DataSet
+
+
+@register
+@serializable
+class VOCDataSet(DataSet):
+    """
+    Load VOC records with annotations in xml directory 'anno_path'.
+
+    Notes:
+    `anno_path` must contains xml file and image file path for annotations.
+
+    Args:
+        anno_path (str): root directory for voc annotation data.
+        sample_num (int): number of samples to load, -1 means all.
+        use_default_label (bool): whether use the default mapping of
+            label to integer index. Default True.
+        with_background (bool): whether load background as a class,
+            default True.
+    Returns:
+        (records, catname2clsid)
+        'records' is list of dict whose structure is:
+        {
+            'im_file': im_fname, # image file name
+            'im_id': im_id, # image id
+            'h': im_h, # height of image
+            'w': im_w, # width
+            'is_crowd': is_crowd,
+            'gt_class': gt_class,
+            'gt_bbox': gt_bbox,
+            'gt_poly': gt_poly,
+        }
+        'cname2id' is a dict to map category name to class id
+    """
+
+    def __init__(self,
+                 anno_path,
+                 sample_num=-1,
+                 use_default_label=True,
+                 with_background=True,
+                 label_list='label_list.txt'):
+        self.anno_path = anno_path
+        self.sample_num = sample_num
+        self.use_default_label = use_default_label
+        self.with_background = with_background
+        self.label_list = label_list
+        self.roidbs = None
+        self.cname2cid = None
+
+    def get_roidb(self):
+        if not self.roidbs:
+            self.roidbs, self.cname2cid = self.load_roidb()
+        return self.roidbs
+
+    def get_cname2cid(self):
+        if not self.cname2cid:
+            self.roidbs, self.cname2cid = self.load_roidb()
+        return self.cname2cid
+
+    def load_roidb(self):
+        data_dir = os.path.dirname(self.anno_path)
+        # mapping category name to class id
+        # if with_background is True:
+        #   background:0, first_class:1, second_class:2, ...
+        # if with_background is False:
+        #   first_class:0, second_class:1, ...
+        records = []
+        ct = 0
+        cname2cid = {}
+        if not self.use_default_label:
+            label_path = os.path.join(data_dir, self.label_list)
+            with open(label_path, 'r') as fr:
+                label_id = int(self.with_background)
+                for line in fr.readlines():
+                    cname2cid[line.strip()] = label_id
+                    label_id += 1
+        else:
+            cname2cid = pascalvoc_label(self.with_background)
+
+        with open(self.anno_path, 'r') as fr:
+            while True:
+                line = fr.readline()
+                if not line:
+                    break
+                img_file, xml_file = [os.path.join(data_dir, x) \
+                        for x in line.strip().split()[:2]]
+                if not os.path.isfile(xml_file):
+                    continue
+                tree = ET.parse(xml_file)
+                if tree.find('id') is None:
+                    im_id = np.array([ct])
+                else:
+                    im_id = np.array([int(tree.find('id').text)])
+
+                objs = tree.findall('object')
+                im_w = float(tree.find('size').find('width').text)
+                im_h = float(tree.find('size').find('height').text)
+                gt_bbox = np.zeros((len(objs), 4), dtype=np.float32)
+                gt_class = np.zeros((len(objs), 1), dtype=np.int32)
+                gt_score = np.ones((len(objs), 1), dtype=np.float32)
+                is_crowd = np.zeros((len(objs), 1), dtype=np.int32)
+                difficult = np.zeros((len(objs), 1), dtype=np.int32)
+                for i, obj in enumerate(objs):
+                    cname = obj.find('name').text
+                    gt_class[i][0] = cname2cid[cname]
+                    _difficult = int(obj.find('difficult').text)
+                    x1 = float(obj.find('bndbox').find('xmin').text)
+                    y1 = float(obj.find('bndbox').find('ymin').text)
+                    x2 = float(obj.find('bndbox').find('xmax').text)
+                    y2 = float(obj.find('bndbox').find('ymax').text)
+                    x1 = max(0, x1)
+                    y1 = max(0, y1)
+                    x2 = min(im_w - 1, x2)
+                    y2 = min(im_h - 1, y2)
+                    gt_bbox[i] = [x1, y1, x2, y2]
+                    is_crowd[i][0] = 0
+                    difficult[i][0] = _difficult
+                voc_rec = {
+                    'im_file': img_file,
+                    'im_id': im_id,
+                    'h': im_h,
+                    'w': im_w,
+                    'is_crowd': is_crowd,
+                    'gt_class': gt_class,
+                    'gt_score': gt_score,
+                    'gt_bbox': gt_bbox,
+                    'gt_poly': [],
+                    'difficult': difficult
+                }
+                if len(objs) != 0:
+                    records.append(voc_rec)
+
+                ct += 1
+                if self.sample_num > 0 and ct >= self.sample_num:
+                    break
+        assert len(records) > 0, 'not found any voc record in %s' % (
+            self.anno_path)
+        return records, cname2cid
+
+
+def pascalvoc_label(with_background=True):
+    labels_map = {
+        'aeroplane': 1,
+        'bicycle': 2,
+        'bird': 3,
+        'boat': 4,
+        'bottle': 5,
+        'bus': 6,
+        'car': 7,
+        'cat': 8,
+        'chair': 9,
+        'cow': 10,
+        'diningtable': 11,
+        'dog': 12,
+        'horse': 13,
+        'motorbike': 14,
+        'person': 15,
+        'pottedplant': 16,
+        'sheep': 17,
+        'sofa': 18,
+        'train': 19,
+        'tvmonitor': 20
+    }
+    if not with_background:
+        labels_map = {k: v - 1 for k, v in labels_map.items()}
+    return labels_map

--- a/ppdet/modeling/architectures/cascade_rcnn.py
+++ b/ppdet/modeling/architectures/cascade_rcnn.py
@@ -75,7 +75,7 @@ class CascadeRCNN(object):
 
     def build(self, feed_vars, mode='train'):
         if mode == 'train':
-            required_fields = ['gt_label', 'gt_box', 'is_crowd', 'im_info']
+            required_fields = ['gt_class', 'gt_bbox', 'is_crowd', 'im_info']
         else:
             required_fields = ['im_shape', 'im_info']
         self._input_check(required_fields, feed_vars)
@@ -84,7 +84,7 @@ class CascadeRCNN(object):
         im_info = feed_vars['im_info']
 
         if mode == 'train':
-            gt_box = feed_vars['gt_box']
+            gt_bbox = feed_vars['gt_bbox']
             is_crowd = feed_vars['is_crowd']
 
         mixed_precision_enabled = mixed_precision_global_state() is not None
@@ -108,7 +108,7 @@ class CascadeRCNN(object):
         rpn_rois = self.rpn_head.get_proposals(body_feats, im_info, mode=mode)
 
         if mode == 'train':
-            rpn_loss = self.rpn_head.get_loss(im_info, gt_box, is_crowd)
+            rpn_loss = self.rpn_head.get_loss(im_info, gt_bbox, is_crowd)
         else:
             if self.rpn_only:
                 im_scale = fluid.layers.slice(
@@ -276,6 +276,38 @@ class CascadeRCNN(object):
         refined_bbox = fluid.layers.reshape(refined_bbox, shape=[-1, 4])
 
         return refined_bbox
+
+    def _inputs_def(self, image_shape):
+        im_shape = [None] + image_shape
+        # yapf: disable
+        inputs_def = {
+            'image':    {'shape': im_shape,  'dtype': 'float32', 'lod_level': 0},
+            'im_info':  {'shape': [None, 3], 'dtype': 'float32', 'lod_level': 0},
+            'im_id':    {'shape': [None, 1], 'dtype': 'int32',   'lod_level': 0},
+            'gt_bbox':   {'shape': [None, 4], 'dtype': 'float32', 'lod_level': 1},
+            'gt_class': {'shape': [None, 1], 'dtype': 'int32',   'lod_level': 1},
+            'is_crowd': {'shape': [None, 1], 'dtype': 'int32',   'lod_level': 1},
+        }
+        # yapf: enable
+        return inputs_def
+
+    def build_inputs(self,
+                     image_shape,
+                     fields,
+                     use_dataloader=True,
+                     iterable=False):
+        inputs_def = self._inputs_def(image_shape)
+        feed_vars = OrderedDict([(key, fluid.layers.data(
+            name=key,
+            shape=inputs_def[key]['shape'],
+            dtype=inputs_def[key]['dtype'],
+            lod_level=inputs_def[key]['lod_level'])) for key in fields])
+        loader = fluid.io.DataLoader.from_generator(
+            feed_list=list(feed_vars.values()),
+            capacity=64,
+            use_double_buffer=True,
+            iterable=iterable) if use_dataloader else None
+        return feed_vars, loader
 
     def train(self, feed_vars):
         return self.build(feed_vars, 'train')

--- a/ppdet/modeling/architectures/cascade_rcnn_cls_aware.py
+++ b/ppdet/modeling/architectures/cascade_rcnn_cls_aware.py
@@ -48,14 +48,14 @@ class CascadeRCNNClsAware(object):
         'bbox_head'
     ]
 
-    def __init__(self,
-                 backbone,
-                 rpn_head,
-                 roi_extractor='FPNRoIAlign',
-                 bbox_head='CascadeBBoxHead',
-                 bbox_assigner='CascadeBBoxAssigner',
-                 fpn='FPN',
-                ):
+    def __init__(
+            self,
+            backbone,
+            rpn_head,
+            roi_extractor='FPNRoIAlign',
+            bbox_head='CascadeBBoxHead',
+            bbox_assigner='CascadeBBoxAssigner',
+            fpn='FPN', ):
         super(CascadeRCNNClsAware, self).__init__()
         assert fpn is not None, "cascade RCNN requires FPN"
         self.backbone = backbone
@@ -78,9 +78,9 @@ class CascadeRCNNClsAware(object):
         im = feed_vars['image']
         im_info = feed_vars['im_info']
         if mode == 'train':
-            gt_box = feed_vars['gt_box']
+            gt_bbox = feed_vars['gt_bbox']
             is_crowd = feed_vars['is_crowd']
-            gt_label = feed_vars['gt_label']
+            gt_class = feed_vars['gt_class']
         else:
             im_shape = feed_vars['im_shape']
 
@@ -95,7 +95,7 @@ class CascadeRCNNClsAware(object):
         rpn_rois = self.rpn_head.get_proposals(body_feats, im_info, mode=mode)
 
         if mode == 'train':
-            rpn_loss = self.rpn_head.get_loss(im_info, gt_box, is_crowd)
+            rpn_loss = self.rpn_head.get_loss(im_info, gt_bbox, is_crowd)
 
         proposal_list = []
         roi_feat_list = []
@@ -103,10 +103,11 @@ class CascadeRCNNClsAware(object):
         rcnn_target_list = []
 
         bbox_pred = None
-        
+
         self.cascade_var_v = []
         for stage in range(3):
-            var_v = np.array(self.cascade_bbox_reg_weights[stage], dtype="float32")
+            var_v = np.array(
+                self.cascade_bbox_reg_weights[stage], dtype="float32")
             prior_box_var = fluid.layers.create_tensor(dtype="float32")
             fluid.layers.assign(input=var_v, output=prior_box_var)
             self.cascade_var_v.append(prior_box_var)
@@ -124,42 +125,37 @@ class CascadeRCNNClsAware(object):
                 outs = self.bbox_assigner(
                     input_rois=pool_rois, feed_vars=feed_vars, curr_stage=stage)
                 pool_rois = outs[0]
-                rcnn_target_list.append( outs )
-            
+                rcnn_target_list.append(outs)
+
             # extract roi features
             roi_feat = self.roi_extractor(body_feats, pool_rois, spatial_scale)
             roi_feat_list.append(roi_feat)
-            
+
             # bbox head
             cls_score, bbox_pred = self.bbox_head.get_output(
                 roi_feat,
                 cls_agnostic_bbox_reg=self.bbox_head.num_classes,
                 wb_scalar=1.0 / self.cascade_rcnn_loss_weight[stage],
-                name='_' + str(stage + 1) )
+                name='_' + str(stage + 1))
 
             cls_prob = fluid.layers.softmax(cls_score, use_cudnn=False)
-            
+
             decoded_box, decoded_assign_box = fluid.layers.box_decoder_and_assign(
-                                                        pool_rois,
-                                                        self.cascade_var_v[stage],
-                                                        bbox_pred,
-                                                        cls_prob,
-                                                        self.bbox_clip)
-            
+                pool_rois, self.cascade_var_v[stage], bbox_pred, cls_prob,
+                self.bbox_clip)
+
             if mode == "train":
                 decoded_box.stop_gradient = True
                 decoded_assign_box.stop_gradient = True
             else:
-                self.cascade_cls_prob.append( cls_prob )
+                self.cascade_cls_prob.append(cls_prob)
                 self.cascade_decoded_box.append(decoded_box)
-            
+
             rcnn_pred_list.append((cls_score, bbox_pred))
-            
-        
+
         # out loop
         if mode == 'train':
-            loss = self.bbox_head.get_loss(rcnn_pred_list,
-                                           rcnn_target_list,
+            loss = self.bbox_head.get_loss(rcnn_pred_list, rcnn_target_list,
                                            self.cascade_rcnn_loss_weight)
             loss.update(rpn_loss)
             total_loss = fluid.layers.sum(list(loss.values()))
@@ -167,12 +163,41 @@ class CascadeRCNNClsAware(object):
             return loss
         else:
             pred = self.bbox_head.get_prediction_cls_aware(
-                       im_info, im_shape,
-                       self.cascade_cls_prob,
-                       self.cascade_decoded_box,
-                      self.cascade_bbox_reg_weights)
+                im_info, im_shape, self.cascade_cls_prob,
+                self.cascade_decoded_box, self.cascade_bbox_reg_weights)
             return pred
-    
+
+    def _inputs_def(self, image_shape):
+        im_shape = [None] + image_shape
+        # yapf: disable
+        inputs_def = {
+            'image':    {'shape': im_shape,  'dtype': 'float32', 'lod_level': 0},
+            'im_info':  {'shape': [None, 3], 'dtype': 'float32', 'lod_level': 0},
+            'im_id':    {'shape': [None, 1], 'dtype': 'int32',   'lod_level': 0},
+            'gt_bbox':   {'shape': [None, 4], 'dtype': 'float32', 'lod_level': 1},
+            'gt_class': {'shape': [None, 1], 'dtype': 'int32',   'lod_level': 1},
+            'is_crowd': {'shape': [None, 1], 'dtype': 'int32',   'lod_level': 1},
+        }
+        # yapf: enable
+        return inputs_def
+
+    def build_inputs(self,
+                     image_shape,
+                     fields,
+                     use_dataloader=True,
+                     iterable=False):
+        inputs_def = self._inputs_def(image_shape)
+        feed_vars = OrderedDict([(key, fluid.layers.data(
+            name=key,
+            shape=inputs_def[key]['shape'],
+            dtype=inputs_def[key]['dtype'],
+            lod_level=inputs_def[key]['lod_level'])) for key in fields])
+        loader = fluid.io.DataLoader.from_generator(
+            feed_list=list(feed_vars.values()),
+            capacity=64,
+            use_double_buffer=True,
+            iterable=iterable) if use_dataloader else None
+        return feed_vars, loader
 
     def train(self, feed_vars):
         return self.build(feed_vars, 'train')

--- a/ppdet/modeling/architectures/retinanet.py
+++ b/ppdet/modeling/architectures/retinanet.py
@@ -50,8 +50,8 @@ class RetinaNet(object):
         im = feed_vars['image']
         im_info = feed_vars['im_info']
         if mode == 'train':
-            gt_box = feed_vars['gt_box']
-            gt_label = feed_vars['gt_label']
+            gt_bbox = feed_vars['gt_bbox']
+            gt_class = feed_vars['gt_class']
             is_crowd = feed_vars['is_crowd']
 
         mixed_precision_enabled = mixed_precision_global_state() is not None
@@ -73,7 +73,7 @@ class RetinaNet(object):
         # retinanet head
         if mode == 'train':
             loss = self.retina_head.get_loss(body_feats, spatial_scale, im_info,
-                                             gt_box, gt_label, is_crowd)
+                                             gt_bbox, gt_class, is_crowd)
             total_loss = fluid.layers.sum(list(loss.values()))
             loss.update({'loss': total_loss})
             return loss
@@ -81,6 +81,41 @@ class RetinaNet(object):
             pred = self.retina_head.get_prediction(body_feats, spatial_scale,
                                                    im_info)
             return pred
+
+    def _inputs_def(self, image_shape):
+        im_shape = [None] + image_shape
+        # yapf: disable
+        inputs_def = {
+            'image':    {'shape': im_shape,  'dtype': 'float32', 'lod_level': 0},
+            'im_info':  {'shape': [None, 3], 'dtype': 'float32', 'lod_level': 0},
+            'im_id':    {'shape': [None, 1], 'dtype': 'int32',   'lod_level': 0},
+            'gt_bbox':   {'shape': [None, 4], 'dtype': 'float32', 'lod_level': 1},
+            'gt_class': {'shape': [None, 1], 'dtype': 'int32',   'lod_level': 1},
+            'is_crowd': {'shape': [None, 1], 'dtype': 'int32',   'lod_level': 1},
+        }
+        # yapf: enable
+        return inputs_def
+
+    def build_inputs(
+            self,
+            image_shape=[3, None, None],
+            fields=[
+                'image', 'im_info', 'im_id', 'gt_bbox', 'gt_class', 'is_crowd'
+            ],  # for-train
+            use_dataloader=True,
+            iterable=False):
+        inputs_def = self._inputs_def(image_shape)
+        feed_vars = OrderedDict([(key, fluid.layers.data(
+            name=key,
+            shape=inputs_def[key]['shape'],
+            dtype=inputs_def[key]['dtype'],
+            lod_level=inputs_def[key]['lod_level'])) for key in fields])
+        loader = fluid.io.DataLoader.from_generator(
+            feed_list=list(feed_vars.values()),
+            capacity=64,
+            use_double_buffer=True,
+            iterable=iterable) if use_dataloader else None
+        return feed_vars, loader
 
     def train(self, feed_vars):
         return self.build(feed_vars, 'train')

--- a/ppdet/modeling/architectures/yolov3.py
+++ b/ppdet/modeling/architectures/yolov3.py
@@ -64,17 +64,52 @@ class YOLOv3(object):
             body_feats = [fluid.layers.cast(v, 'float32') for v in body_feats]
 
         if mode == 'train':
-            gt_box = feed_vars['gt_box']
-            gt_label = feed_vars['gt_label']
+            gt_bbox = feed_vars['gt_bbox']
+            gt_class = feed_vars['gt_class']
             gt_score = feed_vars['gt_score']
 
             return {
-                'loss': self.yolo_head.get_loss(body_feats, gt_box, gt_label,
+                'loss': self.yolo_head.get_loss(body_feats, gt_bbox, gt_class,
                                                 gt_score)
             }
         else:
             im_size = feed_vars['im_size']
             return self.yolo_head.get_prediction(body_feats, im_size)
+
+    def _inputs_def(self, image_shape, num_max_boxes):
+        im_shape = [None] + image_shape
+        # yapf: disable
+        inputs_def = {
+            'image':    {'shape': im_shape,                 'dtype': 'float32', 'lod_level': 0},
+     'im_size':  {'shape': [None, 2],                'dtype': 'int32',   'lod_level': 0},
+            'im_id':    {'shape': [None, 1],                'dtype': 'int32',   'lod_level': 0},
+            'gt_bbox':  {'shape': [None, num_max_boxes, 4], 'dtype': 'float32', 'lod_level': 0},
+            'gt_class': {'shape': [None, num_max_boxes],    'dtype': 'int32',   'lod_level': 0},
+            'gt_score': {'shape': [None, num_max_boxes],    'dtype': 'float32', 'lod_level': 0},
+            'is_difficult': {'shape': [None, num_max_boxes],'dtype': 'int32',   'lod_level': 0},
+        }
+        # yapf: enable
+        return inputs_def
+
+    def build_inputs(
+            self,
+            image_shape=[3, 608, 608],
+            fields=['image', 'gt_bbox', 'gt_class', 'gt_score'],  # for train
+            num_max_boxes=50,
+            use_dataloader=True,
+            iterable=False):
+        inputs_def = self._inputs_def(image_shape, num_max_boxes)
+        feed_vars = OrderedDict([(key, fluid.layers.data(
+            name=key,
+            shape=inputs_def[key]['shape'],
+            dtype=inputs_def[key]['dtype'],
+            lod_level=inputs_def[key]['lod_level'])) for key in fields])
+        loader = fluid.io.DataLoader.from_generator(
+            feed_list=list(feed_vars.values()),
+            capacity=64,
+            use_double_buffer=True,
+            iterable=iterable) if use_dataloader else None
+        return feed_vars, loader
 
     def train(self, feed_vars):
         return self.build(feed_vars, mode='train')

--- a/ppdet/utils/coco_eval.py
+++ b/ppdet/utils/coco_eval.py
@@ -22,8 +22,6 @@ import sys
 import json
 import cv2
 import numpy as np
-import matplotlib
-matplotlib.use('Agg')
 
 import logging
 logger = logging.getLogger(__name__)

--- a/tools/train2.py
+++ b/tools/train2.py
@@ -1,0 +1,318 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import time
+import numpy as np
+import datetime
+from collections import deque
+
+from paddle import fluid
+
+from ppdet.experimental import mixed_precision_context
+from ppdet.core.workspace import load_config, merge_config, create
+#from ppdet.data.data_feed import create_reader
+from ppdet.data2.loader import create_reader
+
+from ppdet.utils.cli import print_total_cfg
+from ppdet.utils import dist_utils
+from ppdet.utils.eval_utils import parse_fetches, eval_run, eval_results
+from ppdet.utils.stats import TrainingStats
+from ppdet.utils.cli import ArgsParser
+from ppdet.utils.check import check_gpu, check_version
+import ppdet.utils.checkpoint as checkpoint
+from ppdet.modeling.model_input import create_feed
+
+import logging
+FORMAT = '%(asctime)s-%(levelname)s: %(message)s'
+logging.basicConfig(level=logging.INFO, format=FORMAT)
+logger = logging.getLogger(__name__)
+
+
+def main():
+    env = os.environ
+    FLAGS.dist = 'PADDLE_TRAINER_ID' in env and 'PADDLE_TRAINERS_NUM' in env
+    if FLAGS.dist:
+        trainer_id = int(env['PADDLE_TRAINER_ID'])
+        import random
+        local_seed = (99 + trainer_id)
+        random.seed(local_seed)
+        np.random.seed(local_seed)
+
+    cfg = load_config(FLAGS.config)
+    if 'architecture' in cfg:
+        main_arch = cfg.architecture
+    else:
+        raise ValueError("'architecture' not specified in config file.")
+
+    merge_config(FLAGS.opt)
+
+    if 'log_iter' not in cfg:
+        cfg.log_iter = 20
+
+    # check if set use_gpu=True in paddlepaddle cpu version
+    check_gpu(cfg.use_gpu)
+    # check if paddlepaddle version is satisfied
+    check_version()
+    #if not FLAGS.dist or trainer_id == 0:
+    #    print_total_cfg(cfg)
+
+    if cfg.use_gpu:
+        devices_num = fluid.core.get_cuda_device_count()
+    else:
+        devices_num = int(os.environ.get('CPU_NUM', 1))
+
+    if 'FLAGS_selected_gpus' in env:
+        device_id = int(env['FLAGS_selected_gpus'])
+    else:
+        device_id = 0
+    place = fluid.CUDAPlace(device_id) if cfg.use_gpu else fluid.CPUPlace()
+    exe = fluid.Executor(place)
+
+    lr_builder = create('LearningRate')
+    optim_builder = create('OptimizerBuilder')
+
+    # build program
+    startup_prog = fluid.Program()
+    train_prog = fluid.Program()
+    with fluid.program_guard(train_prog, startup_prog):
+        with fluid.unique_name.guard():
+            model = create(main_arch)
+            if FLAGS.fp16:
+                assert (getattr(model.backbone, 'norm_type', None)
+                        != 'affine_channel'), \
+                    '--fp16 currently does not support affine channel, ' \
+                    ' please modify backbone settings to use batch norm'
+
+            with mixed_precision_context(FLAGS.loss_scale, FLAGS.fp16) as ctx:
+                print(cfg)
+                inputs_def = cfg['TrainLoader']['inputs_def']
+                feed_vars, train_loader = model.build_inputs(**inputs_def)
+                train_fetches = model.train(feed_vars)
+                loss = train_fetches['loss']
+                if FLAGS.fp16:
+                    loss *= ctx.get_loss_scale_var()
+                lr = lr_builder()
+                optimizer = optim_builder(lr)
+                optimizer.minimize(loss)
+                if FLAGS.fp16:
+                    loss /= ctx.get_loss_scale_var()
+
+    # parse train fetches
+    train_keys, train_values, _ = parse_fetches(train_fetches)
+    train_values.append(lr)
+
+    if FLAGS.eval:
+        eval_prog = fluid.Program()
+        with fluid.program_guard(eval_prog, startup_prog):
+            with fluid.unique_name.guard():
+                model = create(main_arch)
+                inputs_def = cfg['EvalLoader']['inputs_def']
+                feed_vars, eval_loader = model.build_inputs(**inputs_def)
+                fetches = model.eval(feed_vars)
+        eval_prog = eval_prog.clone(True)
+
+        eval_reader = create_reader(cfg.EvalLoader)
+        eval_loader.set_sample_list_generator(eval_reader, place)
+
+        # parse eval fetches
+        extra_keys = []
+        if cfg.metric == 'COCO':
+            extra_keys = ['im_info', 'im_id', 'im_shape']
+        if cfg.metric == 'VOC':
+            extra_keys = ['gt_box', 'gt_label', 'is_difficult']
+        if cfg.metric == 'WIDERFACE':
+            extra_keys = ['im_id', 'im_shape', 'gt_box']
+        eval_keys, eval_values, eval_cls = parse_fetches(fetches, eval_prog,
+                                                         extra_keys)
+
+    # compile program for multi-devices
+    build_strategy = fluid.BuildStrategy()
+    build_strategy.fuse_all_optimizer_ops = False
+    build_strategy.fuse_elewise_add_act_ops = True
+    # only enable sync_bn in multi GPU devices
+    sync_bn = getattr(model.backbone, 'norm_type', None) == 'sync_bn'
+    build_strategy.sync_batch_norm = sync_bn and devices_num > 1 \
+        and cfg.use_gpu
+
+    exec_strategy = fluid.ExecutionStrategy()
+    # iteration number when CompiledProgram tries to drop local execution scopes.
+    # Set it to be 1 to save memory usages, so that unused variables in
+    # local execution scopes can be deleted after each iteration.
+    exec_strategy.num_iteration_per_drop_scope = 1
+    if FLAGS.dist:
+        dist_utils.prepare_for_multi_process(exe, build_strategy, startup_prog,
+                                             train_prog)
+        exec_strategy.num_threads = 1
+
+    exe.run(startup_prog)
+    compiled_train_prog = fluid.CompiledProgram(train_prog).with_data_parallel(
+        loss_name=loss.name,
+        build_strategy=build_strategy,
+        exec_strategy=exec_strategy)
+
+    if FLAGS.eval:
+        compiled_eval_prog = fluid.compiler.CompiledProgram(eval_prog)
+
+    fuse_bn = getattr(model.backbone, 'norm_type', None) == 'affine_channel'
+
+    ignore_params = cfg.finetune_exclude_pretrained_params \
+                 if 'finetune_exclude_pretrained_params' in cfg else []
+
+    start_iter = 0
+    if FLAGS.resume_checkpoint:
+        checkpoint.load_checkpoint(exe, train_prog, FLAGS.resume_checkpoint)
+        start_iter = checkpoint.global_step()
+    elif cfg.pretrain_weights and fuse_bn and not ignore_params:
+        checkpoint.load_and_fusebn(exe, train_prog, cfg.pretrain_weights)
+    elif cfg.pretrain_weights:
+        checkpoint.load_params(
+            exe, train_prog, cfg.pretrain_weights, ignore_params=ignore_params)
+
+    train_reader = create_reader(cfg.TrainLoader,
+                                 (cfg.max_iters - start_iter) * devices_num)
+    train_loader.set_sample_list_generator(train_reader, place)
+
+    # whether output bbox is normalized in model output layer
+    is_bbox_normalized = False
+    if hasattr(model, 'is_bbox_normalized') and \
+            callable(model.is_bbox_normalized):
+        is_bbox_normalized = model.is_bbox_normalized()
+
+    # if map_type not set, use default 11point, only use in VOC eval
+    map_type = cfg.map_type if 'map_type' in cfg else '11point'
+
+    train_stats = TrainingStats(cfg.log_smooth_window, train_keys)
+    train_loader.start()
+    start_time = time.time()
+    end_time = time.time()
+
+    cfg_name = os.path.basename(FLAGS.config).split('.')[0]
+    save_dir = os.path.join(cfg.save_dir, cfg_name)
+    time_stat = deque(maxlen=cfg.log_smooth_window)
+    best_box_ap_list = [0.0, 0]  #[map, iter]
+
+    # use tb-paddle to log data
+    if FLAGS.use_tb:
+        from tb_paddle import SummaryWriter
+        tb_writer = SummaryWriter(FLAGS.tb_log_dir)
+        tb_loss_step = 0
+        tb_mAP_step = 0
+
+    for it in range(start_iter, cfg.max_iters):
+        start_time = end_time
+        end_time = time.time()
+        time_stat.append(end_time - start_time)
+        time_cost = np.mean(time_stat)
+        eta_sec = (cfg.max_iters - it) * time_cost
+        eta = str(datetime.timedelta(seconds=int(eta_sec)))
+        outs = exe.run(compiled_train_prog, fetch_list=train_values)
+        stats = {k: np.array(v).mean() for k, v in zip(train_keys, outs[:-1])}
+
+        # use tb-paddle to log loss
+        if FLAGS.use_tb:
+            if it % cfg.log_iter == 0:
+                for loss_name, loss_value in stats.items():
+                    tb_writer.add_scalar(loss_name, loss_value, tb_loss_step)
+                tb_loss_step += 1
+
+        train_stats.update(stats)
+        logs = train_stats.log()
+        if it % cfg.log_iter == 0 and (not FLAGS.dist or trainer_id == 0):
+            strs = 'iter: {}, lr: {:.6f}, {}, time: {:.3f}, eta: {}'.format(
+                it, np.mean(outs[-1]), logs, time_cost, eta)
+            logger.info(strs)
+
+        if (it > 0 and it % cfg.snapshot_iter == 0 or it == cfg.max_iters - 1) \
+           and (not FLAGS.dist or trainer_id == 0):
+            save_name = str(it) if it != cfg.max_iters - 1 else "model_final"
+            checkpoint.save(exe, train_prog, os.path.join(save_dir, save_name))
+
+            if FLAGS.eval:
+                # evaluation
+                results = eval_run(exe, compiled_eval_prog, eval_loader,
+                                   eval_keys, eval_values, eval_cls)
+                resolution = None
+                if 'mask' in results[0]:
+                    resolution = model.mask_head.resolution
+                box_ap_stats = eval_results(
+                    results, eval_feed, cfg.metric, cfg.num_classes, resolution,
+                    is_bbox_normalized, FLAGS.output_eval, map_type)
+
+                # use tb_paddle to log mAP
+                if FLAGS.use_tb:
+                    tb_writer.add_scalar("mAP", box_ap_stats[0], tb_mAP_step)
+                    tb_mAP_step += 1
+
+                if box_ap_stats[0] > best_box_ap_list[0]:
+                    best_box_ap_list[0] = box_ap_stats[0]
+                    best_box_ap_list[1] = it
+                    checkpoint.save(exe, train_prog,
+                                    os.path.join(save_dir, "best_model"))
+                logger.info("Best test box ap: {}, in iter: {}".format(
+                    best_box_ap_list[0], best_box_ap_list[1]))
+
+    train_loader.reset()
+
+
+if __name__ == '__main__':
+    parser = ArgsParser()
+    parser.add_argument(
+        "-r",
+        "--resume_checkpoint",
+        default=None,
+        type=str,
+        help="Checkpoint path for resuming training.")
+    parser.add_argument(
+        "--fp16",
+        action='store_true',
+        default=False,
+        help="Enable mixed precision training.")
+    parser.add_argument(
+        "--loss_scale",
+        default=8.,
+        type=float,
+        help="Mixed precision training loss scale.")
+    parser.add_argument(
+        "--eval",
+        action='store_true',
+        default=False,
+        help="Whether to perform evaluation in train")
+    parser.add_argument(
+        "--output_eval",
+        default=None,
+        type=str,
+        help="Evaluation directory, default is current directory.")
+    parser.add_argument(
+        "-d",
+        "--dataset_dir",
+        default=None,
+        type=str,
+        help="Dataset path, same as DataFeed.dataset.dataset_dir")
+    parser.add_argument(
+        "--use_tb",
+        type=bool,
+        default=False,
+        help="whether to record the data to Tensorboard.")
+    parser.add_argument(
+        '--tb_log_dir',
+        type=str,
+        default="tb_log_dir/scalar",
+        help='Tensorboard logging directory for scalar.')
+    FLAGS = parser.parse_args()
+    main()


### PR DESCRIPTION
数据预处理的operators.py、多线程/进程数据预处理复用原先的，数据解析模块coco, voc等也复用原先的，但接口做了修改，便于在config里配置。

-  主要接口:

  ```
  class Loader(object):
      def __init__(self,
                 dataset=None,
                 sample_transforms=None,
                 batch_transforms=None,
                 batch_size=None,
                 fields=None,
                 shuffle=False,
                 drop_last=False,
                 drop_empty=True,
                 mixup_epoch=-1,
                 class_aware_sampling=False,
                 worker_num=-1,
                 use_process=False,
                 bufsize=100,
                 memsize='3G',
                 inputs_def=None,
                 **kwargs):
  ```
    
 多进程/线程 处理内容: sample_transforms-> 组batch -> batch_transforms.

- 使用可以参考 ppdet/data2/tests
- 会删掉data_feed.py，预先定义系列基础的数据预处理yml配置，在模型config里引用。

  用户模型的Config里配置，可以参考configs2里， 可以通过 _LOADER_ 关键字加载一个yml的数据预处理文件

```
_LOADER_: 'faster_loader.yml'
TrainLoader: # 可更新faster_loader.yml里的内容
  inputs_def:
    image_shape: [3,800,800]
    fields: ['image', 'im_info', 'im_id', 'gt_bbox', 'gt_class', 'is_crowd']
  batch_size: 3
```
- 删掉model_inputs.py，模型architecture里增加`build_inputs`接口:

```
    def _inputs_def(self, image_shape):
        im_shape = [None] + image_shape
        # yapf: disable
        inputs_def = {
            'image':    {'shape': im_shape,  'dtype': 'float32', 'lod_level': 0},
            'im_info':  {'shape': [None, 3], 'dtype': 'float32', 'lod_level': 0},
            'im_id':    {'shape': [None, 1], 'dtype': 'int32',   'lod_level': 0},
            'gt_bbox':   {'shape': [None, 4], 'dtype': 'float32', 'lod_level': 1},
            'gt_class': {'shape': [None, 1], 'dtype': 'int32',   'lod_level': 1},
            'is_crowd': {'shape': [None, 1], 'dtype': 'int32',   'lod_level': 1},
        }
        # yapf: enable
        return inputs_def

    def build_inputs(
            self,
            image_shape=[3, None, None],
            fields=[
                'image', 'im_info', 'im_id', 'gt_bbox', 'gt_class', 'is_crowd'
            ],  # for train
            use_dataloader=True,
            iterable=False):
        inputs_def = self._inputs_def(image_shape)
        feed_vars = OrderedDict([(key, fluid.layers.data(
            name=key,
            shape=inputs_def[key]['shape'],
            dtype=inputs_def[key]['dtype'],
            lod_level=inputs_def[key]['lod_level'])) for key in fields])
        loader = fluid.io.DataLoader.from_generator(
            feed_list=list(feed_vars.values()),
            capacity=64,
            use_double_buffer=True,
            iterable=iterable) if use_dataloader else None
        return feed_vars, loader
```