### PR TITLE
Freeze reset blocks

### DIFF
--- a/ppdet/modeling/backbones/resnet.py
+++ b/ppdet/modeling/backbones/resnet.py
@@ -584,8 +584,8 @@ class ResNet(nn.Layer):
         outs = []
         for idx, stage in enumerate(self.res_layers):
             x = stage(x)
-            if idx == self.freeze_at:
-                x.stop_gradient = True
+            # if idx == self.freeze_at:
+            #     x.stop_gradient = True
             if idx in self.return_idx:
                 outs.append(x)
         return outs

--- a/ppdet/modeling/backbones/resnet.py
+++ b/ppdet/modeling/backbones/resnet.py
@@ -560,6 +560,15 @@ class ResNet(nn.Layer):
             self.res_layers.append(res_layer)
             self.ch_in = self._out_channels[i]
 
+        if freeze_at >= 0:
+            self._freeze_parameters(self.conv1)
+            for i in range(freeze_at + 1):
+                self._freeze_parameters(self.res_layers[i])
+
+    def _freeze_parameters(self, m):
+        for p in m.parameters():
+            p.stop_gradient = True
+
     @property
     def out_shape(self):
         return [

--- a/ppdet/modeling/backbones/resnet.py
+++ b/ppdet/modeling/backbones/resnet.py
@@ -562,7 +562,7 @@ class ResNet(nn.Layer):
 
         if freeze_at >= 0:
             self._freeze_parameters(self.conv1)
-            for i in range(freeze_at + 1):
+            for i in range(min(freeze_at + 1, num_stages)):
                 self._freeze_parameters(self.res_layers[i])
 
     def _freeze_parameters(self, m):
@@ -584,8 +584,6 @@ class ResNet(nn.Layer):
         outs = []
         for idx, stage in enumerate(self.res_layers):
             x = stage(x)
-            # if idx == self.freeze_at:
-            #     x.stop_gradient = True
             if idx in self.return_idx:
                 outs.append(x)
         return outs


### PR DESCRIPTION
- modifing parameter's `stop_gradien=True` rathe than `x` when freezing
- speed 
  - modified attributes in `__init__` rathe than `forword`
- global status
  - like `GlobalNormClip`
 