### PR TITLE
support not pad gt in rcnn model

### DIFF
--- a/configs/cascade_rcnn/_base_/cascade_fpn_reader.yml
+++ b/configs/cascade_rcnn/_base_/cascade_fpn_reader.yml
@@ -7,10 +7,11 @@ TrainReader:
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
   batch_transforms:
-  - PadBatch: {pad_to_stride: 32, pad_gt: true}
+  - PadBatch: {pad_to_stride: 32}
   batch_size: 1
   shuffle: true
   drop_last: true
+  collate_batch: false
 
 
 EvalReader:
@@ -20,7 +21,7 @@ EvalReader:
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
   batch_transforms:
-  - PadBatch: {pad_to_stride: 32, pad_gt: false}
+  - PadBatch: {pad_to_stride: 32}
   batch_size: 1
   shuffle: false
   drop_last: false
@@ -34,7 +35,7 @@ TestReader:
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
   batch_transforms:
-  - PadBatch: {pad_to_stride: 32, pad_gt: false}
+  - PadBatch: {pad_to_stride: 32}
   batch_size: 1
   shuffle: false
   drop_last: false

--- a/configs/cascade_rcnn/_base_/cascade_mask_fpn_reader.yml
+++ b/configs/cascade_rcnn/_base_/cascade_mask_fpn_reader.yml
@@ -7,10 +7,11 @@ TrainReader:
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
   batch_transforms:
-  - PadBatch: {pad_to_stride: 32, pad_gt: true}
+  - PadBatch: {pad_to_stride: 32}
   batch_size: 1
   shuffle: true
   drop_last: true
+  collate_batch: false
 
 
 EvalReader:
@@ -20,7 +21,7 @@ EvalReader:
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
   batch_transforms:
-  - PadBatch: {pad_to_stride: 32, pad_gt: false}
+  - PadBatch: {pad_to_stride: 32}
   batch_size: 1
   shuffle: false
   drop_last: false
@@ -34,7 +35,7 @@ TestReader:
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
   batch_transforms:
-  - PadBatch: {pad_to_stride: 32, pad_gt: false}
+  - PadBatch: {pad_to_stride: 32}
   batch_size: 1
   shuffle: false
   drop_last: false

--- a/configs/faster_rcnn/_base_/faster_fpn_reader.yml
+++ b/configs/faster_rcnn/_base_/faster_fpn_reader.yml
@@ -7,10 +7,11 @@ TrainReader:
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
   batch_transforms:
-  - PadBatch: {pad_to_stride: 32, pad_gt: true}
+  - PadBatch: {pad_to_stride: 32}
   batch_size: 1
   shuffle: true
   drop_last: true
+  collate_batch: false
 
 
 EvalReader:
@@ -20,7 +21,7 @@ EvalReader:
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
   batch_transforms:
-  - PadBatch: {pad_to_stride: 32, pad_gt: false}
+  - PadBatch: {pad_to_stride: 32}
   batch_size: 1
   shuffle: false
   drop_last: false
@@ -34,7 +35,7 @@ TestReader:
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
   batch_transforms:
-  - PadBatch: {pad_to_stride: 32, pad_gt: false}
+  - PadBatch: {pad_to_stride: 32}
   batch_size: 1
   shuffle: false
   drop_last: false

--- a/configs/faster_rcnn/_base_/faster_reader.yml
+++ b/configs/faster_rcnn/_base_/faster_reader.yml
@@ -7,10 +7,11 @@ TrainReader:
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
   batch_transforms:
-  - PadBatch: {pad_to_stride: -1., pad_gt: true}
+  - PadBatch: {pad_to_stride: -1.}
   batch_size: 1
   shuffle: true
   drop_last: true
+  collate_batch: false
 
 
 EvalReader:
@@ -20,7 +21,7 @@ EvalReader:
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
   batch_transforms:
-  - PadBatch: {pad_to_stride: -1., pad_gt: false}
+  - PadBatch: {pad_to_stride: -1.}
   batch_size: 1
   shuffle: false
   drop_last: false
@@ -34,7 +35,7 @@ TestReader:
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
   batch_transforms:
-  - PadBatch: {pad_to_stride: -1., pad_gt: false}
+  - PadBatch: {pad_to_stride: -1.}
   batch_size: 1
   shuffle: false
   drop_last: false

