### PR TITLE
[PaddlePaddle Hackathon] Task 72 RFC: 为 PaddleDetection 添加PAA模型

### DIFF
--- a/configs/paa/_base_/optimizer_1x.yml
+++ b/configs/paa/_base_/optimizer_1x.yml
@@ -1,0 +1,19 @@
+epoch: 12
+
+LearningRate:
+  base_lr: 0.01
+  schedulers:
+  - !PiecewiseDecay
+    gamma: 0.1
+    milestones: [8, 11]
+  - !LinearWarmup
+    start_factor: 0.1
+    steps: 1000
+
+OptimizerBuilder:
+  optimizer:
+    momentum: 0.9
+    type: Momentum
+  regularizer:
+    factor: 0.0001
+    type: L2

--- a/configs/paa/_base_/paa_fpn_reader.yml
+++ b/configs/paa/_base_/paa_fpn_reader.yml
@@ -1,0 +1,40 @@
+worker_num: 2
+TrainReader:
+  sample_transforms:
+  - Decode: {}
+  - RandomResize: {target_size: [[640, 1333], [672, 1333], [704, 1333], [736, 1333], [768, 1333], [800, 1333]], interp: 2, keep_ratio: True}
+  - RandomFlip: {prob: 0.5}
+  - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
+  - Permute: {}
+  batch_transforms:
+  - PadBatch: {pad_to_stride: 32}
+  batch_size: 1
+  shuffle: true
+  drop_last: true
+  collate_batch: false
+
+
+EvalReader:
+  sample_transforms:
+  - Decode: {}
+  - Resize: {interp: 2, target_size: [800, 1333], keep_ratio: True}
+  - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
+  - Permute: {}
+  batch_transforms:
+  - PadBatch: {pad_to_stride: 32}
+  batch_size: 1
+  shuffle: false
+  drop_last: false
+
+
+TestReader:
+  sample_transforms:
+  - Decode: {}
+  - Resize: {interp: 2, target_size: [800, 1333], keep_ratio: True}
+  - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
+  - Permute: {}
+  batch_transforms:
+  - PadBatch: {pad_to_stride: 32}
+  batch_size: 1
+  shuffle: false
+  drop_last: false

--- a/configs/paa/_base_/paa_r50_fpn.yml
+++ b/configs/paa/_base_/paa_r50_fpn.yml
@@ -1,0 +1,77 @@
+architecture: PAA
+#pretrain_weights: https://paddledet.bj.bcebos.com/models/pretrained/ResNet50_cos_pretrained.pdparams
+
+PAA:
+  backbone: ResNet
+  neck: FPN
+#  rpn_head: RPNHead
+  bbox_head: PAAHead
+  # post process
+  bbox_post_process: BBoxPostProcess
+
+
+ResNet:
+  # index 0 stands for res2
+  depth: 50
+  norm_type: bn
+  freeze_at: 0
+  return_idx: [0,1,2,3]
+  num_stages: 4
+
+FPN:
+  out_channel: 256
+
+RPNHead:
+  anchor_generator:
+    aspect_ratios: [0.5, 1.0, 2.0]
+    anchor_sizes: [[32], [64], [128], [256], [512]]
+    strides: [4, 8, 16, 32, 64]
+  rpn_target_assign:
+    batch_size_per_im: 256
+    fg_fraction: 0.5
+    negative_overlap: 0.3
+    positive_overlap: 0.7
+    use_random: True
+  train_proposal:
+    min_size: 0.0
+    nms_thresh: 0.7
+    pre_nms_top_n: 2000
+    post_nms_top_n: 1000
+    topk_after_collect: True
+  test_proposal:
+    min_size: 0.0
+    nms_thresh: 0.7
+    pre_nms_top_n: 1000
+    post_nms_top_n: 1000
+
+
+PAAHead:
+  head: TwoFCHead
+  anchor_generator:
+    aspect_ratios: [ 0.5, 1.0, 2.0 ]
+    anchor_sizes: [ [ 32 ], [ 64 ], [ 128 ], [ 256 ], [ 512 ] ]
+    strides: [ 4, 8, 16, 32, 64 ]
+#  roi_extractor:
+#    resolution: 7
+#    sampling_ratio: 0
+#    aligned: True
+#  bbox_assigner: BBoxAssigner
+
+BBoxAssigner:
+  batch_size_per_im: 512
+  bg_thresh: 0.5
+  fg_thresh: 0.5
+  fg_fraction: 0.25
+  use_random: True
+
+TwoFCHead:
+  out_channel: 1024
+
+
+BBoxPostProcess:
+  decode: RCNNBox
+  nms:
+    name: MultiClassNMS
+    keep_top_k: 100
+    score_threshold: 0.05
+    nms_threshold: 0.5

