### PR TITLE
refine benchmark log

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -256,8 +256,8 @@ def main():
         logs = train_stats.log()
         if it % cfg.log_iter == 0 and (not FLAGS.dist or trainer_id == 0):
             ips = float(cfg['TrainReader']['batch_size']) / time_cost
-            strs = 'iter: {}, lr: {:.6f}, {}, batch_cost: {:.5f} s, eta: {}, ips: {:.5f} images/sec'.format(
-                it, np.mean(outs[-1]), logs, time_cost, eta, ips)
+            strs = 'iter: {}, lr: {:.6f}, {}, eta: {}, batch_cost: {:.5f} sec, ips: {:.5f} images/sec'.format(
+                it, np.mean(outs[-1]), logs, eta, time_cost, ips)
             logger.info(strs)
 
         # NOTE : profiler tools, used for benchmark


### PR DESCRIPTION
fix https://github.com/PaddlePaddle/PaddleDetection/pull/1507

修改后结果：
```
2020-09-25 18:39:47,914-INFO: iter: 0, lr: 0.000033, 'loss': '7231.944336', eta: 0:00:00, batch_cost: 0.00008 sec, ips: 103883.69040 images/sec
2020-09-25 18:40:34,280-INFO: iter: 2, lr: 0.000035, 'loss': '2898.865234', eta: 5:10:47, batch_cost: 15.56577 sec, ips: 0.51395 images/sec
2020-09-25 18:41:42,289-INFO: iter: 4, lr: 0.000036, 'loss': '576.639832', eta: 7:26:52, batch_cost: 22.41813 sec, ips: 0.35685 images/sec
2020-09-25 18:42:33,344-INFO: iter: 6, lr: 0.000037, 'loss': '495.023651', eta: 7:08:28, batch_cost: 21.53168 sec, ips: 0.37155 images/sec
2020-09-25 18:43:12,951-INFO: iter: 8, lr: 0.000039, 'loss': '95.421570', eta: 7:26:01, batch_cost: 22.45121 sec, ips: 0.35633 images/sec
2020-09-25 18:44:31,000-INFO: iter: 10, lr: 0.000040, 'loss': '43.708477', eta: 8:12:32, batch_cost: 24.83382 sec, ips: 0.32214 images/sec
```