### PR TITLE
fix train diff for fairmot

### DIFF
--- a/ppdet/data/transform/operators.py
+++ b/ppdet/data/transform/operators.py
@@ -2015,12 +2015,12 @@ class Rbox2Poly(BaseOperator):
 
 @register_op
 class AugmentHSV(BaseOperator):
-    def __init__(self, fraction=0.50, is_bgr=False):
+    def __init__(self, fraction=0.50, is_bgr=True):
         """ 
         Augment the SV channel of image data.
         Args:
-            fraction (float): the fraction for augment 
-            is_bgr (bool): whether the image is BGR mode
+            fraction (float): the fraction for augment. Default: 0.5.
+            is_bgr (bool): whether the image is BGR mode. Default: True.
         """
         super(AugmentHSV, self).__init__()
         self.fraction = fraction

--- a/ppdet/modeling/layers.py
+++ b/ppdet/modeling/layers.py
@@ -163,6 +163,8 @@ class ConvNormLayer(nn.Layer):
                 bias_attr=True,
                 lr_scale=dcn_lr_scale,
                 regularizer=dcn_regularizer,
+                dcn_bias_regularizer=dcn_regularizer,
+                dcn_bias_lr_scale=dcn_lr_scale,
                 skip_quant=skip_quant)
 
         norm_lr = 0. if freeze_norm else 1.


### PR DESCRIPTION
* In the pr #2994  where the `dcn_bias_lr_scale` and `dcn_bias_regularizer` for DeformableV2 are always `2.0` and `L2Decay(0.)`, but they could be specified manually and for FairMOT are `1.0` and `None`. We fix this bug.
* We set the default value of `is_bgr` to `True` for the transform `AugmentHSV` because the fed image is usually in a bgr format.