### PR TITLE
add ips for detection models

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -255,8 +255,9 @@ def main():
         train_stats.update(stats)
         logs = train_stats.log()
         if it % cfg.log_iter == 0 and (not FLAGS.dist or trainer_id == 0):
-            strs = 'iter: {}, lr: {:.6f}, {}, time: {:.3f}, eta: {}'.format(
-                it, np.mean(outs[-1]), logs, time_cost, eta)
+            ips = float(cfg['TrainReader']['batch_size']) / time_cost
+            strs = 'iter: {}, lr: {:.6f}, {}, batch_cost: {:.5f} s, eta: {}, ips: {:.5f} images/sec'.format(
+                it, np.mean(outs[-1]), logs, time_cost, eta, ips)
             logger.info(strs)
 
         # NOTE : profiler tools, used for benchmark


### PR DESCRIPTION
根据【Paddle模型性能统计规范】：
1. 计算ips：ips单位在本Repo是images/sec
2. 计算batch_cost：多轮训练1次打印时，batch_cost应求平均值。注意，连续统计，不要遗漏某些轮次。（develop分支已经符合要求）
3. 格式上：batch_cost、reader_cost、ips与模型其它指标共同打印，保留小数点后5位。ips，必须打印！ ips放在整条打印最后

本PR：
1. 增加了ips计算
2. batch_cost从小数点后3位改成5位，同时补充了单位。

- 命令：`python tools/train.py -c configs/yolov3_mobilenet_v1_roadsign.yml --eval -o use_gpu=0`
- 效果：
before: `batch_size=8, log_iter=20`
```
2020-09-25 10:47:02,989-INFO: iter: 0, lr: 0.000033, 'loss': '5710.631836', time: 0.000, eta: 0:00:00
2020-09-25 10:58:01,319-INFO: iter: 20, lr: 0.000047, 'loss': '29.493576', time: 32.155, eta: 10:32:22
```
after: `batch_size=8, log_iter=2`
```
2020-09-25 15:10:53,118-INFO: iter: 0, lr: 0.000033, 'loss': '11803.891602', batch_cost: 0.00006 s, eta: 0:00:00, ips: 125203.10448 images/sec
2020-09-25 15:11:54,840-INFO: iter: 2, lr: 0.000035, 'loss': '1264.233521', batch_cost: 20.69376 s, eta: 6:53:11, ips: 0.38659 images/sec
2020-09-25 15:12:57,061-INFO: iter: 4, lr: 0.000036, 'loss': '557.037598', batch_cost: 26.74744 s, eta: 8:53:09, ips: 0.29909 images/sec
2020-09-25 15:13:51,134-INFO: iter: 6, lr: 0.000037, 'loss': '225.754166', batch_cost: 26.11755 s, eta: 8:39:44, ips: 0.30631 images/sec
2020-09-25 15:14:48,563-INFO: iter: 8, lr: 0.000039, 'loss': '79.420753', batch_cost: 26.78939 s, eta: 8:52:12, ips: 0.29863 images/sec
2020-09-25 15:15:44,973-INFO: iter: 10, lr: 0.000040, 'loss': '46.613548', batch_cost: 27.72659 s, eta: 9:09:54, ips: 0.28853 images/sec
```