### PR TITLE
Fix download.py when train2017.zip exists

### DIFF
--- a/ppdet/utils/download.py
+++ b/ppdet/utils/download.py
@@ -387,7 +387,7 @@ def _download(url, path, md5sum=None):
                     if chunk:
                         f.write(chunk)
         shutil.move(tmp_fullname, fullname)
-        return fullname
+    return fullname
 
 
 def _download_dist(url, path, md5sum=None):


### PR DESCRIPTION
Fix for error that happened when I had downloaded train2017.zip. The function which I changed didn't return any string and it was NoneType instead.
Below is command and error:
`$ python tools/eval.py -c configs/ppyolo/ppyolov2_r50vd_dcn_365e_coco.yml -o use_gpu=false weights=https://paddled
et.bj.bcebos.com/models/ppyolov2_r50vd_dcn_365e_coco.pdparams`
```
/mnt/drive/PaddlePaddle/Paddle/build/python/paddle/tensor/creation.py:132: DeprecationWarning: `np.object` is a deprecated alias for the builtin `object`. To silence this warning, use `object` by itself. Doing this will not modify an
y behavior and is safe.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  if data.dtype == np.object:
[01/24 16:42:43] ppdet.utils.download WARNING: Config annotation dataset/coco/annotations/instances_val2017.json is not a file, dataset config is not valid
[01/24 16:42:43] ppdet.utils.download INFO: Dataset /mnt/drive/PaddlePaddle/PaddleDetection/dataset/coco is not valid for reason above, try searching /home/sfraczek/.cache/paddle/dataset or downloading dataset...
Traceback (most recent call last):
  File "tools/eval.py", line 145, in <module>
    main()
  File "tools/eval.py", line 141, in main
    run(FLAGS, cfg)
  File "tools/eval.py", line 100, in run
    trainer = Trainer(cfg, mode='eval')
  File "/mnt/drive/PaddlePaddle/PaddleDetection/ppdet/engine/trainer.py", line 124, in __init__
    self._eval_batch_sampler)
  File "/mnt/drive/PaddlePaddle/PaddleDetection/ppdet/data/reader.py", line 162, in __call__
    self.dataset.check_or_download_dataset()
  File "/mnt/drive/PaddlePaddle/PaddleDetection/ppdet/data/source/dataset.py", line 91, in check_or_download_dataset
    self.image_dir)
  File "/mnt/drive/PaddlePaddle/PaddleDetection/ppdet/utils/download.py", line 217, in get_dataset_path
    get_path(url, data_dir, md5sum, check_exist)
  File "/mnt/drive/PaddlePaddle/PaddleDetection/ppdet/utils/download.py", line 297, in get_path
    if osp.splitext(fullname)[-1] not in ['.pdparams', '.yml']:
  File "/home/sfraczek/anaconda3/envs/paddle-default/lib/python3.7/posixpath.py", line 122, in splitext
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```