### PR TITLE
[PaddlePaddle Hackathon] Task 71: Mask-RCNN compression

### DIFF
--- a/configs/mask_rcnn/mask_rcnn_r50_1x_coco.yml
+++ b/configs/mask_rcnn/mask_rcnn_r50_1x_coco.yml
@@ -6,3 +6,26 @@ _BASE_: [
   '_base_/mask_reader.yml',
 ]
 weights: output/mask_rcnn_r50_1x_coco/model_final
+
+epoch: 5
+
+LearningRate:
+  base_lr: 0.001
+  schedulers:
+  - !PiecewiseDecay
+    gamma: 0.1
+    milestones: [3,]
+  - !LinearWarmup
+    start_factor: 0.001
+    steps: 1
+
+OptimizerBuilder:
+  clip_grad_by_norm: 0.1
+  optimizer:
+    momentum: 0.9
+    type: Momentum
+  regularizer:
+    factor: 0
+    type: L2
+
+worker_num: 0

--- a/configs/slim/prune/mask_rcnn_r50_prune_fpgm.yml
+++ b/configs/slim/prune/mask_rcnn_r50_prune_fpgm.yml
@@ -1,0 +1,19 @@
+pretrain_weights: https://paddledet.bj.bcebos.com/models/mask_rcnn_r50_1x_coco.pdparams
+slim: Pruner
+
+Pruner:
+  criterion: fpgm
+  pruned_params: ['conv2d_27.w_0', 'conv2d_28.w_0', 'conv2d_29.w_0',
+                  'conv2d_30.w_0', 'conv2d_31.w_0', 'conv2d_32.w_0',
+                  'conv2d_33.w_0', 'conv2d_34.w_0', 'conv2d_35.w_0',
+                  'conv2d_36.w_0', 'conv2d_37.w_0', 'conv2d_38.w_0',
+                  'conv2d_39.w_0', 'conv2d_40.w_0', 'conv2d_41.w_0',
+                  'conv2d_42.w_0', 'conv2d_43.w_0', 'conv2d_44.w_0',
+                  'conv2d_45.w_0', 'conv2d_47.w_0',
+                  'conv2d_48.w_0', 'conv2d_49.w_0', 'conv2d_50.w_0',
+                  'conv2d_51.w_0', 'conv2d_52.w_0']
+  pruned_ratios: [0.1,0.2,0.2,0.2,0.2,0.1,0.2,0.3,0.3,0.3,0.2,0.1,0.3,0.4,0.4,0.4,0.4,0.3,0.4,0.4,0.4,0.4,0.4,0.4,0.4]
+  print_params: False
+
+
+


### PR DESCRIPTION
**PR types**

New features

**PR changes**

APIs

**Describe**

Hi,

This PR add pruning for Mask-RCNN.

The new pruning configuration file is located at _configs/slim/prune/mask_rcnn_r50_prune_fpgm.yml_.

The model parameters count ratio after pruning is 0.8.

For improving training, 5 epoches (learning rate will be decreased by 10 times at epoch 3) are used and learning rate is 1/10 of original learning rate. And weight decay is set to 0 according to this post: https://docs.nvidia.com/tao/tao-toolkit/text/instance_segmentation/mask_rcnn.html#pruning-the-model.



Test result at epoch 3

    Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.320
    Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.506
    Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.338
    Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.171
    Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.364
    Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.417
    Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.291
    Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.459
    Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.479
    Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.272
    Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.537
    Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.620