### PR TITLE
fix trt inference error in lite_hrnet

### DIFF
--- a/ppdet/modeling/backbones/lite_hrnet.py
+++ b/ppdet/modeling/backbones/lite_hrnet.py
@@ -651,7 +651,9 @@ class LiteHRNetModule(nn.Layer):
             for i in range(len(self.fuse_layers)):
                 y = out[0] if i == 0 else self.fuse_layers[i][0](out[0])
                 for j in range(self.num_branches):
-                    if i == j:
+                    if j == 0:
+                        y += y
+                    elif i == j:
                         y += out[j]
                     else:
                         y += self.fuse_layers[i][j](out[j])


### PR DESCRIPTION
Fix litehrnet tensorRT inference error. The precision of trained models are not affected.