### PR TITLE
fix np.int warning in operator

### DIFF
--- a/ppdet/data/transform/operators.py
+++ b/ppdet/data/transform/operators.py
@@ -1506,8 +1506,8 @@ class Cutmix(BaseOperator):
         w = max(img1.shape[1], img2.shape[1])
         cut_rat = np.sqrt(1. - factor)
 
-        cut_w = np.int(w * cut_rat)
-        cut_h = np.int(h * cut_rat)
+        cut_w = np.int32(w * cut_rat)
+        cut_h = np.int32(h * cut_rat)
 
         # uniform
         cx = np.random.randint(w)

--- a/static/ppdet/data/transform/operators.py
+++ b/static/ppdet/data/transform/operators.py
@@ -1343,8 +1343,8 @@ class CutmixImage(BaseOperator):
             w = max(img1.shape[1], img2.shape[1])
             cut_rat = np.sqrt(1. - factor)
 
-            cut_w = np.int(w * cut_rat)
-            cut_h = np.int(h * cut_rat)
+            cut_w = np.int32(w * cut_rat)
+            cut_h = np.int32(h * cut_rat)
 
             # uniform
             cx = np.random.randint(w)


### PR DESCRIPTION
remove such warning：
```
ppdet/data/transform/operators.py:1509: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. 
To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. 
When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. 
If you wish to review your current use, check the release note link for additional information.
```