### PR TITLE
DEBUG: add ncp reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ dataset/wider_face/WIDER_test
 dataset/wider_face/WIDER_train
 dataset/wider_face/WIDER_val
 dataset/wider_face/wider_face_split
+dataset/ncp

--- a/box_utils.py
+++ b/box_utils.py
@@ -1,0 +1,411 @@
+# Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+
+import matplotlib
+matplotlib.use('Agg')
+from matplotlib import pyplot as plt
+from PIL import Image
+
+
+def sigmoid(x):
+    """Perform sigmoid to input numpy array"""
+    return 1.0 / (1.0 + np.exp(-1.0 * x))
+
+
+def coco_anno_box_to_center_relative(box, img_height, img_width):
+    """
+    Convert COCO annotations box with format [x1, y1, w, h] to 
+    center mode [center_x, center_y, w, h] and divide image width
+    and height to get relative value in range[0, 1]
+    """
+    assert len(box) == 4, "box should be a len(4) list or tuple"
+    x, y, w, h = box
+
+    x1 = max(x, 0)
+    x2 = min(x + w - 1, img_width - 1)
+    y1 = max(y, 0)
+    y2 = min(y + h - 1, img_height - 1)
+
+    x = (x1 + x2) / 2 / img_width
+    y = (y1 + y2) / 2 / img_height
+    w = (x2 - x1) / img_width
+    h = (y2 - y1) / img_height
+
+    return np.array([x, y, w, h])
+
+
+def clip_relative_box_in_image(x, y, w, h):
+    """Clip relative box coordinates x, y, w, h to [0, 1]"""
+    x1 = max(x - w / 2, 0.)
+    x2 = min(x + w / 2, 1.)
+    y1 = min(y - h / 2, 0.)
+    y2 = max(y + h / 2, 1.)
+    x = (x1 + x2) / 2
+    y = (y1 + y2) / 2
+    w = x2 - x1
+    h = y2 - y1
+
+
+def box_xywh_to_xyxy(box):
+    shape = box.shape
+    assert shape[-1] == 4, "Box shape[-1] should be 4."
+
+    box = box.reshape((-1, 4))
+    box[:, 0], box[:, 2] = box[:, 0] - box[:, 2] / 2, box[:, 0] + box[:, 2] / 2
+    box[:, 1], box[:, 3] = box[:, 1] - box[:, 3] / 2, box[:, 1] + box[:, 3] / 2
+    box = box.reshape(shape)
+    return box
+
+
+def box_iou_xywh(box1, box2):
+    assert box1.shape[-1] == 4, "Box1 shape[-1] should be 4."
+    assert box2.shape[-1] == 4, "Box2 shape[-1] should be 4."
+
+    b1_x1, b1_x2 = box1[:, 0] - box1[:, 2] / 2, box1[:, 0] + box1[:, 2] / 2
+    b1_y1, b1_y2 = box1[:, 1] - box1[:, 3] / 2, box1[:, 1] + box1[:, 3] / 2
+    b2_x1, b2_x2 = box2[:, 0] - box2[:, 2] / 2, box2[:, 0] + box2[:, 2] / 2
+    b2_y1, b2_y2 = box2[:, 1] - box2[:, 3] / 2, box2[:, 1] + box2[:, 3] / 2
+
+    inter_x1 = np.maximum(b1_x1, b2_x1)
+    inter_x2 = np.minimum(b1_x2, b2_x2)
+    inter_y1 = np.maximum(b1_y1, b2_y1)
+    inter_y2 = np.maximum(b1_y2, b2_y2)
+    inter_w = inter_x2 - inter_x1 + 1
+    inter_h = inter_y2 - inter_y1 + 1
+    inter_w[inter_w < 0] == 0
+    inter_h[inter_h < 0] == 0
+
+    inter_area = inter_w * inter_h
+    b1_area = (b1_x2 - b1_x1 + 1) * (b1_y2 - b1_y1 + 1)
+    b2_area = (b2_x2 - b2_x1 + 1) * (b2_y2 - b2_y1 + 1)
+
+    return inter_area / (b1_area + b2_area - inter_area)
+
+
+def box_iou_xyxy(box1, box2):
+    assert box1.shape[-1] == 4, "Box1 shape[-1] should be 4."
+    assert box2.shape[-1] == 4, "Box2 shape[-1] should be 4."
+
+    b1_x1, b1_y1, b1_x2, b1_y2 = box1[:, 0], box1[:, 1], box1[:, 2], box1[:, 3]
+    b2_x1, b2_y1, b2_x2, b2_y2 = box2[:, 0], box2[:, 1], box2[:, 2], box2[:, 3]
+
+    inter_x1 = np.maximum(b1_x1, b2_x1)
+    inter_x2 = np.minimum(b1_x2, b2_x2)
+    inter_y1 = np.maximum(b1_y1, b2_y1)
+    inter_y2 = np.maximum(b1_y2, b2_y2)
+    inter_w = inter_x2 - inter_x1 + 1
+    inter_h = inter_y2 - inter_y1 + 1
+    inter_w[inter_w < 0] == 0
+    inter_h[inter_h < 0] == 0
+
+    inter_area = inter_w * inter_h
+    b1_area = (b1_x2 - b1_x1 + 1) * (b1_y2 - b1_y1 + 1)
+    b2_area = (b2_x2 - b2_x1 + 1) * (b2_y2 - b2_y1 + 1)
+
+    return inter_area / (b1_area + b2_area - inter_area)
+
+
+def rescale_box_in_input_image(boxes, im_shape, input_size):
+    """Scale (x1, x2, y1, y2) box of yolo output to input image"""
+    h, w = im_shape
+    # max_dim = max(h , w)
+    # boxes = boxes * max_dim / input_size
+    # dim_diff = np.abs(h - w)
+    # pad = dim_diff // 2
+    # if h <= w:
+    #     boxes[:, 1] -= pad
+    #     boxes[:, 3] -= pad
+    # else:
+    #     boxes[:, 0] -= pad
+    #     boxes[:, 2] -= pad
+    fx = w / input_size
+    fy = h / input_size
+    boxes[:, 0] *= fx
+    boxes[:, 1] *= fy
+    boxes[:, 2] *= fx
+    boxes[:, 3] *= fy
+    boxes[boxes < 0] = 0
+    return boxes
+
+
+def box_crop(boxes, labels, scores, crop, img_shape):
+    x, y, w, h = map(float, crop)
+    im_w, im_h = map(float, img_shape)
+
+    boxes = boxes.copy()
+    boxes[:, 0], boxes[:, 2] = (boxes[:, 0] - boxes[:, 2] / 2) * im_w, (
+        boxes[:, 0] + boxes[:, 2] / 2) * im_w
+    boxes[:, 1], boxes[:, 3] = (boxes[:, 1] - boxes[:, 3] / 2) * im_h, (
+        boxes[:, 1] + boxes[:, 3] / 2) * im_h
+
+    crop_box = np.array([x, y, x + w, y + h])
+    centers = (boxes[:, :2] + boxes[:, 2:]) / 2.0
+    mask = np.logical_and(crop_box[:2] <= centers, centers <= crop_box[2:]).all(
+        axis=1)
+
+    boxes[:, :2] = np.maximum(boxes[:, :2], crop_box[:2])
+    boxes[:, 2:] = np.minimum(boxes[:, 2:], crop_box[2:])
+    boxes[:, :2] -= crop_box[:2]
+    boxes[:, 2:] -= crop_box[:2]
+
+    mask = np.logical_and(mask, (boxes[:, :2] < boxes[:, 2:]).all(axis=1))
+    boxes = boxes * np.expand_dims(mask.astype('float32'), axis=1)
+    labels = labels * mask.astype('float32')
+    scores = scores * mask.astype('float32')
+    boxes[:, 0], boxes[:, 2] = (boxes[:, 0] + boxes[:, 2]) / 2 / w, (
+        boxes[:, 2] - boxes[:, 0]) / w
+    boxes[:, 1], boxes[:, 3] = (boxes[:, 1] + boxes[:, 3]) / 2 / h, (
+        boxes[:, 3] - boxes[:, 1]) / h
+
+    return boxes, labels, scores, mask.sum()
+
+
+def get_yolo_detection(preds, anchors, class_num, img_width, img_height):
+    """Get yolo box, confidence score, class label from Darknet53 output"""
+    preds_n = np.array(preds)
+    n, c, h, w = preds_n.shape
+    anchor_num = len(anchors) // 2
+    preds_n = preds_n.reshape([n, anchor_num, class_num + 5, h, w]) \
+                     .transpose((0, 1, 3, 4, 2))
+    preds_n[:, :, :, :, :2] = sigmoid(preds_n[:, :, :, :, :2])
+    preds_n[:, :, :, :, 4:] = sigmoid(preds_n[:, :, :, :, 4:])
+
+    pred_boxes = preds_n[:, :, :, :, :4]
+    pred_confs = preds_n[:, :, :, :, 4]
+    pred_scores = preds_n[:, :, :, :, 5:] * np.expand_dims(pred_confs, axis=4)
+
+    grid_x = np.tile(np.arange(w).reshape((1, w)), (h, 1))
+    grid_y = np.tile(np.arange(h).reshape((h, 1)), (1, w))
+    anchors = [(anchors[i], anchors[i + 1]) for i in range(0, len(anchors), 2)]
+    anchors_s = np.array([(an_w, an_h) for an_w, an_h in anchors])
+    anchor_w = anchors_s[:, 0:1].reshape((1, anchor_num, 1, 1))
+    anchor_h = anchors_s[:, 1:2].reshape((1, anchor_num, 1, 1))
+
+    pred_boxes[:, :, :, :, 0] += grid_x
+    pred_boxes[:, :, :, :, 1] += grid_y
+    pred_boxes[:, :, :, :, 2] = np.exp(pred_boxes[:, :, :, :, 2]) * anchor_w
+    pred_boxes[:, :, :, :, 3] = np.exp(pred_boxes[:, :, :, :, 3]) * anchor_h
+
+    pred_boxes[:, :, :, :, 0] = pred_boxes[:, :, :, :, 0] * img_width / w
+    pred_boxes[:, :, :, :, 1] = pred_boxes[:, :, :, :, 1] * img_height / h
+    pred_boxes[:, :, :, :, 2] = pred_boxes[:, :, :, :, 2]
+    pred_boxes[:, :, :, :, 3] = pred_boxes[:, :, :, :, 3]
+
+    pred_boxes = box_xywh_to_xyxy(pred_boxes)
+    pred_boxes = np.tile(
+        np.expand_dims(
+            pred_boxes, axis=4), (1, 1, 1, 1, class_num, 1))
+    pred_labels = np.zeros_like(pred_scores) + np.arange(class_num)
+
+    return (
+        pred_boxes.reshape((n, -1, 4)),
+        pred_scores.reshape((n, -1)),
+        pred_labels.reshape((n, -1)), )
+
+
+def get_all_yolo_pred(outputs, yolo_anchors, yolo_classes, input_shape):
+    all_pred_boxes = []
+    all_pred_scores = []
+    all_pred_labels = []
+    for output, anchors, classes in zip(outputs, yolo_anchors, yolo_classes):
+        pred_boxes, pred_scores, pred_labels = get_yolo_detection(
+            output, anchors, classes, input_shape[0], input_shape[1])
+        all_pred_boxes.append(pred_boxes)
+        all_pred_labels.append(pred_labels)
+        all_pred_scores.append(pred_scores)
+    pred_boxes = np.concatenate(all_pred_boxes, axis=1)
+    pred_scores = np.concatenate(all_pred_scores, axis=1)
+    pred_labels = np.concatenate(all_pred_labels, axis=1)
+
+    return (pred_boxes, pred_scores, pred_labels)
+
+
+def calc_nms_box_new(pred_boxes,
+                     pred_scores,
+                     pred_labels,
+                     valid_thresh=0.01,
+                     nms_thresh=0.4,
+                     nms_topk=400,
+                     nms_posk=100):
+    output_boxes = np.empty((0, 4))
+    output_scores = np.empty(0)
+    output_labels = np.empty(0)
+    for boxes, labels, scores in zip(pred_boxes, pred_labels, pred_scores):
+        valid_mask = scores > valid_thresh
+        boxes = boxes[valid_mask]
+        scores = scores[valid_mask]
+        labels = labels[valid_mask]
+
+        score_sort_index = np.argsort(scores)[::-1]
+        boxes = boxes[score_sort_index][:nms_topk]
+        scores = scores[score_sort_index][:nms_topk]
+        labels = labels[score_sort_index][:nms_topk]
+
+        for c in np.unique(labels):
+            c_mask = labels == c
+            c_boxes = boxes[c_mask]
+            c_scores = scores[c_mask]
+
+            detect_boxes = []
+            detect_scores = []
+            detect_labels = []
+            while c_boxes.shape[0]:
+                detect_boxes.append(c_boxes[0])
+                detect_scores.append(c_scores[0])
+                detect_labels.append(c)
+                if c_boxes.shape[0] == 1:
+                    break
+                iou = box_iou_xyxy(detect_boxes[-1].reshape((1, 4)),
+                                   c_boxes[1:])
+                c_boxes = c_boxes[1:][iou < nms_thresh]
+                c_scores = c_scores[1:][iou < nms_thresh]
+
+            output_boxes = np.append(output_boxes, detect_boxes, axis=0)
+            output_scores = np.append(output_scores, detect_scores)
+            output_labels = np.append(output_labels, detect_labels)
+    return (output_boxes, output_scores, output_labels)
+
+
+def calc_nms_box(pred_boxes,
+                 pred_confs,
+                 pred_labels,
+                 im_shape,
+                 input_size,
+                 valid_thresh=0.8,
+                 nms_thresh=0.4,
+                 nms_topk=400,
+                 nms_posk=100):
+    """
+    Removes detections which confidence score under valid_thresh and perform 
+    Non-Maximun Suppression to filtered boxes
+    """
+    _, box_num, class_num = pred_labels.shape
+    pred_boxes = box_xywh_to_xyxy(pred_boxes)
+    output_boxes = np.empty((0, 4))
+    output_scores = np.empty(0)
+    output_labels = np.empty((0))
+    for i, (boxes, confs,
+            classes) in enumerate(zip(pred_boxes, pred_confs, pred_labels)):
+        conf_mask = confs > valid_thresh
+        if conf_mask.sum() == 0:
+            continue
+        boxes = boxes[conf_mask]
+        classes = classes[conf_mask]
+        confs = confs[conf_mask]
+
+        conf_sort_index = np.argsort(confs)[::-1]
+        boxes = boxes[conf_sort_index][:nms_topk]
+        classes = classes[conf_sort_index][:nms_topk]
+        confs = confs[conf_sort_index][:nms_topk]
+        cls_score = np.max(classes, axis=1)
+        cls_pred = np.argmax(classes, axis=1)
+
+        for c in np.unique(cls_pred):
+            c_mask = cls_pred == c
+            c_confs = confs[c_mask]
+            c_boxes = boxes[c_mask]
+            c_scores = cls_score[c_mask]
+            c_score_index = np.argsort(c_scores)
+            c_boxes_s = c_boxes[c_score_index[::-1]]
+            c_confs_s = c_confs[c_score_index[::-1]]
+            c_scores_s = c_scores[c_score_index[::-1]]
+
+            detect_boxes = []
+            detect_scores = []
+            detect_labels = []
+            while c_boxes_s.shape[0]:
+                detect_boxes.append(c_boxes_s[0])
+                detect_scores.append(c_scores_s[0])
+                detect_labels.append(c)
+                if c_boxes_s.shape[0] == 1:
+                    break
+                iou = box_iou_xyxy(detect_boxes[-1].reshape((1, 4)),
+                                   c_boxes_s[1:])
+                c_boxes_s = c_boxes_s[1:][iou < nms_thresh]
+                c_confs_s = c_confs_s[1:][iou < nms_thresh]
+                c_scores_s = c_scores_s[1:][iou < nms_thresh]
+
+            output_boxes = np.append(output_boxes, detect_boxes, axis=0)
+            output_scores = np.append(output_scores, detect_scores)
+            output_labels = np.append(output_labels, detect_labels)
+
+    output_boxes = output_boxes[:nms_posk]
+    output_scores = output_scores[:nms_posk]
+    output_labels = output_labels[:nms_posk]
+
+    output_boxes = rescale_box_in_input_image(output_boxes, im_shape,
+                                              input_size)
+    return (output_boxes, output_scores, output_labels)
+
+
+def draw_boxes_on_image(image_path,
+                        boxes,
+                        scores,
+                        labels,
+                        label_names,
+                        score_thresh=0.5):
+    image = np.array(Image.open(image_path))
+    plt.figure()
+    _, ax = plt.subplots(1)
+    ax.imshow(image)
+
+    image_name = image_path.split('/')[-1]
+    print("Image {} detect: ".format(image_name))
+    colors = {}
+    for box, score, label in zip(boxes, scores, labels):
+        if score < score_thresh:
+            continue
+        if box[2] <= box[0] or box[3] <= box[1]:
+            continue
+        label = int(label)
+        if label not in colors:
+            colors[label] = plt.get_cmap('hsv')(label / len(label_names))
+        x1, y1, x2, y2 = box[0], box[1], box[2], box[3]
+        rect = plt.Rectangle(
+            (x1, y1),
+            x2 - x1,
+            y2 - y1,
+            fill=False,
+            linewidth=2.0,
+            edgecolor=colors[label])
+        ax.add_patch(rect)
+        ax.text(
+            x1,
+            y1,
+            '{} {:.4f}'.format(label_names[label], score),
+            verticalalignment='bottom',
+            horizontalalignment='left',
+            bbox={'facecolor': colors[label],
+                  'alpha': 0.5,
+                  'pad': 0},
+            fontsize=8,
+            color='white')
+        print("\t {:15s} at {:25} score: {:.5f}".format(label_names[int(
+            label)], map(int, list(box)), score))
+    image_name = image_name.replace('jpg', 'png')
+    plt.axis('off')
+    plt.gca().xaxis.set_major_locator(plt.NullLocator())
+    plt.gca().yaxis.set_major_locator(plt.NullLocator())
+    plt.savefig(
+        "./output/{}".format(image_name), bbox_inches='tight', pad_inches=0.0)
+    print("Detect result save at ./output/{}\n".format(image_name))
+    plt.cla()
+    plt.close('all')

