### PR TITLE
Reorder installation steps for paddledet in docs/tutorials/INSTALL.md

### DIFF
--- a/docs/tutorials/INSTALL.md
+++ b/docs/tutorials/INSTALL.md
@@ -77,12 +77,12 @@ python -c "import paddle; print(paddle.__version__)"
 cd <path/to/clone/PaddleDetection>
 git clone https://github.com/PaddlePaddle/PaddleDetection.git
 
-# Compile and install paddledet
-cd PaddleDetection
-python setup.py install
-
 # Install other dependencies
+cd PaddleDetection
 pip install -r requirements.txt
+
+# Compile and install paddledet
+python setup.py install
 
 ```
 
@@ -103,9 +103,9 @@ python ppdet/modeling/tests/test_architectures.py
 If the tests are passed, the following information will be prompted:
 
 ```
-.....
+.......
 ----------------------------------------------------------------------
-Ran 5 tests in 4.280s
+Ran 7 tests in 12.816s
 OK
 ```
 

--- a/docs/tutorials/INSTALL_cn.md
+++ b/docs/tutorials/INSTALL_cn.md
@@ -70,10 +70,10 @@ cd <path/to/clone/PaddleDetection>
 git clone https://github.com/PaddlePaddle/PaddleDetection.git
 
 # 安装其他依赖
+cd PaddleDetection
 pip install -r requirements.txt
 
 # 编译安装paddledet
-cd PaddleDetection
 python setup.py install
 ```
 
@@ -96,9 +96,9 @@ python ppdet/modeling/tests/test_architectures.py
 测试通过后会提示如下信息：
 
 ```
-.....
+.......
 ----------------------------------------------------------------------
-Ran 5 tests in 4.280s
+Ran 7 tests in 12.816s
 OK
 ```
 


### PR DESCRIPTION
This fixes the dependency problem with shellcheck_py docs/tutorials/INSTALL

"UnicodeDecodeError: 'utf-8' codec can't decode byte 0xfb in position 41: invalid start byte in scripts/shellcheck file at path: /usr/local/lib/python3.7/dist-packages/shellcheck_py-0.7.2.1-py3.7-linux-x86_64.egg/EGG-INFO/scripts/shellcheck"

See [JensenGao](https://github.com/PaddlePaddle/PaddleDetection/issues/2797#issuecomment-881294837)'s answer