### PR TITLE
fix mask head when mask num is 1

### DIFF
--- a/ppdet/modeling/heads/mask_head.py
+++ b/ppdet/modeling/heads/mask_head.py
@@ -226,6 +226,10 @@ class MaskHead(nn.Layer):
                 num_masks = paddle.shape(mask_logit)[0]
                 index = paddle.arange(num_masks).cast('int32')
                 mask_out = mask_logit[index, labels]
+                mask_out_shape = paddle.shape(mask_out)
+                mask_out = paddle.reshape(mask_out, [
+                    paddle.shape(index), mask_out_shape[-2], mask_out_shape[-1]
+                ])
                 mask_out = F.sigmoid(mask_out)
         return mask_out
 


### PR DESCRIPTION
When index shape is [1], the output of slice will remove the first dimension.
```
mask_logit = paddle.ones([1, 10, 10])
index = paddle.arange(1).cast('int32')
mask_out = mask_logit[index] # output shape is [10, 10]
```

Now use reshape op to skip this problem