### PR TITLE
Change installation order of PaddleDetection

### DIFF
--- a/docs/tutorials/INSTALL_cn.md
+++ b/docs/tutorials/INSTALL_cn.md
@@ -67,12 +67,12 @@ python -c "import paddle; print(paddle.__version__)"
 cd <path/to/clone/PaddleDetection>
 git clone https://github.com/PaddlePaddle/PaddleDetection.git
 
+# 安装其他依赖
+pip install -r requirements.txt
+
 # 编译安装paddledet
 cd PaddleDetection
 python setup.py install
-
-# 安装其他依赖
-pip install -r requirements.txt
 ```
 
 **注意**


### PR DESCRIPTION
Using original order will cause weird exception, like "RuntimeError: implement_array_function method already has a docstring", "AssertionError: PyTypeTest on non extension type"...
Enviroment: AI Studio(2.1.2)