### PR TITLE
swin shift window

### DIFF
--- a/ppdet/modeling/backbones/swin_transformer.py
+++ b/ppdet/modeling/backbones/swin_transformer.py
@@ -493,8 +493,13 @@ class BasicLayer(nn.Layer):
         cnt = 0
         for h in h_slices:
             for w in w_slices:
-                img_mask[:, h, w, :] = cnt
+                try:
+                    img_mask[:, h, w, :] = cnt
+                except:
+                    pass
+
                 cnt += 1
+
         mask_windows = window_partition(
             img_mask, self.window_size)  # nW, window_size, window_size, 1
         mask_windows = mask_windows.reshape(


### PR DESCRIPTION
- handle paddle slice  problem

```
a = paddle.rand([1, 7, 7, 3])
a[:, 0: -7, 0: -7, :]
```