### PR TITLE
Remove `pycocotools` from `requirements.txt`

### DIFF
--- a/docs/tutorials/INSTALL.md
+++ b/docs/tutorials/INSTALL.md
@@ -59,6 +59,8 @@ COCO-API is needed for running. Installation is as follows:
     # Alternatively, if you do not have permissions or prefer
     # not to install the COCO API into global site-packages
     python setup.py install --user
+    # or with pip
+    pip install "git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI"
 
 **Installation of COCO-API in windows:**
 

--- a/docs/tutorials/INSTALL_cn.md
+++ b/docs/tutorials/INSTALL_cn.md
@@ -55,6 +55,8 @@ python -c "import paddle; print(paddle.__version__)"
     make install
     # 若您没有权限或更倾向不安装至全局site-packages
     python setup.py install --user
+    # 或者使用pip安装
+    pip install "git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI"
 
 **windows用户安装COCO-API方式：**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ typeguard ; python_version >= '3.4'
 tb-paddle
 tensorboard >= 1.15
 cython
-pycocotools
 opencv-python
 PyYAML
 shapely

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ docstring_parser @ http://github.com/willthefrog/docstring_parser/tarball/master
 typeguard ; python_version >= '3.4'
 tb-paddle
 tensorboard >= 1.15
-cython
 opencv-python
 PyYAML
 shapely


### PR DESCRIPTION
git version is required for numpy > 1.18