### PR TITLE
Add PP-YOLOE yaml

### DIFF
--- a/configs/ppyoloe/_base_/optimizer_300e.yml
+++ b/configs/ppyoloe/_base_/optimizer_300e.yml
@@ -1,0 +1,18 @@
+epoch: 300
+
+LearningRate:
+  base_lr: 0.03
+  schedulers:
+    - !CosineDecay
+      max_epochs: 360
+    - !LinearWarmup
+      start_factor: 0.001
+      steps: 3000
+
+OptimizerBuilder:
+  optimizer:
+    momentum: 0.9
+    type: Momentum
+  regularizer:
+    factor: 0.0005
+    type: L2

--- a/configs/ppyoloe/_base_/ppyoloe_crn.yml
+++ b/configs/ppyoloe/_base_/ppyoloe_crn.yml
@@ -6,7 +6,7 @@ ema_decay: 0.9998
 YOLOv3:
   backbone: CSPResNet
   neck: CustomCSPPAN
-  yolo_head: PPYOLOHead
+  yolo_head: PPYOLOEHead
   post_process: ~
 
 CSPResNet:
@@ -22,7 +22,7 @@ CustomCSPPAN:
   act: 'swish'
   spp: true
 
-PPYOLOHead:
+PPYOLOEHead:
   fpn_strides: [32, 16, 8]
   grid_cell_scale: 5.0
   grid_cell_offset: 0.5

--- a/configs/ppyoloe/_base_/ppyoloe_crn.yml
+++ b/configs/ppyoloe/_base_/ppyoloe_crn.yml
@@ -1,0 +1,46 @@
+architecture: YOLOv3
+norm_type: sync_bn
+use_ema: true
+ema_decay: 0.9998
+
+YOLOv3:
+  backbone: CSPResNet
+  neck: CustomCSPPAN
+  yolo_head: PPYOLOHead
+  post_process: ~
+
+CSPResNet:
+  layers: [3, 6, 6, 3]
+  channels: [64, 128, 256, 512, 1024]
+  return_idx: [1, 2, 3]
+  use_large_stem: True
+
+CustomCSPPAN:
+  out_channels: [768, 384, 192]
+  stage_num: 1
+  block_num: 3
+  act: 'swish'
+  spp: true
+
+PPYOLOHead:
+  fpn_strides: [32, 16, 8]
+  grid_cell_scale: 5.0
+  grid_cell_offset: 0.5
+  static_assigner_epoch: 100
+  use_varifocal_loss: True
+  eval_input_size: [640, 640]
+  loss_weight: {class: 1.0, iou: 2.5, dfl: 0.5}
+  static_assigner:
+    name: ATSSAssigner
+    topk: 9
+  assigner:
+    name: TaskAlignedAssigner
+    topk: 13
+    alpha: 1.0
+    beta: 6.0
+  nms:
+    name: MultiClassNMS
+    nms_top_k: 1000
+    keep_top_k: 100
+    score_threshold: 0.01
+    nms_threshold: 0.6

--- a/configs/ppyoloe/_base_/ppyoloe_reader.yml
+++ b/configs/ppyoloe/_base_/ppyoloe_reader.yml
@@ -1,0 +1,36 @@
+worker_num: 8
+TrainReader:
+  sample_transforms:
+    - Decode: {}
+    - RandomDistort: {}
+    - RandomExpand: {fill_value: [123.675, 116.28, 103.53]}
+    - RandomCrop: {}
+    - RandomFlip: {}
+  batch_transforms:
+    - BatchRandomResize: {target_size: [320, 352, 384, 416, 448, 480, 512, 544, 576, 608, 640, 672, 704, 736, 768], random_size: True, random_interp: True, keep_ratio: False}
+    - NormalizeImage: {mean: [0.485, 0.456, 0.406], std: [0.229, 0.224, 0.225], is_scale: True}
+    - Permute: {}
+    - PadGT: {}
+  batch_size: 24
+  shuffle: true
+  drop_last: true
+  use_shared_memory: true
+  collate_batch: true
+
+EvalReader:
+  sample_transforms:
+    - Decode: {}
+    - Resize: {target_size: [640, 640], keep_ratio: False, interp: 2}
+    - NormalizeImage: {mean: [0.485, 0.456, 0.406], std: [0.229, 0.224, 0.225], is_scale: True}
+    - Permute: {}
+  batch_size: 4
+
+TestReader:
+  inputs_def:
+    image_shape: [3, 640, 640]
+  sample_transforms:
+    - Decode: {}
+    - Resize: {target_size: [640, 640], keep_ratio: False, interp: 2}
+    - NormalizeImage: {mean: [0.485, 0.456, 0.406], std: [0.229, 0.224, 0.225], is_scale: True}
+    - Permute: {}
+  batch_size: 1