--- a/configs/yolov3_mobilenet_v1_ncp.yml
+++ b/configs/yolov3_mobilenet_v1_ncp.yml
@@ -8,7 +8,7 @@ metric: VOC
 map_type: 11point
 pretrain_weights: http://paddle-imagenet-models-name.bj.bcebos.com/MobileNetV1_pretrained.tar
 weights: output/yolov3_mobilenet_v1_voc/model_final
-num_classes: 20
+num_classes: 1
 use_fine_grained_loss: false
 
 YOLOv3:

--- a/configs/yolov3_mobilenet_v1_ncp.yml
+++ b/configs/yolov3_mobilenet_v1_ncp.yml
@@ -1,0 +1,86 @@
+architecture: YOLOv3
+use_gpu: true
+max_iters: 70000
+log_smooth_window: 20
+save_dir: output
+snapshot_iter: 2000
+metric: VOC
+map_type: 11point
+pretrain_weights: http://paddle-imagenet-models-name.bj.bcebos.com/MobileNetV1_pretrained.tar
+weights: output/yolov3_mobilenet_v1_voc/model_final
+num_classes: 20
+use_fine_grained_loss: false
+
+YOLOv3:
+  backbone: MobileNet
+  yolo_head: YOLOv3Head
+
+MobileNet:
+  norm_type: sync_bn
+  norm_decay: 0.
+  conv_group_scale: 1
+  with_extra_blocks: false
+
+YOLOv3Head:
+  anchor_masks: [[6, 7, 8], [3, 4, 5], [0, 1, 2]]
+  anchors: [[10, 13], [16, 30], [33, 23],
+            [30, 61], [62, 45], [59, 119],
+            [116, 90], [156, 198], [373, 326]]
+  norm_decay: 0.
+  yolo_loss: YOLOv3Loss
+  nms:
+    background_label: -1
+    keep_top_k: 100
+    nms_threshold: 0.45
+    nms_top_k: 1000
+    normalized: false
+    score_threshold: 0.01
+
+YOLOv3Loss:
+  batch_size: 8
+  ignore_thresh: 0.7
+  label_smooth: false
+
+LearningRate:
+  base_lr: 0.001
+  schedulers:
+  - !PiecewiseDecay
+    gamma: 0.1
+    milestones:
+    - 55000
+    - 62000
+  - !LinearWarmup
+    start_factor: 0.
+    steps: 1000
+
+OptimizerBuilder:
+  optimizer:
+    momentum: 0.9
+    type: Momentum
+  regularizer:
+    factor: 0.0005
+    type: L2
+
+_READER_: 'yolov3_reader.yml'
+TrainReader:
+  dataset:
+    !VOCDataSet
+    dataset_dir: dataset/ncp
+    use_default_label: true
+    with_background: false
+
+EvalReader:
+  inputs_def:
+    fields: ['image', 'im_size', 'im_id', 'gt_bbox', 'gt_class', 'is_difficult']
+    num_max_boxes: 50
+  dataset:
+    !VOCDataSet
+    dataset_dir: dataset/ncp
+    use_default_label: true
+    with_background: false
+
+TestReader:
+  dataset:
+    !ImageFolder
+    use_default_label: true
+    with_background: false

