### PR TITLE
fix eval drained thread SIGABRT

### DIFF
--- a/ppdet/data/parallel_map.py
+++ b/ppdet/data/parallel_map.py
@@ -119,7 +119,7 @@ class ParallelMap(object):
         self._producer = threading.Thread(
             target=self._produce,
             args=('producer-' + id, self._source, self._inq))
-        self._producer.daemon = False
+        self._producer.daemon = True
 
         self._consumers = []
         self._consumer_endsig = {}
@@ -130,7 +130,7 @@ class ParallelMap(object):
                 target=self._consume,
                 args=(consumer_id, self._inq, self._outq, self._worker))
             self._consumers.append(p)
-            p.daemon = use_process
+            p.daemon = True
             setattr(p, 'id', consumer_id)
             if use_process:
                 worker_set.add(p)

--- a/ppdet/data/parallel_map.py
+++ b/ppdet/data/parallel_map.py
@@ -119,7 +119,7 @@ class ParallelMap(object):
         self._producer = threading.Thread(
             target=self._produce,
             args=('producer-' + id, self._source, self._inq))
-        self._producer.daemon = True
+        self._producer.daemon = False
 
         self._consumers = []
         self._consumer_endsig = {}
@@ -130,7 +130,7 @@ class ParallelMap(object):
                 target=self._consume,
                 args=(consumer_id, self._inq, self._outq, self._worker))
             self._consumers.append(p)
-            p.daemon = True
+            p.daemon = use_process
             setattr(p, 'id', consumer_id)
             if use_process:
                 worker_set.add(p)

--- a/ppdet/data/reader.py
+++ b/ppdet/data/reader.py
@@ -304,9 +304,11 @@ class Reader(object):
         if self._epoch < 0:
             self.reset()
         if self.drained():
+            self.stop()
             raise StopIteration
         batch = self._load_batch()
         if self._drop_last and len(batch) < self._batch_size:
+            self.stop()
             raise StopIteration
         if self._worker_num > -1:
             return batch
@@ -418,8 +420,8 @@ def create_reader(cfg, max_iter=0, global_cfg=None, devices_num=1):
                     n += 1
                 if max_iter > 0 and n == max_iter:
                     return
-            reader.reset()
             if max_iter <= 0:
                 return
+            reader.reset()
 
     return _reader

--- a/ppdet/data/reader.py
+++ b/ppdet/data/reader.py
@@ -304,11 +304,9 @@ class Reader(object):
         if self._epoch < 0:
             self.reset()
         if self.drained():
-            self.stop()
             raise StopIteration
         batch = self._load_batch()
         if self._drop_last and len(batch) < self._batch_size:
-            self.stop()
             raise StopIteration
         if self._worker_num > -1:
             return batch
@@ -419,8 +417,10 @@ def create_reader(cfg, max_iter=0, global_cfg=None, devices_num=1):
                     yield _batch
                     n += 1
                 if max_iter > 0 and n == max_iter:
+                    reader.stop()
                     return
             if max_iter <= 0:
+                reader.stop()
                 return
             reader.reset()
 


### PR DESCRIPTION
**fix eval drained thread SIGABRT**
- stop `reader.parallel_map` before raise reader iterator returned to make sure sub-thread exit
- do not `reset parallel_map` if `max_iter` unset(eval mode)，for `reset` will start another epoch reading and sub-thread will work again instead of exiting, this may lead to `SIGABRT` segment fault in some operating system