--- a/configs/paa/paa_r34_fpn_1x_coco.yml
+++ b/configs/paa/paa_r34_fpn_1x_coco.yml
@@ -1,0 +1,23 @@
+_BASE_: [
+  '../datasets/coco_detection.yml',
+  '../runtime.yml',
+  '_base_/optimizer_1x.yml',
+  '_base_/paa_r50_fpn.yml',
+  '_base_/paa_fpn_reader.yml',
+]
+
+#pretrain_weights: https://paddledet.bj.bcebos.com/models/pretrained/ResNet34_pretrained.pdparams
+weights: output/paa_r34_fpn_1x_coco/model_final
+
+ResNet:
+  # index 0 stands for res2
+  depth: 34
+  norm_type: bn
+  freeze_at: 0
+  return_idx: [0,1,2,3]
+  num_stages: 4
+
+TrainReader:
+  batch_size: 2
+
+worker_num: 0

--- a/docs/rfcs/paa.md
+++ b/docs/rfcs/paa.md
@@ -1,0 +1,28 @@
+功能名称： 为 PaddleDetection 添加PAA模型
+
+GitHub Issue：[PaddleDetection#4219](https://github.com/PaddlePaddle/PaddleDetection/issues/4219)
+
+# 概述
+通过GMM来拟合anchor score的分布，再根据该GMM分布来区分anchor为正例或负例，来进行anchor的分配
+
+# 动机
+不需要人为的设置anchor正例负例与gt box的iou阈值，简化训练参数的设计并提高准确率
+
+# 流程
+
+- 首先根据featmap的尺寸构建anchors grid
+- 根据与gt box的iou阈值，第一次匹配anchor与gt box得到候选anchor集合
+- 根据上一步获得的候选anchor集合，计算anchor score: 论文的公式3
+- 在每个特征尺度级别上选择K个最高anchor score的anchor
+- 通过GMM拟合上一步所有特征尺度选择出的anchor score的分布
+- 使用该GMM来重新划分anchor正例，负例
+- 根据anchor正负例来进行bbox分类(objectness, class)的反向传播, bbox的回归以及iou分支的预测
+
+# 功能列表
+
+- 构建单阶段目标检测器 (与mmdetection的实现相同)
+- 根据与每个gt box的iou来获取候选的anchor集合
+- 为上一步获得的候选anchor集合，计算anchor score: 论文的公式3
+- 在每个特征尺度级别上选择K个最高anchor score的anchor
+- GMM拟合分布及根据分布划分样本
+- 额外的IOU预测分支

--- a/docs/rfcs/paa.md
+++ b/docs/rfcs/paa.md
@@ -26,3 +26,108 @@ GitHub Issue：[PaddleDetection#4219](https://github.com/PaddlePaddle/PaddleDete
 - 在每个特征尺度级别上选择K个最高anchor score的anchor
 - GMM拟合分布及根据分布划分样本
 - 额外的IOU预测分支
+
+
+# 概要设计
+
+- 构建单阶段目标检测器类PAA
+
+PAA包括backbone, 检测头
+
+- 构建backbone
+
+基于resnet构建backbone
+
+- 构建检测头PAAHead
+
+包括anchor generator根据backbone生成的featmap的尺寸构建anchors grid
+
+根据每个gt box与anchors的iou阈值，匹配anchor与gt box得到候选anchor集合
+
+根据正负例数量比例来采样正负例anchors (第一次匹配anchor)
+
+对第一次匹配的anchor计算anchor score: bbox的分类loss+回归loss
+
+遍历每个gt box:
+  在每个特征尺度上选择前k个anchor score最高的加入anchor样本集合
+  对所有尺度的anchor score样本集合进行GMM拟合
+  根据拟合的GMM对anchor进行新的正负例划分
+
+对最终划分的anchor进行训练
+
+- 新的IOU预测分支
+
+构建PAAFPN, 用于添加新的IOU预测分支. 因为测试时没有gt box, 也就无法计算gt box与bbox的iou, 无法继续进行后续的计算, 所以使用该IOU预测分支来预测IOU.
+
+# 详细设计
+
+- 构建单阶段目标检测器类PAA
+
+```
+class PAA(BaseArch):
+  def __init__:
+    # build backbone
+    # build PAAHead
+
+  # build detector from config file
+  def from_config
+
+  # calculate loss (mainly for traning)
+  def get_loss
+
+  # calculate prediction (mainly for inference)
+  def get_pred
+```
+
+- 检测头PAAHead
+
+```
+class PAAHead(nn.Layer):
+  # 生成anchors
+  def get_anchors()
+
+  # 根据每个gt box与anchors的iou阈值，匹配anchor与gt box, 并标记正负例
+  def label_box()
+
+  # 根据正负例数量比例来采样正负例anchors
+  def subsample_boxes()
+
+  # 计算anchor的anchor score
+  def get_anchor_score()
+
+  # 使用anchor score拟合的GMM，重新划分anchor的正负例
+  def paa_reassign():
+    #在每个特征尺度上选择前k个anchor score最高的加入anchor样本集合
+    
+    #对所有尺度的anchor score样本集合进行GMM拟合 (使用sklearn的GaussianMixture)
+    
+    #根据拟合的GMM对anchor进行新的正负例划分
+
+  # 使用GMM划分anchor正负例
+  def gmm_separation()
+```
+
+- 新的IOU预测分支
+构建PAAFPN, 用于添加新的IOU预测分支
+
+```
+class PAAFPN(nn.Layer):
+    def forward
+```
+
+# 训练和预测方法
+
+通过配置文件指定对应参数，PAAHead项指定PAAHead的参数
+
+`tools/train.py`
+
+训练
+
+`tools/eval.py`
+
+评估
+
+`tools/infer.py`
+
+测试
+

--- a/ppdet/modeling/architectures/__init__.py
+++ b/ppdet/modeling/architectures/__init__.py
@@ -23,6 +23,7 @@ from . import fairmot
 from . import centernet
 from . import detr
 from . import sparse_rcnn
+from . import paa
 
 from .meta_arch import *
 from .faster_rcnn import *

--- a/ppdet/modeling/architectures/paa.py
+++ b/ppdet/modeling/architectures/paa.py
@@ -1,0 +1,82 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import paddle
+from ppdet.core.workspace import register, create
+from .meta_arch import BaseArch
+
+__all__ = ['PAA']
+
+
+@register
+class PAA(BaseArch):
+    """
+    Args:
+        backbone (object): backbone instance
+        bbox_head (object): `BBoxHead` instance
+        bbox_post_process (object): `BBoxPostProcess` instance
+        neck (object): 'FPN' instance
+    """
+    __category__ = 'architecture'
+    __inject__ = ['bbox_post_process']
+
+    def __init__(self,
+                 backbone,
+                 bbox_head,
+                 bbox_post_process,
+                 neck=None):
+        super(PAA, self).__init__()
+        self.backbone = backbone
+        self.neck = neck
+        self.bbox_head = bbox_head
+        self.bbox_post_process = bbox_post_process
+
+    @classmethod
+    def from_config(cls, cfg, *args, **kwargs):
+        backbone = create(cfg['backbone'])
+        kwargs = {'input_shape': backbone.out_shape}
+        neck = cfg['neck'] and create(cfg['neck'], **kwargs)
+
+        out_shape = neck and neck.out_shape or backbone.out_shape
+        kwargs = {'input_shape': out_shape}
+        bbox_head = create(cfg['bbox_head'], **kwargs)
+        return {
+            'backbone': backbone,
+            'neck': neck,
+            "bbox_head": bbox_head,
+        }
+
+    def _forward(self):
+        body_feats = self.backbone(self.inputs)
+        if self.neck is not None:
+            body_feats = self.neck(body_feats)
+        if self.training:
+            bbox_loss, _ = self.bbox_head(body_feats, rois, rois_num,
+                                          self.inputs)
+            return bbox_loss
+        else:
+            preds, _ = self.bbox_head(body_feats, rois, rois_num, None)
+
+            im_shape = self.inputs['im_shape']
+            scale_factor = self.inputs['scale_factor']
+            bbox, bbox_num = self.bbox_post_process(preds,
+                                                    im_shape, scale_factor)
+
+            # rescale the prediction back to origin image
+            bbox_pred = self.bbox_post_process.get_pred(bbox, bbox_num,
+                                                        im_shape, scale_factor)
+            return bbox_pred, bbox_num
+
+    def get_loss(self, ):
+        bbox_loss = self._forward()
+        loss = {}
+        loss.update(bbox_loss)
+        total_loss = paddle.add_n(list(loss.values()))
+        loss.update({'loss': total_loss})
+        return loss
+
+    def get_pred(self):
+        bbox_pred, bbox_num = self._forward()
+        output = {'bbox': bbox_pred, 'bbox_num': bbox_num}
+        return output

--- a/ppdet/modeling/architectures/paa.py
+++ b/ppdet/modeling/architectures/paa.py
@@ -52,11 +52,10 @@ class PAA(BaseArch):
         if self.neck is not None:
             body_feats = self.neck(body_feats)
         if self.training:
-            bbox_loss, _ = self.bbox_head(body_feats, rois, rois_num,
-                                          self.inputs)
+            bbox_loss, _ = self.bbox_head(body_feats, self.inputs)
             return bbox_loss
         else:
-            preds, _ = self.bbox_head(body_feats, rois, rois_num, None)
+            preds, _ = self.bbox_head(body_feats, None)
 
             im_shape = self.inputs['im_shape']
             scale_factor = self.inputs['scale_factor']

--- a/ppdet/modeling/heads/__init__.py
+++ b/ppdet/modeling/heads/__init__.py
@@ -27,6 +27,7 @@ from . import keypoint_hrhrnet_head
 from . import centernet_head
 from . import detr_head
 from . import sparsercnn_head
+from . import paa_head
 
 from .bbox_head import *
 from .mask_head import *

--- a/ppdet/modeling/heads/paa_head.py
+++ b/ppdet/modeling/heads/paa_head.py
@@ -1,0 +1,157 @@
+import paddle
+import paddle.nn as nn
+import paddle.nn.functional as F
+from paddle.nn.initializer import Normal
+
+from ppdet.core.workspace import register
+from .. import AnchorGenerator, RPNTargetAssign
+
+
+@register
+class PAAHead(nn.Layer):
+    """
+    Region Proposal Network
+
+    Args:
+        anchor_generator (dict): configure of anchor generation
+        rpn_target_assign (dict): configure of rpn targets assignment
+        train_proposal (dict): configure of proposals generation
+            at the stage of training
+        test_proposal (dict): configure of proposals generation
+            at the stage of prediction
+        in_channel (int): channel of input feature maps which can be
+            derived by from_config
+    """
+
+    def __init__(self,
+                 anchor_generator=AnchorGenerator().__dict__,
+                 rpn_target_assign=RPNTargetAssign().__dict__,
+                 in_channel=1024,
+                 num_classes=80):
+        super(PAAHead, self).__init__()
+        self.anchor_generator = anchor_generator
+        self.rpn_target_assign = rpn_target_assign
+        if isinstance(anchor_generator, dict):
+            self.anchor_generator = AnchorGenerator(**anchor_generator)
+        if isinstance(rpn_target_assign, dict):
+            self.rpn_target_assign = RPNTargetAssign(**rpn_target_assign)
+
+        num_anchors = self.anchor_generator.num_anchors
+
+        # classification scores
+        self.cls_conv = nn.Conv2D(
+            in_channels=in_channel,
+            out_channels=num_anchors * num_classes,
+            kernel_size=1,
+            padding=0,
+            weight_attr=paddle.ParamAttr(initializer=Normal(
+                mean=0., std=0.01)))
+        self.cls_conv.skip_quant = True
+
+        # regression deltas
+        self.reg_conv = nn.Conv2D(
+            in_channels=in_channel,
+            out_channels=4 * num_anchors,
+            kernel_size=1,
+            padding=0,
+            weight_attr=paddle.ParamAttr(initializer=Normal(
+                mean=0., std=0.01)))
+        self.reg_conv.skip_quant = True
+
+    @classmethod
+    def from_config(cls, cfg, input_shape):
+        # FPN share same rpn head
+        if isinstance(input_shape, (list, tuple)):
+            input_shape = input_shape[0]
+        return {'in_channel': input_shape.channels}
+
+    def forward(self, feats, inputs):
+        scores = []
+        deltas = []
+
+        for feat in feats:
+            scores.append(self.cls_conv(feat))
+            deltas.append(self.reg_conv(feat))
+
+        anchors = self.anchor_generator(feats)
+
+        # rois, rois_num = self._gen_proposal(scores, deltas, anchors, inputs)
+        if self.training:
+            loss = self.get_loss(scores, deltas, anchors, inputs)
+            return loss
+        else:
+            return None
+
+    # only calculate score for positive targets
+    def get_anchor_score(self, anchors, scores, deltas, score_tgt, bbox_tgt):
+        pass
+
+    def get_loss(self, pred_scores, pred_deltas, anchors, inputs):
+        """
+        pred_scores (list[Tensor]): Multi-level scores prediction
+        pred_deltas (list[Tensor]): Multi-level deltas prediction
+        anchors (list[Tensor]): Multi-level anchors
+        inputs (dict): ground truth info, including im, gt_bbox, gt_score
+        """
+        anchors = [paddle.reshape(a, shape=(-1, 4)) for a in anchors]
+        anchors = paddle.concat(anchors)
+
+        scores = [
+            paddle.reshape(
+                paddle.transpose(
+                    v, perm=[0, 2, 3, 1]),
+                shape=(v.shape[0], -1, 1)) for v in pred_scores
+        ]
+        scores = paddle.concat(scores, axis=1)
+
+        deltas = [
+            paddle.reshape(
+                paddle.transpose(
+                    v, perm=[0, 2, 3, 1]),
+                shape=(v.shape[0], -1, 4)) for v in pred_deltas
+        ]
+        deltas = paddle.concat(deltas, axis=1)
+
+        score_tgt, bbox_tgt, loc_tgt, norm = self.rpn_target_assign(inputs,
+                                                                    anchors)
+
+        scores = paddle.reshape(x=scores, shape=(-1, ))
+        deltas = paddle.reshape(x=deltas, shape=(-1, 4))
+
+        score_tgt = paddle.concat(score_tgt)
+        score_tgt.stop_gradient = True
+
+        pos_mask = score_tgt == 1
+        pos_ind = paddle.nonzero(pos_mask)
+
+        valid_mask = score_tgt >= 0
+        valid_ind = paddle.nonzero(valid_mask)
+
+        # cls loss
+        if valid_ind.shape[0] == 0:
+            loss_rpn_cls = paddle.zeros([1], dtype='float32')
+        else:
+            score_pred = paddle.gather(scores, valid_ind)
+            score_label = paddle.gather(score_tgt, valid_ind).cast('float32')
+            score_label.stop_gradient = True
+            loss_rpn_cls = F.binary_cross_entropy_with_logits(
+                logit=score_pred, label=score_label, reduction="sum")
+
+        # reg loss
+        if pos_ind.shape[0] == 0:
+            loss_rpn_reg = paddle.zeros([1], dtype='float32')
+        else:
+            loc_pred = paddle.gather(deltas, pos_ind)
+            loc_tgt = paddle.concat(loc_tgt)
+            loc_tgt = paddle.gather(loc_tgt, pos_ind)
+            loc_tgt.stop_gradient = True
+            loss_rpn_reg = paddle.abs(loc_pred - loc_tgt).sum()
+
+        score_pred_pos = paddle.gather(scores, pos_ind)
+        score_label_pos = paddle.gather(score_tgt, pos_ind)
+        score = self.get_anchor_score(anchors, score_pred_pos, loc_pred, score_label_pos, loc_tgt)
+
+        return {
+            'loss_rpn_cls': loss_rpn_cls / norm,
+            'loss_rpn_reg': loss_rpn_reg / norm
+        }

--- a/ppdet/modeling/heads/paa_head.py
+++ b/ppdet/modeling/heads/paa_head.py
@@ -1,10 +1,12 @@
+import numpy as np
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 from paddle.nn.initializer import Normal
 
 from ppdet.core.workspace import register
-from .. import AnchorGenerator, RPNTargetAssign
+from ...modeling.proposal_generator.anchor_generator import AnchorGenerator
+from ...modeling.proposal_generator.target_layer import RPNTargetAssign
 
 
 @register
@@ -24,11 +26,13 @@ class PAAHead(nn.Layer):
     """
 
     def __init__(self,
+                 head,
                  anchor_generator=AnchorGenerator().__dict__,
                  rpn_target_assign=RPNTargetAssign().__dict__,
                  in_channel=1024,
                  num_classes=80):
         super(PAAHead, self).__init__()
+        self.head = head
         self.anchor_generator = anchor_generator
         self.rpn_target_assign = rpn_target_assign
         if isinstance(anchor_generator, dict):
@@ -83,8 +87,116 @@ class PAAHead(nn.Layer):
             return None
 
     # only calculate score for positive targets
-    def get_anchor_score(self, anchors, scores, deltas, score_tgt, bbox_tgt):
-        pass
+    def get_anchor_score(self, anchors, scores, bbox_pred, score_tgt, bbox_tgt):
+        loss_cls = F.binary_cross_entropy_with_logits(logit=scores, label=score_tgt, reduction="none")
+        loss_reg = paddle.abs(bbox_pred - bbox_tgt).mean(axis=-1)
+
+        return loss_cls+loss_reg
+
+    def paa_reassign(self, pos_losses, label, pos_inds, pos_gt_inds, anchors):
+        """Fit loss to GMM distribution and separate positive, ignore, negative
+        samples again with GMM model.
+
+        Args:
+            pos_losses (Tensor): Losses of all positive samples in
+                single image.
+            label (Tensor): classification target of each anchor with
+                shape (num_anchors,)
+            label_weight (Tensor): Classification loss weight of each
+                anchor with shape (num_anchors).
+            bbox_weight (Tensor): Bbox weight of each anchor with shape
+                (num_anchors, 4).
+            pos_inds (Tensor): Index of all positive samples got from
+                first assign process.
+            pos_gt_inds (Tensor): Gt_index of all positive samples got
+                from first assign process.
+            anchors (list[Tensor]): Anchors of each scale.
+
+        Returns:
+            tuple: Usually returns a tuple containing learning targets.
+
+                - label (Tensor): classification target of each anchor after
+                  paa assign, with shape (num_anchors,)
+                - label_weight (Tensor): Classification loss weight of each
+                  anchor after paa assign, with shape (num_anchors).
+                - bbox_weight (Tensor): Bbox weight of each anchor with shape
+                  (num_anchors, 4).
+                - num_pos (int): The number of positive samples after paa
+                  assign.
+        """
+        if not len(pos_inds):
+            return label, 0
+        label = label.clone()
+        num_gt = pos_gt_inds.max() + 1
+        num_level = len(anchors)
+        num_anchors_each_level = [item.size(0) for item in anchors]
+        num_anchors_each_level.insert(0, 0)
+        inds_level_interval = np.cumsum(num_anchors_each_level)
+        pos_level_mask = []
+        for i in range(num_level):
+            mask = (pos_inds >= inds_level_interval[i]) & (
+                pos_inds < inds_level_interval[i + 1])
+            pos_level_mask.append(mask)
+        pos_inds_after_paa = [label.new_tensor([])]
+        ignore_inds_after_paa = [label.new_tensor([])]
+        for gt_ind in range(num_gt):
+            pos_inds_gmm = []
+            pos_loss_gmm = []
+            gt_mask = pos_gt_inds == gt_ind
+            for level in range(num_level):
+                level_mask = pos_level_mask[level]
+                level_gt_mask = level_mask & gt_mask
+                value, topk_inds = pos_losses[level_gt_mask].topk(
+                    min(level_gt_mask.sum(), self.topk), largest=False)
+                pos_inds_gmm.append(pos_inds[level_gt_mask][topk_inds])
+                pos_loss_gmm.append(value)
+            pos_inds_gmm = torch.cat(pos_inds_gmm)
+            pos_loss_gmm = torch.cat(pos_loss_gmm)
+            # fix gmm need at least two sample
+            if len(pos_inds_gmm) < 2:
+                continue
+            device = pos_inds_gmm.device
+            pos_loss_gmm, sort_inds = pos_loss_gmm.sort()
+            pos_inds_gmm = pos_inds_gmm[sort_inds]
+            pos_loss_gmm = pos_loss_gmm.view(-1, 1).cpu().numpy()
+            min_loss, max_loss = pos_loss_gmm.min(), pos_loss_gmm.max()
+            means_init = np.array([min_loss, max_loss]).reshape(2, 1)
+            weights_init = np.array([0.5, 0.5])
+            precisions_init = np.array([1.0, 1.0]).reshape(2, 1, 1)  # full
+            if self.covariance_type == 'spherical':
+                precisions_init = precisions_init.reshape(2)
+            elif self.covariance_type == 'diag':
+                precisions_init = precisions_init.reshape(2, 1)
+            elif self.covariance_type == 'tied':
+                precisions_init = np.array([[1.0]])
+            if skm is None:
+                raise ImportError('Please run "pip install sklearn" '
+                                  'to install sklearn first.')
+            gmm = skm.GaussianMixture(
+                2,
+                weights_init=weights_init,
+                means_init=means_init,
+                precisions_init=precisions_init,
+                covariance_type=self.covariance_type)
+            gmm.fit(pos_loss_gmm)
+            gmm_assignment = gmm.predict(pos_loss_gmm)
+            scores = gmm.score_samples(pos_loss_gmm)
+            gmm_assignment = torch.from_numpy(gmm_assignment).to(device)
+            scores = torch.from_numpy(scores).to(device)
+
+            pos_inds_temp, ignore_inds_temp = self.gmm_separation_scheme(
+                gmm_assignment, scores, pos_inds_gmm)
+            pos_inds_after_paa.append(pos_inds_temp)
+            ignore_inds_after_paa.append(ignore_inds_temp)
+
+        pos_inds_after_paa = torch.cat(pos_inds_after_paa)
+        ignore_inds_after_paa = torch.cat(ignore_inds_after_paa)
+        reassign_mask = (pos_inds.unsqueeze(1) != pos_inds_after_paa).all(1)
+        reassign_ids = pos_inds[reassign_mask]
+        label[reassign_ids] = self.num_classes
+        num_pos = len(pos_inds_after_paa)
+        return label, num_pos
+
 
     def get_loss(self, pred_scores, pred_deltas, anchors, inputs):
         """
@@ -93,8 +205,8 @@ class PAAHead(nn.Layer):
         anchors (list[Tensor]): Multi-level anchors
         inputs (dict): ground truth info, including im, gt_bbox, gt_score
         """
-        anchors = [paddle.reshape(a, shape=(-1, 4)) for a in anchors]
-        anchors = paddle.concat(anchors)
+        multi_level_anchors = [paddle.reshape(a, shape=(-1, 4)) for a in anchors]
+        anchors = paddle.concat(multi_level_anchors)
 
         scores = [
             paddle.reshape(
@@ -134,8 +246,8 @@ class PAAHead(nn.Layer):
             score_pred = paddle.gather(scores, valid_ind)
             score_label = paddle.gather(score_tgt, valid_ind).cast('float32')
             score_label.stop_gradient = True
-            loss_rpn_cls = F.binary_cross_entropy_with_logits(
-                logit=score_pred, label=score_label, reduction="sum")
+            # loss_rpn_cls = F.binary_cross_entropy_with_logits(
+            #     logit=score_pred, label=score_label, reduction="sum")
 
         # reg loss
         if pos_ind.shape[0] == 0:
@@ -145,11 +257,14 @@ class PAAHead(nn.Layer):
             loc_tgt = paddle.concat(loc_tgt)
             loc_tgt = paddle.gather(loc_tgt, pos_ind)
             loc_tgt.stop_gradient = True
-            loss_rpn_reg = paddle.abs(loc_pred - loc_tgt).sum()
+            # loss_rpn_reg = paddle.abs(loc_pred - loc_tgt).sum()
 
         score_pred_pos = paddle.gather(scores, pos_ind)
-        score_label_pos = paddle.gather(score_tgt, pos_ind)
+        score_label_pos = paddle.gather(score_tgt, pos_ind).cast('float32')
+
         score = self.get_anchor_score(anchors, score_pred_pos, loc_pred, score_label_pos, loc_tgt)
+
+        self.paa_reassign(score, score_label, pos_ind, )
 
         return {
             'loss_rpn_cls': loss_rpn_cls / norm,


### PR DESCRIPTION
**PR types**

RFC

**PR changes**

documentation (rfc files)

**Describe**

功能名称： 为 PaddleDetection 添加PAA模型

GitHub Issue：[PaddleDetection#4219](https://github.com/PaddlePaddle/PaddleDetection/issues/4219)

# 概述
通过GMM来拟合anchor score的分布，再根据该GMM分布来区分anchor为正例或负例，来进行anchor的分配

# 动机
不需要人为的设置anchor正例负例与gt box的iou阈值，简化训练参数的设计并提高准确率

# 流程

- 首先根据featmap的尺寸构建anchors grid
- 根据与gt box的iou阈值，第一次匹配anchor与gt box得到候选anchor集合
- 根据上一步获得的候选anchor集合，计算anchor score: 论文的公式3
- 在每个特征尺度级别上选择K个最高anchor score的anchor
- 通过GMM拟合上一步所有特征尺度选择出的anchor score的分布
- 使用该GMM来重新划分anchor正例，负例
- 根据anchor正负例来进行bbox分类(objectness, class)的反向传播, bbox的回归以及iou分支的预测

# 功能列表

- 构建单阶段目标检测器 (与mmdetection的实现相同)
- 根据与每个gt box的iou来获取候选的anchor集合
- 为上一步获得的候选anchor集合，计算anchor score: 论文的公式3
- 在每个特征尺度级别上选择K个最高anchor score的anchor
- GMM拟合分布及根据分布划分样本
- 额外的IOU预测分支
