### PR TITLE
fix python inference error when use fuse_norm keypoint model

### DIFF
--- a/deploy/python/keypoint_infer.py
+++ b/deploy/python/keypoint_infer.py
@@ -288,7 +288,7 @@ def create_inputs(imgs, im_info):
         inputs (dict): input of model
     """
     inputs = {}
-    inputs['image'] = np.stack(imgs, axis=0)
+    inputs['image'] = np.stack(imgs, axis=0).astype('float32')
     im_shape = []
     for e in im_info:
         im_shape.append(np.array((e['im_shape'])).astype('float32'))


### PR DESCRIPTION
This pr is to fix the `InvalidArgumentError: Tensor holds the wrong type, it holds float, but desires to be int.` when use  keypoint model with `fuse_normalize=true` in deploy inference.