### PR TITLE
simplify reader and enable use_shared_memory

### DIFF
--- a/dygraph/ppdet/data/reader.py
+++ b/dygraph/ppdet/data/reader.py
@@ -55,8 +55,8 @@ class Compose(object):
             except Exception as e:
                 stack_info = traceback.format_exc()
                 logger.warn("fail to map sample transform [{}] "
-                            "with error: {} and stack:\n{}".
-                            format(f, e, str(stack_info)))
+                            "with error: {} and stack:\n{}".format(
+                                f, e, str(stack_info)))
                 raise e
 
         return data
@@ -73,8 +73,8 @@ class BatchCompose(Compose):
             except Exception as e:
                 stack_info = traceback.format_exc()
                 logger.warn("fail to map batch transform [{}] "
-                            "with error: {} and stack:\n{}".
-                            format(f, e, str(stack_info)))
+                            "with error: {} and stack:\n{}".format(
+                                f, e, str(stack_info)))
                 raise e
 
         # remove keys which is not needed by model

--- a/dygraph/ppdet/data/shm_utils.py
+++ b/dygraph/ppdet/data/shm_utils.py
@@ -16,7 +16,7 @@ import os
 
 SIZE_UNIT = ['K', 'M', 'G', 'T']
 SHM_QUERY_CMD = 'df -h'
-SHM_FILESYSTEM = 'shm'
+SHM_KEY = 'shm'
 SHM_DEFAULT_MOUNT = '/dev/shm'
 
 # [ shared memory size check ]
@@ -26,7 +26,7 @@ SHM_DEFAULT_MOUNT = '/dev/shm'
 # disable shared memory use if shared memory size is not enough.
 # Shared memory getting process as follows:
 # 1. use `df -h` get all mount info
-# 2. pick up spaces which is mount as 'shm'
+# 2. pick up spaces whose mount info contains 'shm'
 # 3. if 'shm' space number is only 1, return its size
 # 4. if there are multiple 'shm' space, try to find the default mount
 #    directory '/dev/shm' is Linux-like system, otherwise return the
@@ -48,9 +48,9 @@ def _get_shared_memory_size_in_M():
     else:
         shm_infos = []
         for df_info in df_infos:
-            info = df_info.strip().split()
-            if info[0] == SHM_FILESYSTEM:
-                shm_infos.append(info)
+            info = df_info.strip()
+            if info.find(SHM_KEY) >= 0:
+                shm_infos.append(info.split())
 
         if len(shm_infos) == 0:
             return None

--- a/dygraph/ppdet/data/shm_utils.py
+++ b/dygraph/ppdet/data/shm_utils.py
@@ -32,6 +32,7 @@ SHM_DEFAULT_MOUNT = '/dev/shm'
 #    directory '/dev/shm' is Linux-like system, otherwise return the
 #    biggest space size.
 
+
 def _parse_size_in_M(size_str):
     num, unit = size_str[:-1], size_str[-1]
     assert unit in SIZE_UNIT, \

--- a/dygraph/ppdet/data/shm_utils.py
+++ b/dygraph/ppdet/data/shm_utils.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+SIZE_UNIT = ['K', 'M', 'G', 'T']
+SHM_QUERY_CMD = 'df -h'
+SHM_FILESYSTEM = 'shm'
+SHM_DEFAULT_MOUNT = '/dev/shm'
+
+# [ shared memory size check ]
+# In detection models, image/target data occupies a lot of memory, and
+# will occupy lots of shared memory in multi-process DataLoader, we use
+# following code to get shared memory size and perform a size check to
+# disable shared memory use if shared memory size is not enough.
+# Shared memory getting process as follows:
+# 1. use `df -h` get all mount info
+# 2. pick up spaces which is mount as 'shm'
+# 3. if 'shm' space number is only 1, return its size
+# 4. if there are multiple 'shm' space, try to find the default mount
+#    directory '/dev/shm' is Linux-like system, otherwise return the
+#    biggest space size.
+
+def _parse_size_in_M(size_str):
+    num, unit = size_str[:-1], size_str[-1]
+    assert unit in SIZE_UNIT, \
+            "unknown shm size unit {}".format(unit)
+    return float(num) * \
+            (1024 ** (SIZE_UNIT.index(unit) - 1))
+
+
+def _get_shared_memory_size_in_M():
+    try:
+        df_infos = os.popen(SHM_QUERY_CMD).readlines()
+    except:
+        return None
+    else:
+        shm_infos = []
+        for df_info in df_infos:
+            info = df_info.strip().split()
+            if info[0] == SHM_FILESYSTEM:
+                shm_infos.append(info)
+
+        if len(shm_infos) == 0:
+            return None
+        elif len(shm_infos) == 1:
+            return _parse_size_in_M(shm_infos[0][3])
+        else:
+            shm_infos = [si for si in shm_infos \
+                         if si[-1] == SHM_DEFAULT_MOUNT]
+            if len(shm_infos) == 0:
+                return _parse_size_in_M(shm_infos[0][3])
+            else:
+                return max([_parse_size_in_M(si[3]) \
+                                for si in shm_infos])


### PR DESCRIPTION
**simplify reader and enable use_shared_memory**
- Simplify `DataReader` implement since DataLoader support `dict` format(https://github.com/PaddlePaddle/Paddle/pull/31481)
- enable `use_shared_memory` if `/dev/shm` size is larger than 1G

### Speed test

YOLOv3 training speed improved, this PR has nearly no influence on Mask-RCNN/SSD training speed

**Testing enviorments**
- 4 * Tesla V100(16G)
- CUDA 10.2
- cuDNN 7.6
- shared memory size: 4G

| Model | batch_size | worker_num | develop speed | this PR speed | speed up ratio |
| :--: | :--:|  :--: |  :--: |  :--: |  :--: | 
| YOLOv3-DarkNet53 | 4 * 8 | 4 * 2 | 14.27 samples/s | 22.35 samples/s | 56.6% |
| Mask RCNN-R50 | 4 * 1 | 4 * 2 | 2.52 samples/s | 2.51 samples/s | - |
| SSD-VGG16 | 4 * 8 | 4 * 2 | 22.36 samples/s | 23.41 samples | - |