### PR TITLE
Link yolo reader config to mobile directory

### DIFF
--- a/configs/mobile/yolov3_reader.yml
+++ b/configs/mobile/yolov3_reader.yml
@@ -1,0 +1,1 @@
+../yolov3_reader.yml


### PR DESCRIPTION
otherwise directly running  the config will  fail