### PR TITLE
default fusenorm to False in export model

### DIFF
--- a/configs/keypoint/tiny_pose/keypoint/tinypose_128x96.yml
+++ b/configs/keypoint/tiny_pose/keypoint/tinypose_128x96.yml
@@ -144,4 +144,4 @@ TestReader:
         is_scale: true
     - Permute: {}
   batch_size: 1
-  fuse_normalize: true
+  fuse_normalize: false

--- a/configs/keypoint/tiny_pose/keypoint/tinypose_256x192.yml
+++ b/configs/keypoint/tiny_pose/keypoint/tinypose_256x192.yml
@@ -144,4 +144,4 @@ TestReader:
         is_scale: true
     - Permute: {}
   batch_size: 1
-  fuse_normalize: true
+  fuse_normalize: false


### PR DESCRIPTION
由于目前非lite infer未适配fuse_normalize选项，开启fuse_normalize导出的模型会报错，将默认fuse_normalize置为false。后续更新文档中补充lite开启fuse_normalize加速的操作方式和加速说明。