--- a/configs/yolov3_reader.yml
+++ b/configs/yolov3_reader.yml
@@ -19,8 +19,8 @@ TrainReader:
     # - !RandomExpand
     #   fill_value: [123.675, 116.28, 103.53]
     # - !RandomCrop {}
-    # - !RandomFlipImage
-    #   is_normalized: false
+    - !RandomFlipImage
+      is_normalized: false
     - !NormalizeBox {}
     - !PadBox
       num_max_boxes: 50
@@ -32,8 +32,8 @@ TrainReader:
   - !NormalizeImage
     # mean: [0.485, 0.456, 0.406]
     # std: [0.229, 0.224, 0.225]
-    mean: [0.485]
-    std: [0.229]
+    mean: [-0.6922149577487554]
+    std: [0.5121248402346167]
     is_scale: True
     is_channel_first: false
   - !Permute
@@ -74,8 +74,10 @@ EvalReader:
       target_size: 608
       interp: 2
     - !NormalizeImage
-      mean: [0.485, 0.456, 0.406]
-      std: [0.229, 0.224, 0.225]
+    #   mean: [0.485, 0.456, 0.406]
+    #   std: [0.229, 0.224, 0.225]
+      mean: [-0.6922149577487554]
+      std: [0.5121248402346167]
       is_scale: True
       is_channel_first: false
     - !PadBox