--- a/configs/mask_rcnn/_base_/mask_fpn_reader.yml
+++ b/configs/mask_rcnn/_base_/mask_fpn_reader.yml
@@ -7,10 +7,11 @@ TrainReader:
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
   batch_transforms:
-  - PadBatch: {pad_to_stride: 32, pad_gt: true}
+  - PadBatch: {pad_to_stride: 32}
   batch_size: 1
   shuffle: true
   drop_last: true
+  collate_batch: false
 
 EvalReader:
   sample_transforms:
@@ -19,7 +20,7 @@ EvalReader:
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
   batch_transforms:
-  - PadBatch: {pad_to_stride: 32, pad_gt: false}
+  - PadBatch: {pad_to_stride: 32}
   batch_size: 1
   shuffle: false
   drop_last: false
@@ -33,7 +34,7 @@ TestReader:
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
   batch_transforms:
-  - PadBatch: {pad_to_stride: 32, pad_gt: false}
+  - PadBatch: {pad_to_stride: 32}
   batch_size: 1
   shuffle: false
   drop_last: false

--- a/configs/mask_rcnn/_base_/mask_reader.yml
+++ b/configs/mask_rcnn/_base_/mask_reader.yml
@@ -7,10 +7,11 @@ TrainReader:
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
   batch_transforms:
-  - PadBatch: {pad_to_stride: -1., pad_gt: true}
+  - PadBatch: {pad_to_stride: -1.}
   batch_size: 1
   shuffle: true
   drop_last: true
+  collate_batch: false
 
 
 EvalReader:
@@ -20,7 +21,7 @@ EvalReader:
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
   batch_transforms:
-  - PadBatch: {pad_to_stride: -1., pad_gt: false}
+  - PadBatch: {pad_to_stride: -1.}
   batch_size: 1
   shuffle: false
   drop_last: false
@@ -34,7 +35,7 @@ TestReader:
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
   batch_transforms:
-  - PadBatch: {pad_to_stride: -1., pad_gt: false}
+  - PadBatch: {pad_to_stride: -1.}
   batch_size: 1
   shuffle: false
   drop_last: false

--- a/configs/ttfnet/_base_/ttfnet_reader.yml
+++ b/configs/ttfnet/_base_/ttfnet_reader.yml
@@ -8,7 +8,7 @@ TrainReader:
   - Permute: {}
   batch_transforms:
   - Gt2TTFTarget: {down_ratio: 4}
-  - PadBatch: {pad_to_stride: 32, pad_gt: true}
+  - PadBatch: {pad_to_stride: 32}
   batch_size: 12
   shuffle: true
   drop_last: true

--- a/deploy/python/preprocess.py
+++ b/deploy/python/preprocess.py
@@ -172,9 +172,9 @@ class Permute(object):
 
 
 class PadStride(object):
-    """ padding image for model with FPN , instead PadBatch(pad_to_stride, pad_gt) in original config
+    """ padding image for model with FPN, instead PadBatch(pad_to_stride) in original config
     Args:
