### PR TITLE
Modify return type of matrix_nms to keep same with multiclass_nms3

### DIFF
--- a/ppdet/modeling/ops.py
+++ b/ppdet/modeling/ops.py
@@ -1139,7 +1139,7 @@ def matrix_nms(bboxes,
         index = helper.create_variable_for_type_inference(dtype='int')
         outputs = {'Out': output, 'Index': index}
         if return_rois_num:
-            rois_num = helper.create_variable_for_type_inference(dtype='int')
+            rois_num = helper.create_variable_for_type_inference(dtype='int32')
             outputs['RoisNum'] = rois_num
 
         helper.append_op(


### PR DESCRIPTION
自定义的OP中，MatrixNms的返回type与MulticlassNMS不同，导致在导出ONNX时出现问题

原MulticlassNMS定义返回代码如下
https://github.com/PaddlePaddle/PaddleDetection/blob/develop/ppdet/modeling/ops.py#L1005
原MatrixNMS定义返回代码如下
https://github.com/PaddlePaddle/PaddleDetection/blob/develop/ppdet/modeling/ops.py#L1142

此PR中将MatrixNMS的返回type与MulticlassNMS改为相同