@@ -90,7 +92,7 @@ EvalReader:
 
 TestReader:
   inputs_def:
-    image_shape: [1, 608, 608]
+    image_shape: [3, 608, 608]
     fields: ['image', 'im_size', 'im_id']
   dataset:
     !ImageFolder
@@ -103,8 +105,10 @@ TestReader:
       target_size: 608
       interp: 2
     - !NormalizeImage
-      mean: [0.485, 0.456, 0.406]
-      std: [0.229, 0.224, 0.225]
+      # mean: [0.485, 0.456, 0.406]
+      # std: [0.229, 0.224, 0.225]
+      mean: [-0.6922149577487554]
+      std: [0.5121248402346167]
       is_scale: True
       is_channel_first: false
     - !Permute

--- a/configs/yolov3_reader.yml
+++ b/configs/yolov3_reader.yml
@@ -30,8 +30,10 @@ TrainReader:
   #   sizes: [320, 352, 384, 416, 448, 480, 512, 544, 576, 608]
   #   random_inter: True
   - !NormalizeImage
-    mean: [0.485, 0.456, 0.406]
-    std: [0.229, 0.224, 0.225]
+    # mean: [0.485, 0.456, 0.406]
+    # std: [0.229, 0.224, 0.225]
+    mean: [0.485]
+    std: [0.229]
     is_scale: True
     is_channel_first: false
   - !Permute
