### PR TITLE
fix eval in distill_pruned_model

### DIFF
--- a/slim/extensions/distill_pruned_model/distill_pruned_model.py
+++ b/slim/extensions/distill_pruned_model/distill_pruned_model.py
@@ -319,7 +319,7 @@ def main():
                             os.path.join(save_dir, save_name))
             # eval
             results = eval_run(exe, compiled_eval_prog, eval_loader, eval_keys,
-                               eval_values, eval_cls)
+                               eval_values, eval_cls, cfg)
             resolution = None
             box_ap_stats = eval_results(results, cfg.metric, cfg.num_classes,
                                         resolution, is_bbox_normalized,


### PR DESCRIPTION
**fix eval_run cfg not given in slim\extensions\distill_pruned_model\distill_pruned_model.py**
fix https://github.com/PaddlePaddle/PaddleDetection/issues/1547