-        stride (bool): model with FPN need image shape % stride == 0 
+        stride (bool): model with FPN need image shape % stride == 0
     """
 
     def __init__(self, stride=0):

--- a/ppdet/data/reader.py
+++ b/ppdet/data/reader.py
@@ -64,10 +64,11 @@ class Compose(object):
 
 
 class BatchCompose(Compose):
-    def __init__(self, transforms, num_classes=80):
+    def __init__(self, transforms, num_classes=80, collate_batch=True):
         super(BatchCompose, self).__init__(transforms, num_classes)
         self.output_fields = mp.Manager().list([])
         self.lock = mp.Lock()
+        self.collate_batch = collate_batch
 
     def __call__(self, data):
         for f in self.transforms_cls:
@@ -103,11 +104,21 @@ class BatchCompose(Compose):
                         self.output_fields.append(k)
             self.lock.release()
 
-        data = [[data[i][k] for k in self.output_fields]
-                for i in range(len(data))]
-        data = list(zip(*data))
+        batch_data = []
+        if self.collate_batch:
+            data = [[data[i][k] for k in self.output_fields]
+                    for i in range(len(data))]
+            data = list(zip(*data))
+            batch_data = [np.stack(d, axis=0) for d in data]
+        else:
+            for k in self.output_fields:
+                tmp_data = []
+                for i in range(len(data)):
+                    tmp_data.append(data[i][k])
+                if not 'gt_' in k and not 'is_crowd' in k:
+                    tmp_data = np.stack(tmp_data, axis=0)
+                batch_data.append(tmp_data)
 
-        batch_data = [np.stack(d, axis=0) for d in data]
         return batch_data
 
 
@@ -145,6 +156,7 @@ class BaseDataLoader(object):
                  drop_last=False,
                  drop_empty=True,
                  num_classes=80,
+                 collate_batch=True,
                  use_shared_memory=False,
                  **kwargs):
         # sample transform
@@ -152,8 +164,8 @@ class BaseDataLoader(object):
             sample_transforms, num_classes=num_classes)
 
         # batch transfrom 
-        self._batch_transforms = BatchCompose(batch_transforms, num_classes)
-
+        self._batch_transforms = BatchCompose(batch_transforms, num_classes,
+                                              collate_batch)
         self.batch_size = batch_size
         self.shuffle = shuffle
         self.drop_last = drop_last
@@ -238,10 +250,11 @@ class TrainReader(BaseDataLoader):
                  drop_last=True,
                  drop_empty=True,
                  num_classes=80,
+                 collate_batch=True,
                  **kwargs):
-        super(TrainReader, self).__init__(sample_transforms, batch_transforms,
-                                          batch_size, shuffle, drop_last,
-                                          drop_empty, num_classes, **kwargs)
+        super(TrainReader, self).__init__(
+            sample_transforms, batch_transforms, batch_size, shuffle, drop_last,
+            drop_empty, num_classes, collate_batch, **kwargs)
 
 
 @register

--- a/ppdet/data/reader.py
+++ b/ppdet/data/reader.py
@@ -105,6 +105,12 @@ class BatchCompose(Compose):
             self.lock.release()
 
         batch_data = []
+        # If set collate_batch=True, all data will collate a batch
+        # and it will transfor to paddle.tensor.
+        # If set collate_batch=False, `image`, `im_shape` and
+        # `scale_factor` will collate a batch, but `gt` data(such as:
+        # gt_bbox, gt_class, gt_poly.etc.) will not collate a batch
+        # and it will transfor to list[Tensor] or list[list].
         if self.collate_batch:
             data = [[data[i][k] for k in self.output_fields]
                     for i in range(len(data))]

--- a/ppdet/data/transform/batch_operators.py
+++ b/ppdet/data/transform/batch_operators.py
@@ -50,10 +50,9 @@ class PadBatch(BaseOperator):
             height and width is divisible by `pad_to_stride`.
     """
 
-    def __init__(self, pad_to_stride=0, pad_gt=False):
+    def __init__(self, pad_to_stride=0):
         super(PadBatch, self).__init__()
         self.pad_to_stride = pad_to_stride
