### PR TITLE
fix cpp inference without resize

### DIFF
--- a/configs/face_detection/blazeface.yml
+++ b/configs/face_detection/blazeface.yml
@@ -96,11 +96,12 @@ EvalReader:
   - !DecodeImage
     to_rgb: true
   - !NormalizeBox {}
-  - !Permute {}
   - !NormalizeImage
+    is_channel_first: false
     is_scale: false
-    mean: [104, 117, 123]
+    mean: [123, 117, 104]
     std: [127.502231, 127.502231, 127.502231]
+  - !Permute {}
   batch_size: 1
 
 TestReader:
@@ -112,9 +113,10 @@ TestReader:
   sample_transforms:
   - !DecodeImage
     to_rgb: true
-  - !Permute {}
   - !NormalizeImage
+    is_channel_first: false
     is_scale: false
-    mean: [104, 117, 123]
+    mean: [123, 117, 104]
     std: [127.502231, 127.502231, 127.502231]
+  - !Permute {}
   batch_size: 1

--- a/configs/face_detection/blazeface_keypoint.yml
+++ b/configs/face_detection/blazeface_keypoint.yml
@@ -104,11 +104,12 @@ EvalReader:
   - !DecodeImage
     to_rgb: true
   - !NormalizeBox {}
-  - !Permute {}
   - !NormalizeImage
+    is_channel_first: false
     is_scale: false
-    mean: [104, 117, 123]
+    mean: [123, 117, 104]
     std: [127.502231, 127.502231, 127.502231]
+  - !Permute {}
   batch_size: 1
 
 TestReader:
@@ -120,9 +121,10 @@ TestReader:
   sample_transforms:
   - !DecodeImage
     to_rgb: true
-  - !Permute {}
   - !NormalizeImage
+    is_channel_first: false
     is_scale: false
-    mean: [104, 117, 123]
+    mean: [123, 117, 104]
     std: [127.502231, 127.502231, 127.502231]
+  - !Permute {}
   batch_size: 1

--- a/configs/face_detection/blazeface_nas.yml
+++ b/configs/face_detection/blazeface_nas.yml
@@ -98,11 +98,12 @@ EvalReader:
   - !DecodeImage
     to_rgb: true
   - !NormalizeBox {}
-  - !Permute {}
   - !NormalizeImage
+    is_channel_first: false
     is_scale: false
-    mean: [104, 117, 123]
+    mean: [123, 117, 104]
     std: [127.502231, 127.502231, 127.502231]
+  - !Permute {}
   batch_size: 1
 
 TestReader:
@@ -114,9 +115,10 @@ TestReader:
   sample_transforms:
   - !DecodeImage
     to_rgb: true
-  - !Permute {}
   - !NormalizeImage
+    is_channel_first: false
     is_scale: false
-    mean: [104, 117, 123]
+    mean: [123, 117, 104]
     std: [127.502231, 127.502231, 127.502231]
+  - !Permute {}
   batch_size: 1

--- a/configs/face_detection/blazeface_nas_v2.yml
+++ b/configs/face_detection/blazeface_nas_v2.yml
@@ -98,11 +98,12 @@ EvalReader:
   - !DecodeImage
     to_rgb: true
   - !NormalizeBox {}
-  - !Permute {}
   - !NormalizeImage
+    is_channel_first: false
     is_scale: false
-    mean: [104, 117, 123]
+    mean: [123, 117, 104]
     std: [127.502231, 127.502231, 127.502231]
+  - !Permute {}
   batch_size: 1
 
 TestReader:
@@ -114,9 +115,10 @@ TestReader:
   sample_transforms:
   - !DecodeImage
     to_rgb: true
-  - !Permute {}
   - !NormalizeImage
+    is_channel_first: false
     is_scale: false
-    mean: [104, 117, 123]
+    mean: [123, 117, 104]
     std: [127.502231, 127.502231, 127.502231]
+  - !Permute {}
   batch_size: 1

--- a/configs/face_detection/faceboxes.yml
+++ b/configs/face_detection/faceboxes.yml
@@ -97,11 +97,13 @@ EvalReader:
   sample_transforms:
   - !DecodeImage
     to_rgb: true
-  - !Permute {}
+  - !NormalizeBox {}
   - !NormalizeImage
+    is_channel_first: false
     is_scale: false
-    mean: [104, 117, 123]
+    mean: [123, 117, 104]
     std: [127.502231, 127.502231, 127.502231]
+  - !Permute {}
 
 TestReader:
   inputs_def:
@@ -112,9 +114,10 @@ TestReader:
   sample_transforms:
   - !DecodeImage
     to_rgb: true
-  - !Permute {}
   - !NormalizeImage
+    is_channel_first: false
     is_scale: false
-    mean: [104, 117, 123]
+    mean: [123, 117, 104]
     std: [127.502231, 127.502231, 127.502231]
+  - !Permute {}
   batch_size: 1

--- a/configs/face_detection/faceboxes_lite.yml
+++ b/configs/face_detection/faceboxes_lite.yml
@@ -98,11 +98,13 @@ EvalReader:
   - !DecodeImage
     to_rgb: true
   - !NormalizeBox {}
-  - !Permute {}
   - !NormalizeImage
+    is_channel_first: false
     is_scale: false
-    mean: [104, 117, 123]
+    mean: [123, 117, 104]
     std: [127.502231, 127.502231, 127.502231]
+  - !Permute {}
+
 
 TestReader:
   inputs_def:
@@ -113,9 +115,10 @@ TestReader:
   sample_transforms:
   - !DecodeImage
     to_rgb: true
-  - !Permute {}
   - !NormalizeImage
+    is_channel_first: false
     is_scale: false
-    mean: [104, 117, 123]
+    mean: [123, 117, 104]
     std: [127.502231, 127.502231, 127.502231]
+  - !Permute {}
   batch_size: 1

--- a/deploy/cpp/include/preprocess_op.h
+++ b/deploy/cpp/include/preprocess_op.h
@@ -50,6 +50,12 @@ class PreprocessOp {
   virtual void Run(cv::Mat* im, ImageBlob* data) = 0;
 };
 
+class InitInfo : public PreprocessOp{
+ public:
+  virtual void Init(const YAML::Node& item, const std::string& arch) {}
+  virtual void Run(cv::Mat* im, ImageBlob* data);
+};
+
 class Normalize : public PreprocessOp {
  public:
   virtual void Init(const YAML::Node& item, const std::string& arch) {
@@ -127,6 +133,8 @@ class Preprocessor {
  public:
   void Init(const YAML::Node& config_node, const std::string& arch) {
     arch_ = arch;
+    // initialize image info at first
+    ops_["InitInfo"] = std::make_shared<InitInfo>();
     for (const auto& item : config_node) {
       auto op_name = item["type"].as<std::string>();
       ops_[op_name] = CreateOp(op_name);


### PR DESCRIPTION
Fix  cpp inference without resize by adding InitInfo to get the shape of original image
Adjust the order of permute and normalize in face detection