### PR TITLE
fix the dtype of loss

### DIFF
--- a/ppdet/modeling/anchor_heads/retina_head.py
+++ b/ppdet/modeling/anchor_heads/retina_head.py
@@ -404,5 +404,5 @@ class RetinaHead(object):
             inside_weight=bbox_weight,
             outside_weight=bbox_weight)
         loss_bbox = fluid.layers.reduce_sum(loss_bbox, name='loss_bbox')
-        loss_bbox = loss_bbox / fg_num
+        loss_bbox = loss_bbox / fluid.layers.cast(fg_num, loss_bbox.dtype)
         return {'loss_cls': loss_cls, 'loss_bbox': loss_bbox}


### PR DESCRIPTION
Because of the https://github.com/PaddlePaddle/Paddle/pull/26562, it is not compatible with the upgrade. When the divisor and dividend are both Tensor/Variable, the types must be the same.