### PR TITLE
fix warmup+decay LR

### DIFF
--- a/ppdet/optimizer.py
+++ b/ppdet/optimizer.py
@@ -56,11 +56,13 @@ class CosineDecay(object):
         max_iters = self.max_epochs * int(step_per_epoch)
 
         if boundary is not None and value is not None and self.use_warmup:
+            warmup_iters = len(boundary)
             for i in range(int(boundary[-1]), max_iters):
                 boundary.append(i)
 
-                decayed_lr = base_lr * 0.5 * (
-                    math.cos(i * math.pi / max_iters) + 1)
+                decayed_lr = base_lr * 0.5 * (math.cos(
+                    (i - warmup_iters) * math.pi /
+                    (max_iters - warmup_iters)) + 1)
                 value.append(decayed_lr)
             return optimizer.lr.PiecewiseDecay(boundary, value)
 


### PR DESCRIPTION
fix a bug in warmup+decay LRScheduler:

Assume we are training on the following configs:
total_iters = 10
warmup_iters = 5
cosinedecay_iters=5
start_lr = 1.0
warmup_factor = 1.0
end_lr = 0.0

before bug-fixed: the lr is: [1.0, 1.0, 1.0, 1.0, 1.0, 0.5, ..., 0.0]
after bug-fixed: the lr is: [1.0, 1.0, 1.0, 1.0, 1.0, 0.9xxx, ..., 0.0]

where the '...' stands for the values following the cosine decay function. The only difference is 0.5 vs. 0.9xxx, which is the starting value. So basically, I made it correct by setting a smooth connection between warmup and cosine decays