### PR TITLE
修复FasterRCNN系列网络使用自定义COCO格式数据集时标签错误的问题

### DIFF
--- a/ppdet/utils/coco_eval.py
+++ b/ppdet/utils/coco_eval.py
@@ -427,8 +427,8 @@ def get_category_info_from_anno(anno_file, with_background=True):
     }
     catid2name = {cat['id']: cat['name'] for cat in cats}
     if with_background:
-        clsid2catid.update({0: 0})
-        catid2name.update({0: 'background'})
+        clsid2catid.update({0: -1})
+        catid2name.update({-1: 'background'})
     return clsid2catid, catid2name
 
 


### PR DESCRIPTION
原代码中将'background'类ID设为0，会覆盖掉原类别中ID为0的标签。