### PR TITLE
fix post_process.py

### DIFF
--- a/ppdet/modeling/post_process.py
+++ b/ppdet/modeling/post_process.py
@@ -78,7 +78,7 @@ class BBoxPostProcess(object):
         Currently only support bs = 1.
 
         Args:
-            bbox_pred (Tensor): The output bboxes with shape [N, 6] after decode
+            bboxes (Tensor): The output bboxes with shape [N, 6] after decode
                 and NMS, including labels, scores and bboxes.
             bbox_num (Tensor): The number of prediction boxes of each batch with
                 shape [1], and is N.


### PR DESCRIPTION
在 2.1 的release中 91行是 bbox_pred = paddle.to_tensor(
这会导致空的bbox会没有办法被后续处理
现在看到 https://github.com/PaddlePaddle/PaddleDetection/pull/3109 已经修正了这个错误

但是在代码对应的注释中没有修复这个错误，有可能引发阅读者的理解错误，所以将81行注释的bbox_pred修改成了代码实际使用的bboxes