### PR TITLE
[Docs] fix windows python path

### DIFF
--- a/docs/tutorials/INSTALL.md
+++ b/docs/tutorials/INSTALL.md
@@ -86,13 +86,20 @@ Required python packages are specified in [requirements.txt](https://github.com/
 pip install -r requirements.txt
 ```
 
+**Specify the current Python path:**
+
+```shell
+# In Linux/Mac
+export PYTHONPATH=$PYTHONPATH:.
+# In windows
+set PYTHONPATH=%PYTHONPATH%;.
+```
+
 **Make sure the tests pass:**
 
-```
-export PYTHONPATH=`pwd`:$PYTHONPATH
+```shell
 python ppdet/modeling/tests/test_architectures.py
 ```
-
 
 ## Datasets
 

--- a/docs/tutorials/INSTALL_cn.md
+++ b/docs/tutorials/INSTALL_cn.md
@@ -82,13 +82,20 @@ Python依赖库在[requirements.txt](https://github.com/PaddlePaddle/PaddleDetec
 pip install -r requirements.txt
 ```
 
+**指定当前Python路径：**
+
+```shell
+# 在Linux/Mac系统下运行:
+export PYTHONPATH=$PYTHONPATH:.
+# 在windows系统下运行:
+set PYTHONPATH=%PYTHONPATH%;.
+```
+
 **确认测试通过：**
 
 ```
-export PYTHONPATH=`pwd`:$PYTHONPATH
 python ppdet/modeling/tests/test_architectures.py
 ```
-
 
 ## 数据集
 


### PR DESCRIPTION
fix windows python path, #470 
```shell
# In Linux/Mac
export PYTHONPATH=$PYTHONPATH:. 
# In windows
set PYTHONPATH=%PYTHONPATH%;.
```