--- a/configs/ppyoloe/ppyoloe_crn_l_300e_coco.yml
+++ b/configs/ppyoloe/ppyoloe_crn_l_300e_coco.yml
@@ -11,6 +11,6 @@ snapshot_epoch: 10
 weights: output/ppyoloe_crn_l_300e_coco/model_final
 find_unused_parameters: True
 
-pretrain_weights: https://paddledet.bj.bcebos.com/models/pretrained/CSPResNetb50_l_pretrained.pdparams
+pretrain_weights: https://paddledet.bj.bcebos.com/models/pretrained/CSPResNetb_l_pretrained.pdparams
 depth_mult: 1.0
 width_mult: 1.0

--- a/configs/ppyoloe/ppyoloe_crn_l_300e_coco.yml
+++ b/configs/ppyoloe/ppyoloe_crn_l_300e_coco.yml
@@ -1,0 +1,16 @@
+_BASE_: [
+  '../datasets/coco_detection.yml',
+  '../runtime.yml',
+  './_base_/optimizer_300e.yml',
+  './_base_/ppyoloe_crn.yml',
+  './_base_/ppyoloe_reader.yml',
+]
+
+log_iter: 100
+snapshot_epoch: 10
+weights: output/ppyoloe_crn_l_300e_coco/model_final
+find_unused_parameters: True
+
+pretrain_weights: https://paddledet.bj.bcebos.com/models/pretrained/CSPResNetb50_l_pretrained.pdparams
+depth_mult: 1.0
+width_mult: 1.0

--- a/configs/ppyoloe/ppyoloe_crn_m_300e_coco.yml
+++ b/configs/ppyoloe/ppyoloe_crn_m_300e_coco.yml
@@ -1,0 +1,28 @@
+_BASE_: [
+  '../datasets/coco_detection.yml',
+  '../runtime.yml',
+  './_base_/optimizer_300e.yml',
+  './_base_/ppyoloe_crn.yml',
+  './_base_/ppyoloe_reader.yml',
+]
+
+log_iter: 100
+snapshot_epoch: 10
+weights: output/ppyoloe_crn_m_300e_coco/model_final
+find_unused_parameters: True
+
+pretrain_weights: https://paddledet.bj.bcebos.com/models/pretrained/CSPResNetb50_m_pretrained.pdparams
+depth_mult: 0.67
+width_mult: 0.75
+
+TrainReader:
+  batch_size: 32
+
+LearningRate:
+  base_lr: 0.04
+  schedulers:
+    - !CosineDecay
+      max_epochs: 360
+    - !LinearWarmup
+      start_factor: 0.001
+      steps: 2300

--- a/configs/ppyoloe/ppyoloe_crn_m_300e_coco.yml
+++ b/configs/ppyoloe/ppyoloe_crn_m_300e_coco.yml
@@ -11,7 +11,7 @@ snapshot_epoch: 10
 weights: output/ppyoloe_crn_m_300e_coco/model_final
 find_unused_parameters: True
 
-pretrain_weights: https://paddledet.bj.bcebos.com/models/pretrained/CSPResNetb50_m_pretrained.pdparams
+pretrain_weights: https://paddledet.bj.bcebos.com/models/pretrained/CSPResNetb_m_pretrained.pdparams
 depth_mult: 0.67
 width_mult: 0.75
 

--- a/configs/ppyoloe/ppyoloe_crn_s_300e_coco.yml
+++ b/configs/ppyoloe/ppyoloe_crn_s_300e_coco.yml
@@ -1,0 +1,28 @@
+_BASE_: [
+  '../datasets/coco_detection.yml',
+  '../runtime.yml',
+  './_base_/optimizer_300e.yml',
+  './_base_/ppyoloe_crn.yml',
+  './_base_/ppyoloe_reader.yml',
+]
+
+log_iter: 100
+snapshot_epoch: 10
+weights: output/ppyoloe_crn_s_300e_coco/model_final
+find_unused_parameters: True
+
+pretrain_weights: https://paddledet.bj.bcebos.com/models/pretrained/CSPResNetb50_s_pretrained.pdparams
+depth_mult: 0.33
+width_mult: 0.50
+
+TrainReader:
+  batch_size: 32
+
+LearningRate:
+  base_lr: 0.04
+  schedulers:
+    - !CosineDecay
+      max_epochs: 360
+    - !LinearWarmup
+      start_factor: 0.001
+      steps: 2300

