### PR TITLE
Fix Installation guide link for English Readme

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -205,7 +205,7 @@ The relationship between COCO mAP and FPS on Tesla V100 of representative models
 
 ### Get Started
 
-- [Installation guide](docs/tutorials/INSTALL_en.md)
+- [Installation guide](docs/tutorials/INSTALL.md)
 - [Prepare dataset](docs/tutorials/PrepareDataSet.md)
 - [Quick start on PaddleDetection](docs/tutorials/GETTING_STARTED_cn.md)
 


### PR DESCRIPTION
The link to installation guide in English readme was not working. Its minor change but important for readme file.