### PR TITLE
Update test_architectures.py

### DIFF
--- a/ppdet/modeling/tests/test_architectures.py
+++ b/ppdet/modeling/tests/test_architectures.py
@@ -16,6 +16,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
+import sys
+# add python path of PadleDetection to sys.path
+parent_path = os.path.abspath(os.path.join(__file__, *(['..'] * 4)))
+sys.path.insert(0, parent_path)
+
 import unittest
 import ppdet
 


### PR DESCRIPTION
fix issue when executing

Traceback (most recent call last):
  File "ppdet/modeling/tests/test_architectures.py", line 26, in <module>
    import ppdet
ModuleNotFoundError: No module named 'ppdet'