### PR TITLE
fix yolo eval

### DIFF
--- a/ppdet/modeling/architectures/yolo.py
+++ b/ppdet/modeling/architectures/yolo.py
@@ -42,7 +42,7 @@ class YOLOv3(object):
 
     def __init__(self,
                  backbone,
-                 yolo_head='YOLOv4Head',
+                 yolo_head='YOLOv3Head',
                  use_fine_grained_loss=False):
         super(YOLOv3, self).__init__()
         self.backbone = backbone

--- a/ppdet/utils/coco_eval.py
+++ b/ppdet/utils/coco_eval.py
@@ -275,11 +275,11 @@ def bbox2out(results, clsid2catid, is_bbox_normalized=False):
                     w *= im_width
                     h *= im_height
                 else:
-                    im_size = t['im_size'][0][i].tolist()
-                    xmin, ymin, xmax, ymax = \
-                            clip_bbox([xmin, ymin, xmax, ymax], im_size)
-                    w = xmax - xmin
-                    h = ymax - ymin
+                    # for yolov4
+                    # w = xmax - xmin
+                    # h = ymax - ymin
+                    w = xmax - xmin + 1
+                    h = ymax - ymin + 1
 
                 bbox = [xmin, ymin, w, h]
                 coco_res = {

--- a/tools/eval.py
+++ b/tools/eval.py
@@ -111,7 +111,7 @@ def main():
     extra_keys = []
 
     if cfg.metric == 'COCO':
-        extra_keys = ['im_info', 'im_id', 'im_shape', 'im_size']
+        extra_keys = ['im_info', 'im_id', 'im_shape']
     if cfg.metric == 'VOC':
         extra_keys = ['gt_bbox', 'gt_class', 'is_difficult']
 


### PR DESCRIPTION
For yolov3 models, w and h should be calculated as xmax - xmin + 1 and ymax - ymin + 1.
'+1' for w and h will decrease the mAP about 0.9%

clip_box in bbox2out actually have little effect on final precision but im_size only exists in yolo so remove it for correctness of the other models.