@@ -88,7 +90,7 @@ EvalReader:
 
 TestReader:
   inputs_def:
-    image_shape: [3, 608, 608]
+    image_shape: [1, 608, 608]
     fields: ['image', 'im_size', 'im_id']
   dataset:
     !ImageFolder

--- a/configs/yolov3_reader.yml
+++ b/configs/yolov3_reader.yml
@@ -15,20 +15,20 @@ TrainReader:
     # - !MixupImage
     #   alpha: 1.5
     #   beta: 1.5
-    - !ColorDistort {}
-    - !RandomExpand
-      fill_value: [123.675, 116.28, 103.53]
-    - !RandomCrop {}
-    - !RandomFlipImage
-      is_normalized: false
+    # - !ColorDistort {}
+    # - !RandomExpand
+    #   fill_value: [123.675, 116.28, 103.53]
+    # - !RandomCrop {}
+    # - !RandomFlipImage
+    #   is_normalized: false
     - !NormalizeBox {}
     - !PadBox
       num_max_boxes: 50
     - !BboxXYXY2XYWH {}
   batch_transforms:
-  - !RandomShape
-    sizes: [320, 352, 384, 416, 448, 480, 512, 544, 576, 608]
-    random_inter: True
+  # - !RandomShape
+  #   sizes: [320, 352, 384, 416, 448, 480, 512, 544, 576, 608]
+  #   random_inter: True
   - !NormalizeImage
     mean: [0.485, 0.456, 0.406]
     std: [0.229, 0.224, 0.225]

