### PR TITLE
Add eval notice

### DIFF
--- a/configs/ppyolo/ppyolo_r50vd_dcn_roadsign.yml
+++ b/configs/ppyolo/ppyolo_r50vd_dcn_roadsign.yml
@@ -1,0 +1,42 @@
+_BASE_: [
+  '../datasets/voc.yml',
+  '../runtime.yml',
+  './_base_/ppyolo_r50vd_dcn.yml',
+  './_base_/optimizer_1x.yml',
+  './_base_/ppyolo_reader.yml',
+]
+
+snapshot_epoch: 83
+weights: output/ppyolo_r50vd_dcn_voc/model_final
+
+TrainReader:
+  mixup_epoch: 350
+  batch_size: 12
+
+# set collate_batch to false because ground-truth info is needed
+# on voc dataset and should not collate data in batch when batch size
+# is larger than 1.
+EvalReader:
+  collate_batch: false
+
+epoch: 583
+
+LearningRate:
+  base_lr: 0.00333
+  schedulers:
+  - !PiecewiseDecay
+    gamma: 0.1
+    milestones:
+    - 466
+    - 516
+  - !LinearWarmup
+    start_factor: 0.
+    steps: 4000
+
+OptimizerBuilder:
+  optimizer:
+    momentum: 0.9
+    type: Momentum
+  regularizer:
+    factor: 0.0005
+    type: L2

--- a/configs/ppyolo/ppyolov2_r50vd_dcn_roadsign.yml
+++ b/configs/ppyolo/ppyolov2_r50vd_dcn_roadsign.yml
@@ -1,0 +1,43 @@
+_BASE_: [
+  '../datasets/roadsign_voc.yml',
+  '../runtime.yml',
+  './_base_/ppyolov2_r50vd_dcn.yml',
+  './_base_/optimizer_365e.yml',
+  './_base_/ppyolov2_reader.yml',
+]
+
+snapshot_epoch: 40
+pretrain_weights: https://paddledet.bj.bcebos.com/models/ppyolov2_r50vd_dcn_365e_coco.pdparams
+weights: output/ppyolov2_r50vd_dcn_roadsign/model_final
+
+TrainReader:
+  mixup_epoch: 350
+  batch_size: 8
+
+# set collate_batch to false because ground-truth info is needed
+# on voc dataset and should not collate data in batch when batch size
+# is larger than 1.
+EvalReader:
+  collate_batch: false
+
+epoch: 583
+
+LearningRate:
+  base_lr: 0.000333
+  schedulers:
+  - !PiecewiseDecay
+    gamma: 0.1
+    milestones:
+    - 466
+    - 516
+  - !LinearWarmup
+    start_factor: 0.
+    steps: 4000
+
+OptimizerBuilder:
+  optimizer:
+    momentum: 0.9
+    type: Momentum
+  regularizer:
+    factor: 0.0005
+    type: L2

--- a/ppdet/engine/trainer.py
+++ b/ppdet/engine/trainer.py
@@ -361,6 +361,7 @@ class Trainer(object):
                         "\t3. try to do finetune training by set '-o "
                         "pretrain_weights=xxx' xxx is weights released "
                         "in PaddleDetection model zoo")
+                    is_validate_notice_logged = True
                 with paddle.no_grad():
                     self.status['save_best_model'] = True
                     self._eval_with_loader(self._eval_loader)

--- a/ppdet/engine/trainer.py
+++ b/ppdet/engine/trainer.py
@@ -279,6 +279,7 @@ class Trainer(object):
             self.cfg.log_iter, fmt='{avg:.4f}')
         self.status['training_staus'] = stats.TrainingStats(self.cfg.log_iter)
 
+        is_validate_notice_logged = False
         for epoch_id in range(self.start_epoch, self.cfg.epoch):
             self.status['mode'] = 'train'
             self.status['epoch_id'] = epoch_id
@@ -345,6 +346,21 @@ class Trainer(object):
                         self._eval_dataset,
                         self.cfg.worker_num,
                         batch_sampler=self._eval_batch_sampler)
+                if not is_validate_notice_logged:
+                    logger.info(
+                        "Validation may cost lost of time and look like hanging "
+                        "when sorting bbox in NMS and the model is not converged "
+                        "because of training iteration is not enough, you can "
+                        "try followings:\n"
+                        "\t1. if model training is not on 8 GPU or batch_size "
+                        "has been decreased, please decrease learning_rate "
+                        "by the same ratio of total batch_size\n"
+                        "\t2. if the sample number of your custom dataset "
+                        "is not large enough, please increase snapshot_epoch "
+                        "to increase training iterations when validating\n"
+                        "\t3. try to do finetune training by set '-o "
+                        "pretrain_weights=xxx' xxx is weights released "
+                        "in PaddleDetection model zoo")
                 with paddle.no_grad():
                     self.status['save_best_model'] = True
                     self._eval_with_loader(self._eval_loader)


### PR DESCRIPTION
**Add eval notice & ppyolov1/v2_roadsign config**
- add `ppyolo_r50vd_dcn_roadsign` and `ppyolov2_r50vd_dcn_roadsign`
- add notice when eval in train with `--eval`, only log in the first time
```
[06/02 08:37:21] ppdet.engine INFO: Validation may cost lost of time and look like hanging when sorting bbox in NMS and the model is not converged because of training iteration is not enough, you can try followings:
        1. if model training is not on 8 GPU or batch_size has been decreased, please decrease learning_rate by the same ratio of total batch_size
        2. if the sample number of your custom dataset is not large enough, please increase snapshot_epoch to increase training iterations when validating
        3. try to do finetune training by set '-o pretrain_weights=xxx' xxx is weights released in PaddleDetection model zoo
```