### PR TITLE
delete redundant code

### DIFF
--- a/tools/x2coco.py
+++ b/tools/x2coco.py
@@ -43,14 +43,8 @@ class MyEncoder(json.JSONEncoder):
             return obj.tolist()
         else:
             return super(MyEncoder, self).default(obj)
-
-
-def getbbox(self, points):
-    polygons = points
-    mask = self.polygons_to_mask([self.height, self.width], polygons)
-    return self.mask2box(mask)
-
-
+        
+        
 def images_labelme(data, num):
     image = {}
     image['height'] = data['imageHeight']


### PR DESCRIPTION
I read `x2coco.py`, and I think `getbbox` function is redundant.
``` python
def getbbox(self, points):
    polygons = points
    mask = self.polygons_to_mask([self.height, self.width], polygons)
    return self.mask2box(mask)
```