--- a/configs/yolov3_reader.yml
+++ b/configs/yolov3_reader.yml
@@ -11,10 +11,10 @@ TrainReader:
   sample_transforms:
     - !DecodeImage
       to_rgb: True
-      with_mixup: True
-    - !MixupImage
-      alpha: 1.5
-      beta: 1.5
+      with_mixup: False
+    # - !MixupImage
+    #   alpha: 1.5
+    #   beta: 1.5
     - !ColorDistort {}
     - !RandomExpand
       fill_value: [123.675, 116.28, 103.53]

--- a/ppdet/data/source/__init__.py
+++ b/ppdet/data/source/__init__.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 from . import coco
-from . import voc
+# from . import voc
+from . import ncp
 from . import widerface
 
 from .coco import *
-from .voc import *
+# from .voc import *
+from .ncp import *
 from .widerface import *

--- a/ppdet/data/source/dataset.py
+++ b/ppdet/data/source/dataset.py
@@ -83,7 +83,7 @@ class DataSet(object):
         return self._imid2path
 
 
-def _is_valid_file(f, extensions=('.jpg', '.jpeg', '.png', '.bmp')):
+def _is_valid_file(f, extensions=('.jpg', '.jpeg', '.png', '.bmp', 'npy')):
     return f.lower().endswith(extensions)
 
 

