### PR TITLE
fix rcnn export

### DIFF
--- a/ppdet/modeling/post_process.py
+++ b/ppdet/modeling/post_process.py
@@ -42,10 +42,6 @@ class BBoxPostProcess(nn.Layer):
         self.num_classes = num_classes
         self.decode = decode
         self.nms = nms
-        self.fake_bboxes = paddle.to_tensor(
-            np.array(
-                [[-1, 0.0, 0.0, 0.0, 0.0, 0.0]], dtype='float32'))
-        self.fake_bbox_num = paddle.to_tensor(np.array([1], dtype='int32'))
 
     def forward(self, head_out, rois, im_shape, scale_factor):
         """
@@ -94,11 +90,16 @@ class BBoxPostProcess(nn.Layer):
         bboxes_list = []
         bbox_num_list = []
         id_start = 0
+        fake_bboxes = paddle.to_tensor(
+            np.array(
+                [[-1, 0.0, 0.0, 0.0, 0.0, 0.0]], dtype='float32'))
+        fake_bbox_num = paddle.to_tensor(np.array([1], dtype='int32'))
+
         # add fake bbox when output is empty for each batch
         for i in range(bbox_num.shape[0]):
             if bbox_num[i] == 0:
-                bboxes_i = self.fake_bboxes
-                bbox_num_i = self.fake_bbox_num
+                bboxes_i = fake_bboxes
+                bbox_num_i = fake_bbox_num
                 id_start += 1
             else:
                 bboxes_i = bboxes[id_start:id_start + bbox_num[i], :]


### PR DESCRIPTION
由于Paddle框架升级https://github.com/PaddlePaddle/Paddle/pull/37888 ，导致rcnn后处理方式无法正常导出，
目前更新rcnn后处理写法，后续框架会做升级适配。