### PR TITLE
temp fix slice op no kernel error

### DIFF
--- a/ppdet/modeling/losses/yolo_loss.py
+++ b/ppdet/modeling/losses/yolo_loss.py
@@ -127,6 +127,7 @@ class YOLOv3Loss(object):
         assert len(outputs) == len(targets), \
             "YOLOv3 output layer number not equal target number"
 
+        targets = [target * 1.0 for target in targets]
         loss_xys, loss_whs, loss_objs, loss_clss = [], [], [], []
         if self._iou_loss is not None:
             loss_ious = []


### PR DESCRIPTION
**运行PPYOLO遇到slice找不到kernel报错的可先用此方法规避**

报错如下：
```
Error: op slice does not have kernel for data_type[float]:data_layout[ANY_LAYOUT]:place[CUDAPinnedPlace]:library_type[PLAIN] at (/paddle/paddle/fluid/framework/operator.cc:1090)
[operator < slice > error]
```

最近Paddle develop分支有修改，每日版本跑PPYOLO会报上述错误，可以先在`ppdet/modeling/loss/yolo_loss.py`的130行添加规避，如本PR中修改方式，Paddle develop问题我们在确认
```
targets = [target * 1.0 for target in targets]
```