### PR TITLE
fix reid resnet bn export

### DIFF
--- a/ppdet/modeling/reid/resnet.py
+++ b/ppdet/modeling/reid/resnet.py
@@ -55,7 +55,7 @@ class ConvBNLayer(nn.Layer):
             bias_attr=False,
             data_format=data_format)
 
-        self._batch_norm = nn.BatchNorm2D(num_filters, data_layout=data_format)
+        self._batch_norm = nn.BatchNorm2D(num_filters)
         self.act = act
 
     def forward(self, inputs):


### PR DESCRIPTION
fix reid resnet bn export  in Paddle >= 2.2.1