### PR TITLE
when export_model &  exclude_nms  == true, output of YOLO without bbox.

### DIFF
--- a/ppdet/modeling/anchor_heads/yolo_head.py
+++ b/ppdet/modeling/anchor_heads/yolo_head.py
@@ -458,7 +458,7 @@ class YOLOv3Head(object):
 
         # Only for benchmark, postprocess(NMS) is not needed
         if exclude_nms:
-            return {'bbox': yolo_scores}
+            return {'bbox': yolo_boxes, 'score': yolo_scores}
 
         if type(self.nms) is MultiClassSoftNMS:
             yolo_scores = fluid.layers.transpose(yolo_scores, perm=[0, 2, 1])


### PR DESCRIPTION
when exclude_nms  == true, outputs add yolo_boxes. 