--- a/ppdet/data/source/ncp.py
+++ b/ppdet/data/source/ncp.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import numpy as np
+
+from ppdet.core.workspace import register, serializable
+
+from .dataset import DataSet
+import glob
+import json
+import logging
+logger = logging.getLogger(__name__)
+
+
+@register
+@serializable
+class VOCDataSet(DataSet):
+    """
+    Load dataset with PascalVOC format.
+
+    Notes:
+    `anno_path` must contains xml file and image file path for annotations.
+
+    Args:
+        dataset_dir (str): root directory for dataset.
+        image_dir (str): directory for images.
+        anno_path (str): voc annotation file path.
+        sample_num (int): number of samples to load, -1 means all.
+        use_default_label (bool): whether use the default mapping of
+            label to integer index. Default True.
+        with_background (bool): whether load background as a class,
+            default True.
+        label_list (str): if use_default_label is False, will load
+            mapping between category and class index.
+    """
+
+    def __init__(self,
+                 dataset_dir=None,
+                 image_dir=None,
+                 anno_path=None,
+                 sample_num=-1,
+                 use_default_label=True,
+                 with_background=True):
+        super(VOCDataSet, self).__init__(
+            image_dir=image_dir,
+            anno_path=anno_path,
+            sample_num=sample_num,
+            dataset_dir=dataset_dir,
+            with_background=with_background)
+        # roidbs is list of dict whose structure is:
+        # {
+        #     'im_file': im_fname, # image file name
+        #     'im_id': im_id, # image id
+        #     'h': im_h, # height of image
+        #     'w': im_w, # width
+        #     'is_crowd': is_crowd,
+        #     'gt_class': gt_class,
+        #     'gt_score': gt_score,
+        #     'gt_bbox': gt_bbox,
+        #     'difficult': difficult
+        # }
+        self.roidbs = None
+        # 'cname2id' is a dict to map category name to class id
+        self.cname2cid = None
+        self.use_default_label = use_default_label
+
+    def load_roidb_and_cname2cid(self):
+        def poly2xyxy(points):
+            xs = []
+            ys = []
+            for n, p in points.items():
+                if n.find('x') >= 0:
+                    xs.append(float(p))
+                if n.find('y') >= 0:
+                    ys.append(float(p))
+            return [min(xs), min(ys), max(xs), max(ys)]
+
+        records = []
+        ct = 0
+        cname2cid = ncp_label(with_background=self.with_background)
+        patient_list = glob.glob("{}/patient*".format(self.dataset_dir))
+        for p in patient_list:
+            images = glob.glob("{}/npy/*.npy".format(p))
+            for image in images:
+                layer_id = image.split('/')[-1].split('.')[0]
+                anno_file = "{}/outputs/{}.json".format(p, layer_id)
+                if not os.path.isfile(anno_file):
+                    logger.warn("No json file {}".format(anno_file))
+                    continue
+                anno = json.load(open(anno_file))
+                if not anno['labeled']:
+                    logging.warn("{} not labeld".format(image))
+
+                rec = {}
+                rec['im_file'] = image
+                rec['im_id'] = ct
+                rec['h'] = anno['size']['height']
+                rec['w'] = anno['size']['width']
+
+                objs = anno['outputs']['object']
+                gt_bbox = np.zeros((len(objs), 4), dtype=np.float32)
+                gt_class = np.zeros((len(objs), 1), dtype=np.int32)
+                gt_score = np.ones((len(objs), 1), dtype=np.float32)
+                is_crowd = np.zeros((len(objs), 1), dtype=np.int32)
+                difficult = np.zeros((len(objs), 1), dtype=np.int32)
+                for i, obj in enumerate(objs):
+                    gt_bbox[i, :] = poly2xyxy(obj['polygon'])
+                    gt_class[i][0] = int(self.with_background)
+                    is_crowd[i][0] = 0
+                    difficult[i][0] = 0
+                rec['gt_bbox'] = gt_bbox
+                rec['gt_class'] = gt_class
+                rec['gt_score'] = gt_score
+                rec['is_crowd'] = is_crowd
+                rec['difficult'] = difficult
+
+                records.append(rec)
+                ct += 1
+                if self.sample_num > 0 and ct >= self.sample_num:
+                    break
+
+        assert len(records) > 0, 'not found any voc record in %s' % (
+            self.anno_path)
+        logger.info('{} samples in file {}'.format(ct, self.dataset_dir))
+        self.roidbs, self.cname2cid = records, cname2cid
+
+
+def ncp_label(with_background=True):
+    labels_map = {'1': 1}
+    if not with_background:
+        labels_map = {k: v - 1 for k, v in labels_map.items()}
+    return labels_map

--- a/ppdet/data/source/ncp.py
+++ b/ppdet/data/source/ncp.py
@@ -110,6 +110,10 @@ class VOCDataSet(DataSet):
                 rec['w'] = anno['size']['width']
 
                 objs = anno['outputs']['object']
+                # uncomment this if not filter out 0 object sample
+                if len(objs) == 0:
+                    continue
+
                 gt_bbox = np.zeros((len(objs), 4), dtype=np.float32)
                 gt_class = np.zeros((len(objs), 1), dtype=np.int32)
                 gt_score = np.ones((len(objs), 1), dtype=np.float32)

--- a/ppdet/data/source/ncp.py
+++ b/ppdet/data/source/ncp.py
@@ -116,6 +116,8 @@ class VOCDataSet(DataSet):
                 # uncomment this if not filter out 0 object sample
                 if not objs or len(objs) == 0:
                     continue
+                if objs is None:
+                    objs = []
 
                 gt_bbox = np.zeros((len(objs), 4), dtype=np.float32)
                 gt_class = np.zeros((len(objs), 1), dtype=np.int32)

--- a/ppdet/data/source/ncp.py
+++ b/ppdet/data/source/ncp.py
@@ -105,6 +105,8 @@ class VOCDataSet(DataSet):
 
                 rec = {}
                 rec['im_file'] = image
+                # use for test_reader.py
+                # rec['im_file'] = image.replace('npy', 'png')
                 rec['im_id'] = ct
                 rec['h'] = anno['size']['height']
                 rec['w'] = anno['size']['width']

