### PR TITLE
fix mixup error when dataset has only 1 sample

### DIFF
--- a/ppdet/data/source/roidb_source.py
+++ b/ppdet/data/source/roidb_source.py
@@ -28,6 +28,9 @@ import copy
 import pickle as pkl
 from ..dataset import Dataset
 
+import logging
+logger = logging.getLogger(__name__)
+
 
 class RoiDbSource(Dataset):
     """ interface to load roidb data from files
@@ -133,6 +136,10 @@ class RoiDbSource(Dataset):
         self._samples = len(self._roidb)
         if self._is_shuffle:
             random.shuffle(self._roidb)
+
+        if self._mixup_epoch > 0 and self._samples < 2:
+            logger.info("Disable mixup for dataset samples less than 2")
+            self._mixup_epoch = -1
 
         if self._epoch < 0:
             self._epoch = 0

--- a/ppdet/data/source/roidb_source.py
+++ b/ppdet/data/source/roidb_source.py
@@ -138,7 +138,8 @@ class RoiDbSource(Dataset):
             random.shuffle(self._roidb)
 
         if self._mixup_epoch > 0 and self._samples < 2:
-            logger.info("Disable mixup for dataset samples less than 2")
+            logger.info("Disable mixup for dataset samples "
+                        "less than 2 samples")
             self._mixup_epoch = -1
 
         if self._epoch < 0:


### PR DESCRIPTION
**fix mixup error**
mixup can only be performed when dataset contains at least 2 samples, disable mixup when dataset has less than 2 samples.