### PR TITLE
Fix loading checkpoint in eval script of pruning demo

### DIFF
--- a/slim/prune/eval.py
+++ b/slim/prune/eval.py
@@ -86,6 +86,7 @@ def main():
                 fetches = model.eval(feed_vars, multi_scale_test)
     eval_prog = eval_prog.clone(True)
 
+    exe.run(startup_prog)
     reader = create_reader(cfg.EvalReader)
     loader.set_sample_list_generator(reader, place)
 
@@ -123,7 +124,7 @@ def main():
         params=pruned_params,
         ratios=pruned_ratios,
         place=place,
-        only_graph=True)
+        only_graph=False)
     pruned_flops = flops(eval_prog)
     logger.info("pruned FLOPS: {}".format(
         float(base_flops - pruned_flops) / base_flops))
@@ -174,7 +175,6 @@ def main():
         sub_eval_prog = sub_eval_prog.clone(True)
 
     # load model
-    exe.run(startup_prog)
     if 'weights' in cfg:
         checkpoint.load_checkpoint(exe, eval_prog, cfg.weights)
 


### PR DESCRIPTION
The load_parameters API of Paddle1.7 will enforce the shape of weights in scope equals to that loaded from the checkpoint.

https://github.com/PaddlePaddle/Paddle/blame/4e8bc02461826b7b62919e5e9ba0833027b82859/python/paddle/fluid/io.py#L1905

So, it is necessary to prune the scope before loading the checkpoint.

fix #330