### PR TITLE
fix use_fine_grained_loss eval in train

### DIFF
--- a/ppdet/modeling/architectures/yolov3.py
+++ b/ppdet/modeling/architectures/yolov3.py
@@ -135,7 +135,10 @@ class YOLOv3(object):
             use_dataloader=True,
             iterable=False):
         inputs_def = self._inputs_def(image_shape, num_max_boxes)
-        if self.use_fine_grained_loss:
+        # if fields has im_size, this is in eval/infer mode, fine grained loss
+        # will be disabled for YOLOv3 architecture do not calculate loss in
+        # eval/infer mode.
+        if 'im_size' not in fields and self.use_fine_grained_loss:
             fields.extend(['target0', 'target1', 'target2'])
         feed_vars = OrderedDict([(key, fluid.data(
             name=key,


### PR DESCRIPTION
**fix use_fine_grained_loss eval in train**
EvalReader and build_inputs in eval mode should not set use_fined_grained_loss for no loss is calculated in eval/infer mode. 
Following error will be occur when use `--eval` in training
```
2020-01-06 09:20:37,224-WARNING: recv endsignal from outq with errmsg[consumer[consumer-0be-1] failed to map with error:[target0 not in samples]]
```
use whether `im_size` is in fields to distinguish train and eval/infer mode

备选方案：
- build_inputs中加入mode参数，由train/eval/infer中传入该参数区分当前mode，需要修改所有architecture
- 读取配置后，将`-o use_fine_grained_loss=true`设置的配置同步到TrainReader.input_def，需要在train.py中新增硬编码处理