### PR TITLE
Remove dependency on `docstring_parser`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 tqdm
-docstring_parser @ http://github.com/willthefrog/docstring_parser/tarball/master
 typeguard ; python_version >= '3.4'
 tb-paddle
 tensorboard >= 1.15


### PR DESCRIPTION
optional, and seems to be causing problems during installation for some users.