### PR TITLE
set highest import priority for current dir

### DIFF
--- a/tools/anchor_cluster.py
+++ b/tools/anchor_cluster.py
@@ -20,8 +20,7 @@ import os
 import sys
 # add python path of PadleDetection to sys.path
 parent_path = os.path.abspath(os.path.join(__file__, *(['..'] * 2)))
-if parent_path not in sys.path:
-    sys.path.append(parent_path)
+sys.path.insert(0, parent_path)
 
 from ppdet.utils.logger import setup_logger
 logger = setup_logger('ppdet.anchor_cluster')

--- a/tools/eval.py
+++ b/tools/eval.py
@@ -21,8 +21,7 @@ import sys
 
 # add python path of PadleDetection to sys.path
 parent_path = os.path.abspath(os.path.join(__file__, *(['..'] * 2)))
-if parent_path not in sys.path:
-    sys.path.append(parent_path)
+sys.path.insert(0, parent_path)
 
 # ignore warning log
 import warnings

--- a/tools/eval_mot.py
+++ b/tools/eval_mot.py
@@ -21,8 +21,7 @@ import sys
 
 # add python path of PadleDetection to sys.path
 parent_path = os.path.abspath(os.path.join(__file__, *(['..'] * 2)))
-if parent_path not in sys.path:
-    sys.path.append(parent_path)
+sys.path.insert(0, parent_path)
 
 # ignore warning log
 import warnings

--- a/tools/export_model.py
+++ b/tools/export_model.py
@@ -21,8 +21,7 @@ import sys
 
 # add python path of PadleDetection to sys.path
 parent_path = os.path.abspath(os.path.join(__file__, *(['..'] * 2)))
-if parent_path not in sys.path:
-    sys.path.append(parent_path)
+sys.path.insert(0, parent_path)
 
 # ignore warning log
 import warnings

--- a/tools/infer.py
+++ b/tools/infer.py
@@ -21,8 +21,7 @@ import sys
 
 # add python path of PadleDetection to sys.path
 parent_path = os.path.abspath(os.path.join(__file__, *(['..'] * 2)))
-if parent_path not in sys.path:
-    sys.path.append(parent_path)
+sys.path.insert(0, parent_path)
 
 # ignore warning log
 import warnings

--- a/tools/infer_mot.py
+++ b/tools/infer_mot.py
@@ -21,8 +21,7 @@ import sys
 
 # add python path of PadleDetection to sys.path
 parent_path = os.path.abspath(os.path.join(__file__, *(['..'] * 2)))
-if parent_path not in sys.path:
-    sys.path.append(parent_path)
+sys.path.insert(0, parent_path)
 
 # ignore warning log
 import warnings

--- a/tools/train.py
+++ b/tools/train.py
@@ -21,8 +21,7 @@ import sys
 
 # add python path of PadleDetection to sys.path
 parent_path = os.path.abspath(os.path.join(__file__, *(['..'] * 2)))
-if parent_path not in sys.path:
-    sys.path.append(parent_path)
+sys.path.insert(0, parent_path)
 
 # ignore warning log
 import warnings


### PR DESCRIPTION
**set highest import priority for current dir**
- Python import order: `buildin -> sys.path -> PYTHONPATH`
- `sys.path` usually contains current dir at position 1, contains `site-packages` at nearly the last position, for example
```
>>> sys.path
['', '/paddle/dengkaipeng/PaddleDetection', '/paddle/git/models/PaddleCV/PaddleDetection', '/usr/local/lib/python37.zip', '/usr/local/lib/python3.7', '/usr/local/lib/python3.7/lib-dynload', '/usr/local/lib/python3.7/site-packages', '/usr/local/lib/python3.7/site-packages/pip-20.0.1-py3.7.egg', '/usr/local/lib/python3.7/site-packages/rbox_iou_ops-0.0.0-py3.7-linux-x86_64.egg', '/usr/local/lib/python3.7/site-packages/ppdet-2.2.0-py3.7.egg']
```
- `append` root directory cannot change priority, should `insert` to position 0