### PR TITLE
refine PaddleDetection benchmard print

### DIFF
--- a/configs/cascade_rcnn_r50_1x.yml
+++ b/configs/cascade_rcnn_r50_1x.yml
@@ -1,7 +1,7 @@
 architecture: CascadeRCNN
 use_gpu: true
 max_iters: 180000
-log_smooth_window: 50
+log_iter: 50
 save_dir: output
 snapshot_iter: 10000
 pretrain_weights: https://paddlemodels.bj.bcebos.com/object_detection/dygraph/resnet50.pdparams

--- a/configs/faster_rcnn_r50_1x.yml
+++ b/configs/faster_rcnn_r50_1x.yml
@@ -1,7 +1,7 @@
 architecture: FasterRCNN
 use_gpu: true
 max_iters: 180000
-log_smooth_window: 50
+log_iter: 50
 save_dir: output
 snapshot_iter: 10000
 pretrain_weights: https://paddlemodels.bj.bcebos.com/object_detection/dygraph/resnet50.pdparams

--- a/configs/mask_rcnn_r50_1x.yml
+++ b/configs/mask_rcnn_r50_1x.yml
@@ -1,7 +1,7 @@
 architecture: MaskRCNN
 use_gpu: true
 max_iters: 180000
-log_smooth_window: 50
+log_iter: 50
 save_dir: output
 snapshot_iter: 10000
 pretrain_weights: https://paddlemodels.bj.bcebos.com/object_detection/dygraph/resnet50.pdparams

--- a/configs/mask_rcnn_r50_fpn_1x.yml
+++ b/configs/mask_rcnn_r50_fpn_1x.yml
@@ -1,7 +1,7 @@
 architecture: MaskRCNN
 use_gpu: true
 max_iters: 180000
-log_smooth_window: 20
+log_iter: 20
 save_dir: output
 snapshot_iter: 10000
 pretrain_weights: https://paddle-imagenet-models-name.bj.bcebos.com/ResNet50_cos_pretrained.tar

--- a/configs/yolov3_darknet.yml
+++ b/configs/yolov3_darknet.yml
@@ -1,7 +1,7 @@
 architecture: YOLOv3
 use_gpu: true
 max_iters: 500000
-log_smooth_window: 20
+log_iter: 20
 save_dir: output
 snapshot_iter: 50000
 metric: COCO

--- a/tools/train.py
+++ b/tools/train.py
@@ -8,7 +8,7 @@ if parent_path not in sys.path:
     sys.path.append(parent_path)
 
 import time
-# ignore numba warning 
+# ignore numba warning
 import warnings
 warnings.filterwarnings('ignore')
 import random

--- a/tools/train.py
+++ b/tools/train.py
@@ -8,7 +8,7 @@ if parent_path not in sys.path:
     sys.path.append(parent_path)
 
 import time
-# ignore numba warning
+# ignore numba warning 
 import warnings
 warnings.filterwarnings('ignore')
 import random
@@ -167,8 +167,7 @@ def run(FLAGS, cfg):
         if ParallelEnv().nranks < 2 or ParallelEnv().local_rank == 0:
             # Log state 
             if iter_id == 0:
-                train_stats = TrainingStats(cfg.log_iter,
-                                            outputs.keys())
+                train_stats = TrainingStats(cfg.log_iter, outputs.keys())
             train_stats.update(outputs)
             logs = train_stats.log()
             if iter_id % cfg.log_iter == 0:

--- a/tools/train.py
+++ b/tools/train.py
@@ -172,7 +172,7 @@ def run(FLAGS, cfg):
             logs = train_stats.log()
             if iter_id % cfg.log_iter == 0:
                 ips = float(cfg['TrainReader']['batch_size']) / time_cost
-                strs = 'iter: {}, lr: {:.6f}, {}, eta: {}, time: {:.5f} sec, ips: {:.5f} images/sec'.format(
+                strs = 'iter: {}, lr: {:.6f}, {}, eta: {}, batch_cost: {:.5f} sec, ips: {:.5f} images/sec'.format(
                     iter_id, curr_lr, logs, eta, time_cost, ips)
                 logger.info(strs)
             # Save Stage 

--- a/tools/train.py
+++ b/tools/train.py
@@ -132,7 +132,7 @@ def run(FLAGS, cfg):
     train_reader = create_reader(
         cfg.TrainReader, (cfg.max_iters - start_iter), cfg, devices_num=1)
 
-    time_stat = deque(maxlen=cfg.log_smooth_window)
+    time_stat = deque(maxlen=cfg.log_iter)
     start_time = time.time()
     end_time = time.time()
     # Run Train 
@@ -167,13 +167,14 @@ def run(FLAGS, cfg):
         if ParallelEnv().nranks < 2 or ParallelEnv().local_rank == 0:
             # Log state 
             if iter_id == 0:
-                train_stats = TrainingStats(cfg.log_smooth_window,
+                train_stats = TrainingStats(cfg.log_iter,
                                             outputs.keys())
             train_stats.update(outputs)
             logs = train_stats.log()
             if iter_id % cfg.log_iter == 0:
-                strs = 'iter: {}, lr: {:.6f}, {}, time: {:.3f}, eta: {}'.format(
-                    iter_id, curr_lr, logs, time_cost, eta)
+                ips = float(cfg['TrainReader']['batch_size']) / time_cost
+                strs = 'iter: {}, lr: {:.6f}, {}, eta: {}, time: {:.5f} sec, ips: {:.5f} images/sec'.format(
+                    iter_id, curr_lr, logs, eta, time_cost, ips)
                 logger.info(strs)
             # Save Stage 
             if iter_id > 0 and iter_id % int(


### PR DESCRIPTION
修改Benchmark打印格式：
1. 使用batch_cost作为每轮时间的描述
2. 添加ips的计算和打印
3. 统一log_smooth_windows和log_iter这两个参数：
- log_smooth_windows：表示log平滑参数，平滑窗口大小，会从取历史窗口中取log_smooth_windows大小的loss求平均值
- log_iter: 表示每隔log_iter轮打印下各种指标
但，如果log_iter=10，而smooth_window=20。每隔10轮打印出来的指标，其实是20轮的平均值，这样对用户来说很纠结。因此建议两个参数统一。

整体与静态图保持一致：
https://github.com/PaddlePaddle/PaddleDetection/pull/1530