### PR TITLE
Decode and cache

### DIFF
--- a/ppdet/data/transform/operators.py
+++ b/ppdet/data/transform/operators.py
@@ -36,6 +36,9 @@ import copy
 import logging
 import cv2
 from PIL import Image, ImageDraw
+import pickle
+import threading
+mutex = threading.Lock()
 
 from ppdet.core.workspace import serializable
 from ppdet.modeling import bbox_utils
@@ -147,6 +150,76 @@ class Decode(BaseOperator):
         sample['im_shape'] = np.array(im.shape[:2], dtype=np.float32)
         sample['scale_factor'] = np.array([1., 1.], dtype=np.float32)
         return sample
+
+
+def _make_dirs(dirname):
+    try:
+        from pathlib import Path
+    except ImportError:
+        from pathlib2 import Path
+    Path(dirname).mkdir(exist_ok=True)
+
+
+@register_op
+class DecodeCache(BaseOperator):
+    def __init__(self, cache_root=None):
+        """ Transform the image data to numpy format following the rgb format
+        """
+        super(DecodeCache, self).__init__()
+
+        self.use_cache = False if cache_root is None else True 
+        self.cache_root = cache_root
+
+        if cache_root is not None:
+            _make_dirs(cache_root)
+
+    def apply(self, sample, context=None):
+
+        if self.use_cache and os.path.exists(self.cache_path(self.cache_root, sample['im_file'])):
+            path = self.cache_path(self.cache_root, sample['im_file'])
+            with open(path, 'rb') as f:
+                im = pickle.load(f)
+
+        else:
+            if 'image' not in sample:
+                with open(sample['im_file'], 'rb') as f:
+                    sample['image'] = f.read()
+                # sample.pop('im_file')
+
+            im = sample['image']
+            data = np.frombuffer(im, dtype='uint8')
+            im = cv2.imdecode(data, 1)  # BGR mode, but need RGB mode
+            if 'keep_ori_im' in sample and sample['keep_ori_im']:
+                sample['ori_image'] = im
+            im = cv2.cvtColor(im, cv2.COLOR_BGR2RGB)
+
+            if self.use_cache and not os.path.exists(self.cache_path(self.cache_root, sample['im_file'])):
+                path = self.cache_path(self.cache_root, sample['im_file'])
+                self.dump(im, path)
+
+            sample['image'] = im
+            sample['h'] = im.shape[0]
+            sample['w'] = im.shape[1]
+
+            sample['im_shape'] = np.array(im.shape[:2], dtype=np.float32)
+            sample['scale_factor'] = np.array([1., 1.], dtype=np.float32)
+
+        return sample
+
+    @staticmethod
+    def cache_path(dir_oot, im_file):
+        return os.path.join(dir_oot, os.path.basename(im_file) + '.pkl')
+
+    @staticmethod
+    def dump(obj, path):
+        mutex.acquire()
+        try:
+            with open(path, 'wb') as f:
+                pickle.dump(obj, f)
+        except:
+            pass
+        finally:
+            mutex.release()
 
 
 @register_op

--- a/ppdet/data/transform/operators.py
+++ b/ppdet/data/transform/operators.py
@@ -39,6 +39,7 @@ from PIL import Image, ImageDraw
 import pickle
 import threading
 mutex = threading.Lock()
+import fcntl
 
 from ppdet.core.workspace import serializable
 from ppdet.modeling import bbox_utils
@@ -212,14 +213,18 @@ class DecodeCache(BaseOperator):
 
     @staticmethod
     def dump(obj, path):
-        mutex.acquire()
+        # mutex.acquire()
+        # fcntl.flock()
         try:
             with open(path, 'wb') as f:
+                fcntl.LOCK_EX(f, fcntl.LOCK_EX)
                 pickle.dump(obj, f)
+                fcntl.LOCK_EX(f, fcntl.F_UNLCK)
         except:
             pass
         finally:
-            mutex.release()
+            # mutex.release()
+            pass
 
 
 @register_op


### PR DESCRIPTION
- using cache to skip image decode
  - op `DecodeCache` will decode image and cache it on disk when first visiting
  - suggesting to decod images offline to get better performance in first epoch
  - using it when disk is large enough, meanwhile cpu is bottleneck
 
- test on m1-mac (read <.jpg, .npy, .pkl, .proto w/ 513x640x3> from disk)

![image](https://user-images.githubusercontent.com/17582080/133882183-f22c1e37-184e-4374-910e-462f392850c5.png)
