### PR TITLE
[fp16] fix bug when use drop block in fp16

### DIFF
--- a/ppdet/modeling/layers.py
+++ b/ppdet/modeling/layers.py
@@ -279,7 +279,7 @@ class DropBlock(nn.Layer):
             for s in shape:
                 gamma *= s / (s - self.block_size + 1)
 
-            matrix = paddle.cast(paddle.rand(x.shape, x.dtype) < gamma, x.dtype)
+            matrix = paddle.cast(paddle.rand(x.shape) < gamma, x.dtype)
             mask_inv = F.max_pool2d(
                 matrix,
                 self.block_size,


### PR DESCRIPTION
由于paddle.rand没有fp16类型的kernel，故在使用fp16训练时会报错，此处修复此bug