--- a/ppdet/data/source/voc.py
+++ b/ppdet/data/source/voc.py
@@ -24,8 +24,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-@register
-@serializable
+# @register
+# @serializable
 class VOCDataSet(DataSet):
     """
     Load dataset with PascalVOC format.

--- a/ppdet/data/transform/operators.py
+++ b/ppdet/data/transform/operators.py
@@ -109,7 +109,7 @@ class DecodeImage(BaseOperator):
             im = np.load(sample['im_file'])
             sample['h'] = im.shape[0]
             sample['w'] = im.shape[1]
-            im = im.reshape((sample['h'], sample['w'], 1))
+            im = np.tile(im.reshape((sample['h'], sample['w'], 1)), (1, 1, 3))
             sample['image'] = im
         else:
             if 'image' not in sample:
@@ -338,6 +338,8 @@ class ResizeImage(BaseOperator):
             im = im.resize((int(resize_w), int(resize_h)), self.interp)
             im = np.array(im)
 
+        if len(im.shape) == 2:
+            im = im[:, :, np.newaxis]
         sample['image'] = im
         return sample
 
@@ -491,7 +493,8 @@ class NormalizeImage(BaseOperator):
                         mean = np.array(self.mean)[np.newaxis, np.newaxis, :]
                         std = np.array(self.std)[np.newaxis, np.newaxis, :]
                     if self.is_scale:
-                        im = im / 255.0
+                        # im = im / 255.0
+                        im = im / 1000.
                     im -= mean
                     im /= std
                     sample[k] = im

--- a/ppdet/data/transform/operators.py
+++ b/ppdet/data/transform/operators.py
@@ -109,7 +109,7 @@ class DecodeImage(BaseOperator):
             im = np.load(sample['im_file'])
             sample['h'] = im.shape[0]
             sample['w'] = im.shape[1]
-            im = np.tile(im.reshape((sample['h'], sample['w'], 1)), (1, 1, 3))
+            im = im.reshape((sample['h'], sample['w'], 1))
             sample['image'] = im
         else:
             if 'image' not in sample:

--- a/ppdet/modeling/architectures/yolov3.py
+++ b/ppdet/modeling/architectures/yolov3.py
@@ -129,7 +129,7 @@ class YOLOv3(object):
 
     def build_inputs(
             self,
-            image_shape=[3, None, None],
+            image_shape=[1, None, None],
             fields=['image', 'gt_bbox', 'gt_class', 'gt_score'],  # for train
             num_max_boxes=50,
             use_dataloader=True,

--- a/ppdet/modeling/architectures/yolov3.py
+++ b/ppdet/modeling/architectures/yolov3.py
@@ -129,7 +129,7 @@ class YOLOv3(object):
 
     def build_inputs(
             self,
-            image_shape=[1, None, None],
+            image_shape=[3, None, None],
             fields=['image', 'gt_bbox', 'gt_class', 'gt_score'],  # for train
             num_max_boxes=50,
             use_dataloader=True,

--- a/test_reader.py
+++ b/test_reader.py
@@ -1,0 +1,31 @@
+import numpy as np
+import box_utils
+import cv2
+from ppdet.core.workspace import load_config, merge_config, create
+from ppdet.data.reader import create_reader
+
+category_names = ['1']
+means = [0.485, 0.456, 0.406]
+stds = [0.229, 0.224, 0.225]
+random_sizes = [32 * i for i in range(10, 20)]
+# train_reader = reader.train(416, 1, shuffle=True, mixup_iter=10, random_sizes=random_sizes, use_multiprocessing=False)
+cfg = load_config('./configs/yolov3_mobilenet_v1_ncp.yml')
+train_reader = create_reader(cfg.TrainReader, 100, cfg)
+for i, data in enumerate(train_reader()):
+    img, gtboxes, gtlabels, gtscores = data[0]
+    print("img shape: ", img.shape)
+    c, h, w = img.shape
+    real_img = (img.transpose((1, 2, 0)) * stds + means) * 255.0
+    real_img = cv2.cvtColor(real_img.astype('uint8'), cv2.COLOR_RGB2BGR)
+    cv2.imwrite("output/test{}.jpg".format(i), real_img.astype("uint8"))
+    gtboxes = box_utils.box_xywh_to_xyxy(gtboxes)
+    gtboxes = box_utils.rescale_box_in_input_image(gtboxes, (h, w), 1.0)
+    box_utils.draw_boxes_on_image(
+        "output/test{}.jpg".format(i),
+        gtboxes,
+        gtscores,
+        gtlabels,
+        category_names,
+        score_thresh=0.01)
+    if i >= 10:
+        break


### PR DESCRIPTION
- 数据集结构: dataset/ncp下包含各patient文件夹，patient文件夹下包含npy和outputs文件夹，outputs文件夹下为各json标注文件
- npy里的数据shape为(512, 512)，reshape为(512, 512, 1)，**注意模型的channel数要适配**
- `vimdiff configs/yolov3_mobilenet_v1_ncp.yml configs/yolov3_mobilenet_v1_voc.yml`查看配置文件修改方法
- 数据测试和可视化ok，方法为uncomment`ppdet/data/source/ncp.py:L109`，运行`python test_reader.py`，注意`test_reader.py`和`box_utils.py`为测试文件
