### PR TITLE
remove stride param in anchor_generator

### DIFF
--- a/configs/faster_rcnn_r50_fpn_1x.yml
+++ b/configs/faster_rcnn_r50_fpn_1x.yml
@@ -34,7 +34,6 @@ FPNRPNHead:
   anchor_generator:
     anchor_sizes: [32, 64, 128, 256, 512]
     aspect_ratios: [0.5, 1.0, 2.0]
-    stride: [16.0, 16.0]
     variance: [1.0, 1.0, 1.0, 1.0]
   anchor_start_size: 32
   min_level: 2


### PR DESCRIPTION
(1) 去掉anchor_generator中的stride参数，当使用FPN的时候，该参数不起作用。