### PR TITLE
fix switch_ir_optim in deploy/infer

### DIFF
--- a/dygraph/deploy/python/infer.py
+++ b/dygraph/deploy/python/infer.py
@@ -316,7 +316,11 @@ def load_predictor(model_dir,
         # initial GPU memory(M), device ID
         config.enable_use_gpu(200, 0)
         # optimize graph and fuse op
-        config.switch_ir_optim(True)
+        # FIXME(dkp): ir optimize may prune variable inside graph
+        #             and incur error in Paddle 2.0, e.g. in SSDLite
+        #             FCOS model, set as False currently and should
+        #             be set as True after switch_ir_optim fixed
+        config.switch_ir_optim(False)
     else:
         config.disable_gpu()
 


### PR DESCRIPTION
**fix switch_ir_optim in deploy/infer**
- set switch_ir_optim as False for variable inside graph may be pruned in models like SSD/SSDLite/FCOS