### PR TITLE
[SSD] add use_fuse_decode to SSDBox

### DIFF
--- a/ppdet/modeling/layers.py
+++ b/ppdet/modeling/layers.py
@@ -553,9 +553,14 @@ class YOLOBox(object):
 @register
 @serializable
 class SSDBox(object):
-    def __init__(self, is_normalized=True):
+    def __init__(self,
+                 is_normalized=True,
+                 prior_box_var=[0.1, 0.1, 0.2, 0.2],
+                 use_fuse_decode=False):
         self.is_normalized = is_normalized
         self.norm_delta = float(not self.is_normalized)
+        self.prior_box_var = prior_box_var
+        self.use_fuse_decode = use_fuse_decode
 
     def __call__(self,
                  preds,
@@ -564,40 +569,42 @@ class SSDBox(object):
                  scale_factor,
                  var_weight=None):
         boxes, scores = preds
-        outputs = []
-        for box, score, prior_box in zip(boxes, scores, prior_boxes):
-            pb_w = prior_box[:, 2] - prior_box[:, 0] + self.norm_delta
-            pb_h = prior_box[:, 3] - prior_box[:, 1] + self.norm_delta
-            pb_x = prior_box[:, 0] + pb_w * 0.5
-            pb_y = prior_box[:, 1] + pb_h * 0.5
-            out_x = pb_x + box[:, :, 0] * pb_w * 0.1
-            out_y = pb_y + box[:, :, 1] * pb_h * 0.1
-            out_w = paddle.exp(box[:, :, 2] * 0.2) * pb_w
-            out_h = paddle.exp(box[:, :, 3] * 0.2) * pb_h
+        boxes = paddle.concat(boxes, axis=1)
+        prior_boxes = paddle.concat(prior_boxes)
+        if self.use_fuse_decode:
+            output_boxes = ops.box_coder(
+                prior_boxes,
+                self.prior_box_var,
+                boxes,
+                code_type="decode_center_size",
+                box_normalized=self.is_normalized)
+        else:
+            pb_w = prior_boxes[:, 2] - prior_boxes[:, 0] + self.norm_delta
+            pb_h = prior_boxes[:, 3] - prior_boxes[:, 1] + self.norm_delta
+            pb_x = prior_boxes[:, 0] + pb_w * 0.5
+            pb_y = prior_boxes[:, 1] + pb_h * 0.5
+            out_x = pb_x + boxes[:, :, 0] * pb_w * self.prior_box_var[0]
+            out_y = pb_y + boxes[:, :, 1] * pb_h * self.prior_box_var[1]
+            out_w = paddle.exp(boxes[:, :, 2] * self.prior_box_var[2]) * pb_w
+            out_h = paddle.exp(boxes[:, :, 3] * self.prior_box_var[3]) * pb_h
+            output_boxes = paddle.stack(
+                [
+                    out_x - out_w / 2., out_y - out_h / 2., out_x + out_w / 2.,
+                    out_y + out_h / 2.
+                ],
+                axis=-1)
 
-            if self.is_normalized:
-                h = paddle.unsqueeze(
-                    im_shape[:, 0] / scale_factor[:, 0], axis=-1)
-                w = paddle.unsqueeze(
-                    im_shape[:, 1] / scale_factor[:, 1], axis=-1)
-                output = paddle.stack(
-                    [(out_x - out_w / 2.) * w, (out_y - out_h / 2.) * h,
-                     (out_x + out_w / 2.) * w, (out_y + out_h / 2.) * h],
-                    axis=-1)
-            else:
-                output = paddle.stack(
-                    [
-                        out_x - out_w / 2., out_y - out_h / 2.,
-                        out_x + out_w / 2. - 1., out_y + out_h / 2. - 1.
-                    ],
-                    axis=-1)
-            outputs.append(output)
-        boxes = paddle.concat(outputs, axis=1)
+        if self.is_normalized:
+            h = (im_shape[:, 0] / scale_factor[:, 0]).unsqueeze(-1)
+            w = (im_shape[:, 1] / scale_factor[:, 1]).unsqueeze(-1)
+            im_shape = paddle.stack([w, h, w, h], axis=-1)
+            output_boxes *= im_shape
+        else:
+            output_boxes[..., -2:] -= 1.0
+        output_scores = F.softmax(paddle.concat(
+            scores, axis=1)).transpose([0, 2, 1])
 
-        scores = F.softmax(paddle.concat(scores, axis=1))
-        scores = paddle.transpose(scores, [0, 2, 1])
-
-        return boxes, scores
+        return output_boxes, output_scores
 
 
 @register


### PR DESCRIPTION
- 本次针对ppdet/modeling/layers.py中的`SSDBox`做出更新，新增`prior_box_var`参数用于适配decode过程中的`prior_box_variance`，该参数默认为[0.1, 0.1, 0.2, 0.2]；新增`use_fuse_decode`参数用于决定是否使用`box_coder`大OP来进行decode，该参数默认为False
- 同时更新原有动态图小OP的decode逻辑，更新后eval的FPS提升64%+


测试环境：P40，CUDA10.1，paddlepaddle-gpu-2.2.2
测试模型：`ssd_mobilenet_v1_300_120e_voc`，`ssd_vgg16_300_240e_voc`
**before**：
ssd_mobilenet_v1_300_120e_voc：
<img width="677" alt="0309 0637347 ppdet retrics retrics INFO Accumulating evaluatotion results" src="https://user-images.githubusercontent.com/23647349/157388584-68f74d2c-3ae1-40b0-be09-81f574bb9265.png">

ssd_vgg16_300_240e_voc：
<img width="658" alt="0300 064323) ppdet retrics petrics INFO Mccurlatino evaluatatfon results" src="https://user-images.githubusercontent.com/23647349/157388640-cc1f18c2-b95e-4715-8b76-fffac4465c2f.png">

**after**：
when `use_fuse_decode=False`，使用小OP的decode逻辑
ssd_mobilenet_v1_300_120e_voc：
<img width="662" alt="(0309 055084) ppdet retrics netrics INFO Accuulating evaluatation results" src="https://user-images.githubusercontent.com/23647349/157389405-b0e23fc1-640e-4141-bb82-5a3d36cdf221.png">

ssd_vgg16_300_240e_voc：
<img width="657" alt="0309 6655421 ppdet metrics metrics INFO Accurulating evaluatation results" src="https://user-images.githubusercontent.com/23647349/157389439-95650097-3faf-4574-aadf-848c7ea3a80a.png">

when `use_fuse_decode=True`，使用大OP的decode逻辑
ssd_mobilenet_v1_300_120e_voc：
<img width="649" alt="Pasted Graphic 5" src="https://user-images.githubusercontent.com/23647349/157389784-46ed8ca7-3bd7-4391-99cc-cfcccf89d1e3.png">


ssd_vgg16_300_240e_voc：
<img width="652" alt="0389 870029  ppdet metrics metrics INFO Accurulating evoluatat ion results" src="https://user-images.githubusercontent.com/23647349/157389576-6114b098-be1a-4a62-ad7a-7433d0cd5bc5.png">


若想开启大OP的decode逻辑，修改如下（以ssd_mobilenet_v1_300_120e_voc为例）：
```
BBoxPostProcess:
  decode:
    name: SSDBox
    use_fuse_decode: True
```