### PR TITLE
fix no label training in bs=2

### DIFF
--- a/ppdet/modeling/proposal_generator/target.py
+++ b/ppdet/modeling/proposal_generator/target.py
@@ -50,8 +50,8 @@ def rpn_anchor_target(anchors,
             labels = paddle.scatter(labels, fg_inds, paddle.ones_like(fg_inds))
         # Step3: make output  
         if gt_bbox.shape[0] == 0:
-            matched_gt_boxes = paddle.zeros([0, 4])
-            tgt_delta = paddle.zeros([0, 4])
+            matched_gt_boxes = paddle.zeros([matches.shape[0], 4])
+            tgt_delta = paddle.zeros([matches.shape[0], 4])
         else:
             matched_gt_boxes = paddle.gather(gt_bbox, matches)
             tgt_delta = bbox2delta(anchors, matched_gt_boxes, weights)


### PR DESCRIPTION
Fix the bug: If gt box is empty when bs=2, RPN module will generate empty regression target and nonempty classification target. At the stage of RPN loss, positive sample will be computed by classification target which will not be corresponding to regression target.

Solution: Add fake regression target with the same shape of classification target in RPN module when gt box is empty.