--- a/configs/ppyoloe/ppyoloe_crn_s_300e_coco.yml
+++ b/configs/ppyoloe/ppyoloe_crn_s_300e_coco.yml
@@ -11,7 +11,7 @@ snapshot_epoch: 10
 weights: output/ppyoloe_crn_s_300e_coco/model_final
 find_unused_parameters: True
 
-pretrain_weights: https://paddledet.bj.bcebos.com/models/pretrained/CSPResNetb50_s_pretrained.pdparams
+pretrain_weights: https://paddledet.bj.bcebos.com/models/pretrained/CSPResNetb_s_pretrained.pdparams
 depth_mult: 0.33
 width_mult: 0.50
 

--- a/configs/ppyoloe/ppyoloe_crn_x_300e_coco.yml
+++ b/configs/ppyoloe/ppyoloe_crn_x_300e_coco.yml
@@ -11,7 +11,7 @@ snapshot_epoch: 10
 weights: output/ppyoloe_crn_x_300e_coco/model_final
 find_unused_parameters: True
 
-pretrain_weights: https://paddledet.bj.bcebos.com/models/pretrained/CSPResNetb50_x_pretrained.pdparams
+pretrain_weights: https://paddledet.bj.bcebos.com/models/pretrained/CSPResNetb_x_pretrained.pdparams
 depth_mult: 1.33
 width_mult: 1.25
 

--- a/configs/ppyoloe/ppyoloe_crn_x_300e_coco.yml
+++ b/configs/ppyoloe/ppyoloe_crn_x_300e_coco.yml
@@ -1,0 +1,28 @@
+_BASE_: [
+  '../datasets/coco_detection.yml',
+  '../runtime.yml',
+  './_base_/optimizer_300e.yml',
+  './_base_/ppyoloe_crn.yml',
+  './_base_/ppyoloe_reader.yml',
+]
+
+log_iter: 100
+snapshot_epoch: 10
+weights: output/ppyoloe_crn_x_300e_coco/model_final
+find_unused_parameters: True
+
+pretrain_weights: https://paddledet.bj.bcebos.com/models/pretrained/CSPResNetb50_x_pretrained.pdparams
+depth_mult: 1.33
+width_mult: 1.25
+
+TrainReader:
+  batch_size: 16
+
+LearningRate:
+  base_lr: 0.02
+  schedulers:
+    - !CosineDecay
+      max_epochs: 360
+    - !LinearWarmup
+      start_factor: 0.001
+      steps: 4600

--- a/ppdet/modeling/heads/__init__.py
+++ b/ppdet/modeling/heads/__init__.py
@@ -32,7 +32,7 @@ from . import detr_head
 from . import sparsercnn_head
 from . import tood_head
 from . import retina_head
-from . import ppyolo_head
+from . import ppyoloe_head
 
 from .bbox_head import *
 from .mask_head import *
@@ -54,4 +54,4 @@ from .detr_head import *
 from .sparsercnn_head import *
 from .tood_head import *
 from .retina_head import *
-from .ppyolo_head import *
+from .ppyoloe_head import *

--- a/ppdet/modeling/heads/ppyoloe_head.py
+++ b/ppdet/modeling/heads/ppyoloe_head.py
@@ -24,7 +24,7 @@ from ..assigners.utils import generate_anchors_for_grid_cell
 from ppdet.modeling.backbones.cspresnet import ConvBNLayer
 from ppdet.modeling.ops import get_static_shape, paddle_distributed_is_initialized, get_act_fn
 
-__all__ = ['PPYOLOHead']
+__all__ = ['PPYOLOEHead']
 
 
 class ESEAttn(nn.Layer):
@@ -44,7 +44,7 @@ class ESEAttn(nn.Layer):
 
 
 @register
-class PPYOLOHead(nn.Layer):
+class PPYOLOEHead(nn.Layer):
     __shared__ = ['num_classes', 'trt']
     __inject__ = ['static_assigner', 'assigner', 'nms']
 
@@ -68,7 +68,7 @@ class PPYOLOHead(nn.Layer):
                      'dfl': 0.5,
                  },
                  trt=False):
-        super(PPYOLOHead, self).__init__()
+        super(PPYOLOEHead, self).__init__()
         assert len(in_channels) > 0, "len(in_channels) should > 0"
         self.in_channels = in_channels
         self.num_classes = num_classes


### PR DESCRIPTION
- add PP-YOLOE yaml
- PP-YOLOE的yaml默认为混合精度训练配置，请在训练时指定`--amp`参数，否则请按比例缩放`batch_size`和`learning_rate`
- 在ppyoloe_head中新增`exclude_nms`字段，在`export_model`时可指定`-o exclude_nms=True`导出benchmark model用以测速