### PR TITLE
add implementation for flow_statistics

### DIFF
--- a/deploy/pptracking/include/pipeline.h
+++ b/deploy/pptracking/include/pipeline.h
@@ -86,7 +86,8 @@ class Pipeline {
                     cv::Mat out_img, std::vector<std::string>& records,
                     std::set<int>& count_set, std::set<int>& interval_count_set,
                     std::vector<int>& in_count_list, std::vector<int>& out_count_list,
-                    std::map<int, std::vector<float>>& prev_center);
+                    std::map<int, std::vector<float>>& prev_center,
+                    std::vector<std::string>& flow_records);
   void RunMTMCTStream(const std::vector<cv::Mat> imgs, std::vector<std::string>& records);
 
   void PrintBenchmarkLog(std::vector<double> det_time, int img_num);

--- a/deploy/pptracking/include/pipeline.h
+++ b/deploy/pptracking/include/pipeline.h
@@ -50,7 +50,8 @@ class Pipeline {
                   const bool save_result=false,
                   const std::string& scene="pedestrian",
                   const bool tiny_obj=false,
-                  const bool is_mtmct=false) {
+                  const bool is_mtmct=false,
+                  const int secs_interval=10) {
     std::vector<std::string> input;
     this->input_ = input;
     this->device_ = device;
@@ -62,6 +63,7 @@ class Pipeline {
     this->cpu_threads_ = cpu_threads;
     this->trt_calib_mode_ = trt_calib_mode;
     this->count_ = count;
+    this->secs_interval_ = secs_interval_;
     this->save_result_ = save_result;
     SelectModel(scene, tiny_obj, is_mtmct);
     InitPredictor();
@@ -79,7 +81,12 @@ class Pipeline {
   void PredictMTMCT(const std::vector<std::string> video_inputs);
 
   // Run pipeline in stream
-  void RunMOTStream(const cv::Mat img, const int frame_id, cv::Mat out_img, std::vector<std::string>& records, std::vector<int>& count_list, std::vector<int>& in_count_list, std::vector<int>& out_count_list);
+  void RunMOTStream(const cv::Mat img, const int frame_id,
+                    const int video_fps, const Rect entrance,
+                    cv::Mat out_img, std::vector<std::string>& records,
+                    std::set<int>& count_set, std::set<int>& interval_count_set,
+                    std::vector<int>& in_count_list, std::vector<int>& out_count_list,
+                    std::map<int, std::vector<float>>& prev_center);
   void RunMTMCTStream(const std::vector<cv::Mat> imgs, std::vector<std::string>& records);
 
   void PrintBenchmarkLog(std::vector<double> det_time, int img_num);
@@ -109,6 +116,7 @@ class Pipeline {
   bool trt_calib_mode_ = false;
   bool count_ = false;
   bool save_result_ = false;
+  int secs_interval_ = 10;
 };
 
 } // namespace PaddleDetection

--- a/deploy/pptracking/include/pipeline.h
+++ b/deploy/pptracking/include/pipeline.h
@@ -53,7 +53,7 @@ class Pipeline {
                     const std::string& scene = "pedestrian",
                     const bool tiny_obj = false,
                     const bool is_mtmct = false,
-                    const int secs_interval=10) {
+                    const int secs_interval = 10) {
     std::vector<std::string> input;
     this->input_ = input;
     this->device_ = device;

--- a/deploy/pptracking/include/postprocess.h
+++ b/deploy/pptracking/include/postprocess.h
@@ -25,6 +25,7 @@
 #include <opencv2/highgui/highgui.hpp>
 
 #include "include/utils.h"
+#include "include/config_parser.h"
 
 namespace PaddleDetection {
 
@@ -38,9 +39,13 @@ cv::Mat VisualizeTrackResult(const cv::Mat& img,
 
 // Pedestrian/Vehicle Counting
 void FlowStatistic(const MOTResult& results, const int frame_id,
-                   std::vector<int>* count_list, 
-                   std::vector<int>* in_count_list, 
-                   std::vector<int>* out_count_list);
+                   const int secs_interval, const int video_fps,
+                   const Rect entrance, const std::string output_dir,
+                   std::set<int>* count_set,
+                   std::set<int>* interval_count_set,
+                   std::vector<int>* in_count_list,
+                   std::vector<int>* out_count_list,
+                   std::map<int, std::vector<float>>* prev_center);
 
 // Save Tracking Results
 void SaveMOTResult(const MOTResult& results, const int frame_id, std::vector<std::string>& records);

--- a/deploy/pptracking/include/postprocess.h
+++ b/deploy/pptracking/include/postprocess.h
@@ -25,7 +25,6 @@
 #include <opencv2/highgui/highgui.hpp>
 
 #include "include/utils.h"
-#include "include/config_parser.h"
 
 namespace PaddleDetection {
 
@@ -39,13 +38,14 @@ cv::Mat VisualizeTrackResult(const cv::Mat& img,
 
 // Pedestrian/Vehicle Counting
 void FlowStatistic(const MOTResult& results, const int frame_id,
-                   const int secs_interval, const int video_fps,
-                   const Rect entrance, const std::string output_dir,
+                   const int secs_interval, const bool count,
+                   const int video_fps, const Rect entrance,
                    std::set<int>* count_set,
                    std::set<int>* interval_count_set,
                    std::vector<int>* in_count_list,
                    std::vector<int>* out_count_list,
-                   std::map<int, std::vector<float>>* prev_center);
+                   std::map<int, std::vector<float>>* prev_center,
+                   std::vector<std::string>* records);
 
 // Save Tracking Results
 void SaveMOTResult(const MOTResult& results, const int frame_id, std::vector<std::string>& records);

--- a/deploy/pptracking/src/main.cc
+++ b/deploy/pptracking/src/main.cc
@@ -47,6 +47,7 @@ DEFINE_int32(cpu_threads, 1, "Num of threads with CPU");
 DEFINE_bool(trt_calib_mode, false, "If the model is produced by TRT offline quantitative calibration, trt_calib_mode need to set True");
 DEFINE_bool(tiny_obj, false, "Whether tracking tiny object");
 DEFINE_bool(count, false, "Whether counting after tracking");
+DEFINE_int32(secs_interval, 10, "The seconds interval to count after tracking");
 DEFINE_bool(save_result, false, "Whether saving result after tracking");
 DEFINE_string(scene, "", "scene of tracking system, it can be : pedestrian/vehicle/multiclass");
 DEFINE_bool(is_mtmct, false, "Whether use multi-target multi-camera tracking");
@@ -121,7 +122,7 @@ int main(int argc, char** argv) {
                     FLAGS_output_dir, FLAGS_run_mode, FLAGS_gpu_id, 
                     FLAGS_use_mkldnn, FLAGS_cpu_threads, FLAGS_trt_calib_mode,
                     FLAGS_count, FLAGS_save_result, FLAGS_scene, FLAGS_tiny_obj, 
-                    FLAGS_is_mtmct);
+                    FLAGS_is_mtmct, FLAGS_secs_interval);
 
   pipeline.SetInput(FLAGS_video_file);
   if (!FLAGS_video_other_file.empty()) {

--- a/deploy/pptracking/src/main.cc
+++ b/deploy/pptracking/src/main.cc
@@ -46,7 +46,7 @@ DEFINE_bool(use_mkldnn, false, "Whether use mkldnn with CPU");
 DEFINE_int32(cpu_threads, 1, "Num of threads with CPU");
 DEFINE_bool(trt_calib_mode, false, "If the model is produced by TRT offline quantitative calibration, trt_calib_mode need to set True");
 DEFINE_bool(tiny_obj, false, "Whether tracking tiny object");
-DEFINE_bool(count, false, "Whether counting after tracking");
+DEFINE_bool(count, false, "Whether counting in and out numbers after tracking");
 DEFINE_int32(secs_interval, 10, "The seconds interval to count after tracking");
 DEFINE_bool(save_result, false, "Whether saving result after tracking");
 DEFINE_string(scene, "", "scene of tracking system, it can be : pedestrian/vehicle/multiclass");

--- a/deploy/pptracking/src/pipeline.cc
+++ b/deploy/pptracking/src/pipeline.cc
@@ -18,6 +18,7 @@
 #include <iomanip>
 #include <iostream>
 #include <string>
+
 #include "include/pipeline.h"
 #include "include/postprocess.h"
 #include "include/predictor.h"
@@ -164,8 +165,9 @@ void Pipeline::PredictMOT(const std::string& video_path) {
   std::vector<int> in_count_list;
   std::vector<int> out_count_list;
   std::map<int, std::vector<float>> prev_center;
-  Rect entrance = {
-    0, float(video_height) / 2, float(video_width), float(video_height) / 2};
+  Rect entrance = {0, static_cast<float>(video_height) / 2,
+                   static_cast<float>(video_width),
+                   static_cast<float>(video_height) / 2};
   double times;
   double total_time;
   // Capture all frames and do inference
@@ -192,11 +194,11 @@ void Pipeline::PredictMOT(const std::string& video_path) {
               << " predict time(s): " << total_time / 1000;
 
     cv::Mat out_img = PaddleDetection::VisualizeTrackResult(
-        frame, result, 1000./times, frame_id);
+        frame, result, 1000. / times, frame_id);
     PaddleDetection::FlowStatistic(
-      result, frame_id, secs_interval_, count_, video_fps, entrance,
-      &count_set, &interval_count_set, &in_count_list, &out_count_list,
-      &prev_center, &flow_records);
+        result, frame_id, secs_interval_, count_, video_fps, entrance,
+        &count_set, &interval_count_set, &in_count_list, &out_count_list,
+        &prev_center, &flow_records);
 
     if (save_result_) {
       PaddleDetection::SaveMOTResult(result, frame_id, &records);
@@ -226,11 +228,11 @@ void Pipeline::PredictMOT(const std::string& video_path) {
     LOG(INFO) << "txt result output saved as " << result_output_path.c_str();
 
     result_output_path = output_dir_ + OS_PATH_SEP + "flow_statistic.txt";
-    if((fp = fopen(result_output_path.c_str(), "w+")) == NULL) {
+    if ((fp = fopen(result_output_path.c_str(), "w+")) == NULL) {
       printf("Open %s error.\n", result_output_path);
       return;
     }
-    
+
     for (int l; l < flow_records.size(); ++l) {
       fprintf(fp, flow_records[l].c_str());
     }
@@ -270,15 +272,15 @@ void Pipeline::RunMOTStream(const cv::Mat img,
   LOG(INFO) << "frame_id: " << frame_id
             << " predict time(s): " << total_time / 1000;
 
-  out_img = PaddleDetection::VisualizeTrackResult(
-      img, result, 1000. / times, frame_id);
+  out_img = PaddleDetection::VisualizeTrackResult(img, result, 1000. / times,
+                                                  frame_id);
 
-  // Count total number 
+  // Count total number
   // Count in & out number
-  PaddleDetection::FlowStatistic(
-    result, frame_id, secs_interval_, count_, video_fps, entrance,
-    count_set, interval_count_set, in_count_list, out_count_list,
-    prev_center, flow_records);
+  PaddleDetection::FlowStatistic(result, frame_id, secs_interval_, count_,
+                                 video_fps, entrance, count_set,
+                                 interval_count_set, in_count_list,
+                                 out_count_list, prev_center, flow_records);
 
   PrintBenchmarkLog(det_times, frame_id);
   if (save_result_) {
@@ -323,4 +325,4 @@ void Pipeline::PrintBenchmarkLog(const std::vector<double> det_time,
             << ", postprocess_time(ms): " << det_time[2] / num;
 }
 
-}  // namespace PaddleDetection
+} // namespace PaddleDetection

--- a/deploy/pptracking/src/postprocess.cc
+++ b/deploy/pptracking/src/postprocess.cc
@@ -98,38 +98,47 @@ cv::Mat VisualizeTrackResult(const cv::Mat& img,
 }
 
 void FlowStatistic(const MOTResult& results, const int frame_id,
-                   const int secs_interval, const int video_fps,
-                   const Rect entrance, const std::string output_dir,
+                   const int secs_interval, const bool count,
+                   const int video_fps, const Rect entrance, 
                    std::set<int>* count_set,
                    std::set<int>* interval_count_set, 
                    std::vector<int>* in_count_list, 
                    std::vector<int>* out_count_list,
-                   std::map<int, std::vector<float>>* prev_center) {
-  if (frame_id == 0) {
+                   std::map<int, std::vector<float>>* prev_center,
+                   std::vector<std::string>* records) {
+  if (frame_id == 0)
     interval_count_set->clear();
-  }
   
-  // Count in and out number
-  // Use horizontal center line as the entrance just for simplification
-  float entrance_y = entrance.top; 
-  for (const auto& result : results) {
-    float center_x = (result.rects.left + result.rects.right) / 2;
-    float center_y = (result.rects.top + result.rects.bottom) / 2;
-    int ids = result.ids;
-    std::map<int, std::vector<float>>::iterator iter;  
-    iter = prev_center->find(ids);
-    if (iter != prev_center->end()) {
-      if (iter->second[1] <= entrance_y && center_y > entrance_y) {
-        in_count_list->push_back(ids);
+  if (count) {
+    // Count in and out number: 
+    // Use horizontal center line as the entrance just for simplification.
+    // If a person located in the above the horizontal center line 
+    // at the previous frame and is in the below the line at the current frame,
+    // the in number is increased by one.
+    // If a person was in the below the horizontal center line 
+    // at the previous frame and locates in the below the line at the current frame,
+    // the out number is increased by one.
+    
+    float entrance_y = entrance.top; 
+    for (const auto& result : results) {
+      float center_x = (result.rects.left + result.rects.right) / 2;
+      float center_y = (result.rects.top + result.rects.bottom) / 2;
+      int ids = result.ids;
+      std::map<int, std::vector<float>>::iterator iter;  
+      iter = prev_center->find(ids);
+      if (iter != prev_center->end()) {
+        if (iter->second[1] <= entrance_y && center_y > entrance_y) {
+          in_count_list->push_back(ids);
+        }
+        if (iter->second[1] >= entrance_y && center_y < entrance_y) {
+          out_count_list->push_back(ids);
+        }
+        (*prev_center)[ids][0] = center_x;
+        (*prev_center)[ids][1] = center_y;
+      } else {
+        prev_center->insert(
+          std::pair<int, std::vector<float>>(ids, {center_x, center_y}));
       }
-      if (iter->second[1] >= entrance_y && center_y < entrance_y) {
-        out_count_list->push_back(ids);
-      }
-      (*prev_center)[ids][0] = center_x;
-      (*prev_center)[ids][1] = center_y;
-    } else {
-      prev_center->insert(
-        std::pair<int, std::vector<float>>(ids, {center_x, center_y}));
     }
   }
 
@@ -139,35 +148,26 @@ void FlowStatistic(const MOTResult& results, const int frame_id,
     interval_count_set->insert(result.ids);
   }
 
-  printf("Frame id: %d, Total count: %d, In count: %d, Out count: %d",
-    frame_id, count_set->size(), in_count_list->size(), out_count_list->size());
+  std::ostringstream os;
+  os << "Frame id: " << frame_id
+     << ", Total count: " << count_set->size();
+  if (count) {
+    os << ", In count: " << in_count_list->size()
+       << ", Out count: " << out_count_list->size();
+  }
+
   // Reset counting at the interval beginning
   int curr_interval_count = -1;
   if (frame_id % video_fps == 0 && frame_id / video_fps % secs_interval == 0) {
     curr_interval_count = interval_count_set->size();
-    printf(", Count during %d secs: %d\n", secs_interval, curr_interval_count);
+    os << ", Count during " << secs_interval
+       << " secs: " << curr_interval_count;
     interval_count_set->clear();
   }
-  printf("\n");
-
-  FILE * fp;
-  std::string result_output_path = output_dir + OS_PATH_SEP + "flow_statistic.txt";
-  std::string file_mode = "w+";
-  if (frame_id > 2)
-    file_mode = "a";
-  if((fp = fopen(result_output_path.c_str(), file_mode.c_str())) == NULL) {
-    printf("Open %s error.\n", result_output_path);
-    return;
-  }
-  
-  fprintf(fp, "Frame id: %d, Total count: %d, In count: %d, Out count: %d",
-    frame_id, count_set->size(), in_count_list->size(), out_count_list->size());
-  // Note: if the input video duration is small than the interval.
-  // printf will not be done.
-  if (curr_interval_count > -1)
-    fprintf(fp, ", Count during %d secs: %d", secs_interval, curr_interval_count);
-  fprintf(fp, "\n");
-  fclose(fp);
+  os << "\n";
+  std::string record = os.str();
+  records->push_back(record);
+  std::cout << record;
 }
 
 void SaveMOTResult(const MOTResult& results, const int frame_id, std::vector<std::string>& records) {

--- a/deploy/pptracking/src/postprocess.cc
+++ b/deploy/pptracking/src/postprocess.cc
@@ -100,9 +100,12 @@ cv::Mat VisualizeTrackResult(const cv::Mat& img,
   return vis_img;
 }
 
-void FlowStatistic(const MOTResult& results, const int frame_id,
-                   const int secs_interval, const bool count,
-                   const int video_fps, const Rect entrance, 
+void FlowStatistic(const MOTResult& results,
+                   const int frame_id,
+                   const int secs_interval,
+                   const bool count,
+                   const int video_fps,
+                   const Rect entrance, 
                    std::set<int>* count_set,
                    std::set<int>* interval_count_set, 
                    std::vector<int>* in_count_list, 


### PR DESCRIPTION
At each frame, count the following data from the the beginning to current frame:
* the number of identifiers 
* the number of identifiers across the horizontal center line in a top to down manner
* the number of identifiers across the horizontal center line in a down to top manner

At a manual-set interval (unit: seconds), count the number of identifiers from the the beginning to end frame.