### PR TITLE
[dev] adjust merge config order

### DIFF
--- a/tools/eval.py
+++ b/tools/eval.py
@@ -115,7 +115,6 @@ def main():
     cfg['classwise'] = True if FLAGS.classwise else False
     cfg['output_eval'] = FLAGS.output_eval
     cfg['save_prediction_only'] = FLAGS.save_prediction_only
-    merge_config(FLAGS.opt)
 
     place = paddle.set_device('gpu' if cfg.use_gpu else 'cpu')
 
@@ -125,6 +124,7 @@ def main():
     if FLAGS.slim_config:
         cfg = build_slim_model(cfg, FLAGS.slim_config, mode='eval')
 
+    merge_config(FLAGS.opt)
     check_config(cfg)
     check_gpu(cfg.use_gpu)
     check_version()

--- a/tools/export_model.py
+++ b/tools/export_model.py
@@ -98,11 +98,11 @@ def main():
     # TODO: to be refined in the future
     if 'norm_type' in cfg and cfg['norm_type'] == 'sync_bn':
         FLAGS.opt['norm_type'] = 'bn'
-    merge_config(FLAGS.opt)
 
     if FLAGS.slim_config:
         cfg = build_slim_model(cfg, FLAGS.slim_config, mode='test')
 
+    merge_config(FLAGS.opt)
     check_config(cfg)
     check_gpu(cfg.use_gpu)
     check_version()

--- a/tools/infer.py
+++ b/tools/infer.py
@@ -140,7 +140,6 @@ def main():
     cfg = load_config(FLAGS.config)
     cfg['use_vdl'] = FLAGS.use_vdl
     cfg['vdl_log_dir'] = FLAGS.vdl_log_dir
-    merge_config(FLAGS.opt)
 
     place = paddle.set_device('gpu' if cfg.use_gpu else 'cpu')
 
@@ -150,6 +149,7 @@ def main():
     if FLAGS.slim_config:
         cfg = build_slim_model(cfg, FLAGS.slim_config, mode='test')
 
+    merge_config(FLAGS.opt)
     check_config(cfg)
     check_gpu(cfg.use_gpu)
     check_version()

--- a/tools/train.py
+++ b/tools/train.py
@@ -118,7 +118,6 @@ def main():
     cfg['use_vdl'] = FLAGS.use_vdl
     cfg['vdl_log_dir'] = FLAGS.vdl_log_dir
     cfg['save_prediction_only'] = FLAGS.save_prediction_only
-    merge_config(FLAGS.opt)
 
     place = paddle.set_device('gpu' if cfg.use_gpu else 'cpu')
 
@@ -128,6 +127,7 @@ def main():
     if FLAGS.slim_config:
         cfg = build_slim_model(cfg, FLAGS.slim_config)
 
+    merge_config(FLAGS.opt)
     check.check_config(cfg)
     check.check_gpu(cfg.use_gpu)
     check.check_version()


### PR DESCRIPTION
- When use `--slim_config` to train/eval/infer/export_model, `-o` has a lower priority than`--slim_config`
- Adjust the order of `merge_config()`