-        self.pad_gt = pad_gt
 
     def __call__(self, samples, context=None):
         """
@@ -70,7 +69,6 @@ class PadBatch(BaseOperator):
             max_shape[2] = int(
                 np.ceil(max_shape[2] / coarsest_stride) * coarsest_stride)
 
-        padding_batch = []
         for data in samples:
             im = data['image']
             im_c, im_h, im_w = im.shape[:]
@@ -91,55 +89,6 @@ class PadBatch(BaseOperator):
                     dtype=np.uint8)
                 padding_segm[:, :im_h, :im_w] = gt_segm
                 data['gt_segm'] = padding_segm
-
-        if self.pad_gt:
-            gt_num = []
-            if 'gt_poly' in data and data['gt_poly'] is not None and len(data[
-                    'gt_poly']) > 0:
-                pad_mask = True
-            else:
-                pad_mask = False
-
-            if pad_mask:
-                poly_num = []
-                poly_part_num = []
-                point_num = []
-            for data in samples:
-                gt_num.append(data['gt_bbox'].shape[0])
-                if pad_mask:
-                    poly_num.append(len(data['gt_poly']))
-                    for poly in data['gt_poly']:
-                        poly_part_num.append(int(len(poly)))
-                        for p_p in poly:
-                            point_num.append(int(len(p_p) / 2))
-            gt_num_max = max(gt_num)
-
-            for i, data in enumerate(samples):
-                gt_box_data = -np.ones([gt_num_max, 4], dtype=np.float32)
-                gt_class_data = -np.ones([gt_num_max], dtype=np.int32)
-                is_crowd_data = np.ones([gt_num_max], dtype=np.int32)
-
-                if pad_mask:
-                    poly_num_max = max(poly_num)
-                    poly_part_num_max = max(poly_part_num)
-                    point_num_max = max(point_num)
-                    gt_masks_data = -np.ones(
-                        [poly_num_max, poly_part_num_max, point_num_max, 2],
-                        dtype=np.float32)
-
-                gt_num = data['gt_bbox'].shape[0]
-                gt_box_data[0:gt_num, :] = data['gt_bbox']
-                gt_class_data[0:gt_num] = np.squeeze(data['gt_class'])
-                is_crowd_data[0:gt_num] = np.squeeze(data['is_crowd'])
-                if pad_mask:
-                    for j, poly in enumerate(data['gt_poly']):
-                        for k, p_p in enumerate(poly):
-                            pp_np = np.array(p_p).reshape(-1, 2)
-                            gt_masks_data[j, k, :pp_np.shape[0], :] = pp_np
-                    data['gt_poly'] = gt_masks_data
-                data['gt_bbox'] = gt_box_data
-                data['gt_class'] = gt_class_data
-                data['is_crowd'] = is_crowd_data
 
         return samples
 
@@ -585,6 +534,9 @@ class Gt2TTFTarget(BaseOperator):
             sample['ttf_heatmap'] = heatmap
             sample['ttf_box_target'] = box_target
             sample['ttf_reg_weight'] = reg_weight
+            sample.pop('is_crowd')
+            sample.pop('gt_class')
+            sample.pop('gt_bbox')
         return samples
 
     def draw_truncate_gaussian(self, heatmap, center, h_radius, w_radius):

--- a/ppdet/engine/export_utils.py
+++ b/ppdet/engine/export_utils.py
@@ -56,10 +56,9 @@ def _parse_reader(reader_cfg, dataset_cfg, metric, arch, image_shape):
             preprocess_list.append(p)
     batch_transforms = reader_cfg.get('batch_transforms', None)
     if batch_transforms:
-        methods = [list(bt.keys())[0] for bt in batch_transforms]
         for bt in batch_transforms:
             for key, value in bt.items():
-                # for deploy/infer, use PadStride(stride) instead PadBatch(pad_to_stride, pad_gt)
+                # for deploy/infer, use PadStride(stride) instead PadBatch(pad_to_stride)
                 if key == 'PadBatch':
                     preprocess_list.append({
                         'type': 'PadStride',

--- a/ppdet/modeling/proposal_generator/target_layer.py
+++ b/ppdet/modeling/proposal_generator/target_layer.py
@@ -41,7 +41,7 @@ class RPNTargetAssign(object):
         anchor_box (Tensor): [num_anchors, 4], num_anchors are all anchors in all feature maps.
         """
         gt_boxes = inputs['gt_bbox']
-        batch_size = gt_boxes.shape[0]
+        batch_size = len(gt_boxes)
         tgt_labels, tgt_bboxes, tgt_deltas = rpn_anchor_target(
             anchors, gt_boxes, self.batch_size_per_im, self.positive_overlap,
             self.negative_overlap, self.fg_fraction, self.use_random,


### PR DESCRIPTION
DataLoader based on https://github.com/PaddlePaddle/Paddle/pull/31481
- `Mask RCNN R50 FPN` P40 single GPU
    - batch size=4: gt pad batch ips: `2.85 images/s`, gt **not** pad batch ips: `3.20 images/s` (+12%)
    - batch size=1: gt pad batch ips: `3.27 images/s`, gt **not** pad batch ips: `3.53 images/s`(+8%)
- `Mask RCNN R50 FPN` P40 4 GPU
    - batch size=4: gt pad batch ips: `2.29 * 4 images/s`, gt **not** pad batch ips: `2.42 * 4 images/s` (+5.7%)