### PR TITLE
Fix rl 2.1/infer lables

### DIFF
--- a/ppdet/metrics/json_results.py
+++ b/ppdet/metrics/json_results.py
@@ -27,7 +27,13 @@ def get_det_res(bboxes, bbox_nums, image_id, label_to_cat_id_map, bias=0):
             num_id, score, xmin, ymin, xmax, ymax = dt.tolist()
             if int(num_id) < 0:
                 continue
-            category_id = label_to_cat_id_map[int(num_id)]
+            # when a model is trained for customer dataset but initialed with pretrained model,
+            # there is possiblities to genereate class_id not in the map
+            klass_id = int(num_id)
+            if label_to_cat_id_map.get(klass_id, None) is None:
+              category_id = 0 # background
+            else:
+              category_id = label_to_cat_id_map[klass_id]
             w = xmax - xmin + bias
             h = ymax - ymin + bias
             bbox = [xmin, ymin, w, h]


### PR DESCRIPTION
1. set category_id when no record found in coco label to cat_id map

Suppose customer dataset has 3 labels: background, vehicle and pedestrian, the dataset generated by labeling toolkit only records vehicle and pedestrian:

```python
1: vehicle
2: pedestrian
```

The label_to_cat_id map for ['vehicle', 'pedestrian'] will be 
 
> {0: 1, 1:2}

While our number of categories is still number 3, which means we will generate label 2 with score almost 0 by Softmax layer when we are performing inference.

Hence we need to change this

```python
# ppdet/metrics/json_utils.py#28
category_id = label_to_cat_id_map[int(num_id)]
```

to

```python
klass_id = int(num_id)
if label_to_cat_id_map.get(klass_id, None) is None:
    category_id = 0
else:
    # 1 or 2
    category_id = label_to_cat_id_map[int(num_id)]
```