### PR TITLE
modify keep_prob from 0.9 to 0.94

### DIFF
--- a/configs/dcn/yolov3_r50vd_dcn_db_obj365_pretrained_coco.yml
+++ b/configs/dcn/yolov3_r50vd_dcn_db_obj365_pretrained_coco.yml
@@ -40,6 +40,7 @@ YOLOv3Head:
     normalized: false
     score_threshold: 0.01
   drop_block: true
+  keep_prob: 0.94
 
 YOLOv3Loss:
   batch_size: 8


### PR DESCRIPTION
modify the dropblock keep_prob of the enhanced yolo v3 from 0.9 to 0.94