### PR TITLE
In Pad, use normal division instead of floor division to calculate target height

### DIFF
--- a/ppdet/data/transform/operators.py
+++ b/ppdet/data/transform/operators.py
@@ -1862,7 +1862,7 @@ class Pad(BaseOperator):
                 im_h < h and im_w < w
             ), '(h, w) of target size should be greater than (im_h, im_w)'
         else:
-            h = np.ceil(im_h // self.size_divisor) * self.size_divisor
+            h = np.ceil(im_h / self.size_divisor) * self.size_divisor
             w = np.ceil(im_w / self.size_divisor) * self.size_divisor
 
         if h == im_h and w == im_w:

--- a/ppdet/data/transform/operators.py
+++ b/ppdet/data/transform/operators.py
@@ -1795,7 +1795,8 @@ class Pad(BaseOperator):
         assert pad_mode in [
             -1, 0, 1, 2
         ], 'currently only supports four modes [-1, 0, 1, 2]'
-        assert pad_mode == -1 and offsets, 'if pad_mode is -1, offsets should not be None'
+        if pad_mode == -1:
+            assert offsets, 'if pad_mode is -1, offsets should not be None'
 
         self.size = size
         self.size_divisor = size_divisor


### PR DESCRIPTION
做padding时，当用户未给定size时，h = np.ceil(im_h / /self.size_divisor) * self.size_divisor可能会导致h小于图片原始高度，且如果使用地板除，np.ceil就没有必要了。是否应改为普通除法？