### PR TITLE
fix voc eval

### DIFF
--- a/ppdet/utils/map_utils.py
+++ b/ppdet/utils/map_utils.py
@@ -145,7 +145,9 @@ class DetectionMAP(object):
         valid_cnt = 0
         for score_pos, count in zip(self.class_score_poss,
                                     self.class_gt_counts):
-            if count == 0 or len(score_pos) == 0:
+            if count == 0: continue
+            if len(score_pos) == 0:
+                valid_cnt += 1
                 continue
 
             accum_tp_list, accum_fp_list = \


### PR DESCRIPTION
**fix class should be valid if gt > 0 and true positive predction = 0**
In `ppdet/utils/map_utils.py`, if gt number > 0 and true_positive prediction number = 0, this class will be skipped, but it should be calculated as a valid class, this bug may make mAP higher.
Normally, like in Pascal VOC dataset, true_positive predictions for a class would not be 0, this bug has no influence on released models currently