### PR TITLE
fix loading rcnn pretrain

### DIFF
--- a/ppdet/utils/checkpoint.py
+++ b/ppdet/utils/checkpoint.py
@@ -159,6 +159,16 @@ def load_pretrain_weight(model, pretrain_weight):
     param_state_dict = paddle.load(weights_path)
     ignore_weights = set()
 
+    # hack: fit for faster rcnn. Pretrain weights contain prefix of 'backbone'
+    # while res5 module is located in bbox_head.head. Replace the prefix of
+    # res5 with 'bbox_head.head' to load pretrain weights correctly.
+    for k in param_state_dict.keys():
+        if 'backbone.res5' in k:
+            new_k = k.replace('backbone', 'bbox_head.head')
+            if new_k in model_dict.keys():
+                value = param_state_dict.pop(k)
+                param_state_dict[new_k] = value
+
     for name, weight in param_state_dict.items():
         if name in model_dict.keys():
             if list(weight.shape) != list(model_dict[name].shape):


### PR DESCRIPTION
The pretrained weights contain prefix of 'backbone', while the pretrained model of faster rcnn needs res5 module which is located in bbox_head.head, due to the pretrain of res5 could not be loaded. Replace the pretrained weights name in correct format.
 