### PR TITLE
fix use_dark can not set to False

### DIFF
--- a/deploy/python/det_keypoint_unite_utils.py
+++ b/deploy/python/det_keypoint_unite_utils.py
@@ -112,7 +112,7 @@ def argsparser():
         "calibration, trt_calib_mode need to set True.")
     parser.add_argument(
         '--use_dark',
-        type=bool,
+        type=ast.literal_eval,
         default=True,
         help='whether to use darkpose to get better keypoint position predict ')
     parser.add_argument(

--- a/deploy/python/utils.py
+++ b/deploy/python/utils.py
@@ -133,7 +133,7 @@ def argsparser():
         help="max batch_size for reid model inference.")
     parser.add_argument(
         '--use_dark',
-        type=bool,
+        type=ast.literal_eval,
         default=True,
         help='whether to use darkpose to get better keypoint position predict ')
     return parser


### PR DESCRIPTION
- Current now the `use_dark` is `bool` and set `True` by default.  When running `keypoint_infer.py` and `det_keypoint_unite_infer.py`, we can not set it to `False` by `--use_dark=False`. It's because any string input will be treated as `True`. 

- This PR fix the bug mentioned above.