### PR TITLE
fix warning

### DIFF
--- a/ppdet/modeling/__init__.py
+++ b/ppdet/modeling/__init__.py
@@ -2,9 +2,7 @@
 # DeprecationWarning in string parsing
 import warnings
 warnings.filterwarnings(
-            action='ignore',
-            category=DeprecationWarning,
-            module='ops')
+    action='ignore', category=DeprecationWarning, module='ops')
 
 from . import ops
 from . import backbones

--- a/ppdet/modeling/__init__.py
+++ b/ppdet/modeling/__init__.py
@@ -1,3 +1,11 @@
+# OP docs may contains math formula which may cause
+# DeprecationWarning in string parsing
+import warnings
+warnings.filterwarnings(
+            action='ignore',
+            category=DeprecationWarning,
+            module='ops')
+
 from . import ops
 from . import backbones
 from . import necks

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ shapely
 scipy
 terminaltables
 pycocotools
+setuptools>=42.0.0

--- a/tools/eval.py
+++ b/tools/eval.py
@@ -22,10 +22,6 @@ parent_path = os.path.abspath(os.path.join(__file__, *(['..'] * 2)))
 if parent_path not in sys.path:
     sys.path.append(parent_path)
 
-# ignore warning log
-import warnings
-warnings.filterwarnings('ignore')
-
 import paddle
 
 from ppdet.core.workspace import load_config, merge_config

--- a/tools/export_model.py
+++ b/tools/export_model.py
@@ -21,10 +21,6 @@ parent_path = os.path.abspath(os.path.join(__file__, *(['..'] * 2)))
 if parent_path not in sys.path:
     sys.path.append(parent_path)
 
-# ignore warning log
-import warnings
-warnings.filterwarnings('ignore')
-
 import paddle
 
 from ppdet.core.workspace import load_config, merge_config

--- a/tools/infer.py
+++ b/tools/infer.py
@@ -21,9 +21,6 @@ parent_path = os.path.abspath(os.path.join(__file__, *(['..'] * 2)))
 if parent_path not in sys.path:
     sys.path.append(parent_path)
 
-# ignore warning log
-import warnings
-warnings.filterwarnings('ignore')
 import glob
 
 import paddle

--- a/tools/train.py
+++ b/tools/train.py
@@ -22,9 +22,6 @@ parent_path = os.path.abspath(os.path.join(__file__, *(['..'] * 2)))
 if parent_path not in sys.path:
     sys.path.append(parent_path)
 
-# ignore warning log
-import warnings
-warnings.filterwarnings('ignore')
 import random
 import numpy as np
 


### PR DESCRIPTION
**fix warning**
- remove following string parsing warnings
```
/paddle/paddle/dengkaipeng/PaddleDetection/ppdet/modeling/ops.py:529: DeprecationWarning: invalid escape sequence \_
  """
/paddle/paddle/dengkaipeng/PaddleDetection/ppdet/modeling/ops.py:1362: DeprecationWarning: invalid escape sequence \l
  """
```
- remove following import warnings
```
/usr/local/lib/python3.7/site-packages/setuptools/depends.py:2: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
```