### PR TITLE
fix save checkpoint in quantization

### DIFF
--- a/slim/quantization/train.py
+++ b/slim/quantization/train.py
@@ -36,7 +36,6 @@ from ppdet.utils.stats import TrainingStats
 from ppdet.utils.cli import ArgsParser
 from ppdet.utils.check import check_gpu, check_version
 import ppdet.utils.checkpoint as checkpoint
-sys.path.append('/cv/workspace/PaddleSlim/')
 from paddleslim.quant import quant_aware, convert
 import logging
 FORMAT = '%(asctime)s-%(levelname)s: %(message)s'


### PR DESCRIPTION
fix save checkpoint in quantization.
因为fluid.io.save 存储时会先存储Parameter,再存储persistables为优化器相关参数，但是量化里的program没有parameter的概念，模型参数和优化器相关参数都只是persistable的，会存储在优化器相关参数的文件内，而存储的参数文件为空，会给用户带来困扰，因此，改为用save_persistables存储。
而fluid.io.load兼容save_persistables存储的文件，所以不做修改。