### PR TITLE
Initialize batch_size, prevent gpu memory overflow in infer

### DIFF
--- a/ppdet/data/reader.py
+++ b/ppdet/data/reader.py
@@ -190,7 +190,7 @@ class Reader(object):
                  dataset=None,
                  sample_transforms=None,
                  batch_transforms=None,
-                 batch_size=None,
+                 batch_size=1,
                  shuffle=False,
                  drop_last=False,
                  drop_empty=True,


### PR DESCRIPTION
If batch_size=None, when set `infer_dir` in infer, all image will build up a batch, GPU memory may overflow.