### PR TITLE
fix anno not found in infer mode

### DIFF
--- a/ppdet/data/source/dataset.py
+++ b/ppdet/data/source/dataset.py
@@ -149,7 +149,12 @@ class ImageFolder(DetDataset):
         self.sample_num = sample_num
 
     def check_or_download_dataset(self):
-        return
+        if self.dataset_dir:
+            # NOTE: ImageFolder is only used for prediction, in
+            #       infer mode, image_dir is set by set_images
+            #       so we only check anno_path here
+            self.dataset_dir = get_dataset_path(self.dataset_dir,
+                                                self.anno_path, None)
 
     def parse_dataset(self, ):
         if not self.roidbs:

--- a/ppdet/utils/download.py
+++ b/ppdet/utils/download.py
@@ -195,6 +195,10 @@ def get_dataset_path(path, annotation, image_dir):
                         "Please apply and download the dataset following docs/tutorials/PrepareMOTDataSet.md".
                         format(name))
 
+            if name == "spine_coco":
+                if _dataset_exists(data_dir, annotation, image_dir):
+                    return data_dir
+
             # For voc, only check dir VOCdevkit/VOC2012, VOCdevkit/VOC2007
             if name in ['voc', 'fruit', 'roadsign_voc']:
                 exists = True


### PR DESCRIPTION
**fix anno not found in infer mode**
fix `anno_path` cannot be correctly mapped and default class label of COCO/VOC is always used

**test command:** 
```
python3.7 tools/infer.py -c configs/dota/s2anet_1x_spine.yml -o weights=s2anet_spine.pdparams --infer_img=demo/39006.jpg --draw_threshold=0.1
```