### PR TITLE
increase min_subgraph_size for fairmot

### DIFF
--- a/ppdet/engine/export_utils.py
+++ b/ppdet/engine/export_utils.py
@@ -41,7 +41,7 @@ TRT_MIN_SUBGRAPH = {
     'HRNet': 3,
     'DeepSORT': 3,
     'JDE': 3,
-    'FairMOT': 3,
+    'FairMOT': 5,
 }
 
 KEYPOINT_ARCH = ['HigherHRNet', 'TopDownHRNet']


### PR DESCRIPTION
The origin setting of min_subgraph_size is so small that tensorrt inference cannot be done successfully, so we increase it to 5. 