### PR TITLE
refine ema_model save

### DIFF
--- a/ppdet/engine/callbacks.py
+++ b/ppdet/engine/callbacks.py
@@ -182,7 +182,7 @@ class Checkpointer(Callback):
                 ) % self.model.cfg.snapshot_epoch == 0 or epoch_id == end_epoch - 1:
                     save_name = str(
                         epoch_id) if epoch_id != end_epoch - 1 else "model_final"
-                    weight = self.weight
+                    weight = self.weight.state_dict()
             elif mode == 'eval':
                 if 'save_best_model' in status and status['save_best_model']:
                     for metric in self.model._metrics:
@@ -201,18 +201,22 @@ class Checkpointer(Callback):
                         if map_res[key][0] > self.best_ap:
                             self.best_ap = map_res[key][0]
                             save_name = 'best_model'
-                            weight = self.weight
+                            weight = self.weight.state_dict()
                         logger.info("Best test {} ap is {:0.3f}.".format(
                             key, self.best_ap))
             if weight:
                 if self.model.use_ema:
-                    save_model(status['weight'], self.save_dir, save_name,
-                               epoch_id + 1, self.model.optimizer)
-                    save_model(weight, self.save_dir,
-                               '{}_ema'.format(save_name), epoch_id + 1)
+                    # save model and ema_model
+                    save_model(
+                        status['weight'],
+                        self.model.optimizer,
+                        self.save_dir,
+                        save_name,
+                        epoch_id + 1,
+                        ema_model=weight)
                 else:
-                    save_model(weight, self.save_dir, save_name, epoch_id + 1,
-                               self.model.optimizer)
+                    save_model(weight, self.model.optimizer, self.save_dir,
+                               save_name, epoch_id + 1)
 
 
 class WiferFaceEval(Callback):

--- a/ppdet/optimizer.py
+++ b/ppdet/optimizer.py
@@ -332,7 +332,7 @@ class ModelEMA(object):
         for k, v in self.state_dict.items():
             self.state_dict[k] = paddle.zeros_like(v)
 
-    def resume(self, state_dict, step):
+    def resume(self, state_dict, step=0):
         for k, v in state_dict.items():
             self.state_dict[k] = v
         self.step = step


### PR DESCRIPTION
- 改进ema_model的保存方式：由于模型训练完毕后需要保存的是ema_model，故在保存时交换ema_model和真实model
- 将真实model改为`model.pdema`保存下来以便resume时使用，将ema_model以正常保存模型的方式改为`model.pdparams`保存下来以便用户eval。以上改动同时涉及`save_model`和`load_weight`的改动