### PR TITLE
Add Timer for Action

### DIFF
--- a/deploy/pphuman/config/infer_cfg.yml
+++ b/deploy/pphuman/config/infer_cfg.yml
@@ -2,6 +2,7 @@ crop_thresh: 0.5
 attr_thresh: 0.5
 kpt_thresh: 0.2
 visual: True
+warmup_frame: 50
 
 DET:
   model_dir: output_inference/mot_ppyolov3/

--- a/deploy/pphuman/pipeline.py
+++ b/deploy/pphuman/pipeline.py
@@ -265,7 +265,7 @@ class PipePredictor(object):
         self.cfg = cfg
         self.output_dir = output_dir
 
-        self.warmup_frame = 1
+        self.warmup_frame = self.cfg['warmup_frame']
         self.pipeline_res = Result()
         self.pipe_timer = PipeTimer()
         self.file_name = None
@@ -492,14 +492,16 @@ class PipePredictor(object):
 
                 action_res = {}
                 if state:
-                    self.pipe_timer.module_time['action'].start()
+                    if frame_id > self.warmup_frame:
+                        self.pipe_timer.module_time['action'].start()
                     collected_keypoint = self.kpt_collector.get_collected_keypoint(
                     )  # reoragnize kpt output with ID
                     action_input = parse_mot_keypoint(collected_keypoint,
                                                       self.coord_size)
                     action_res = self.action_predictor.predict_skeleton_with_mot(
                         action_input)
-                    self.pipe_timer.module_time['action'].end()
+                    if frame_id > self.warmup_frame:
+                        self.pipe_timer.module_time['action'].end()
                     self.pipeline_res.update(action_res, 'action')
 
                 if self.cfg['visual']:

--- a/deploy/python/action_infer.py
+++ b/deploy/python/action_infer.py
@@ -80,7 +80,8 @@ class ActionRecognizer(Detector):
             cpu_threads=cpu_threads,
             enable_mkldnn=enable_mkldnn,
             output_dir=output_dir,
-            threshold=threshold)
+            threshold=threshold,
+            delete_shuffle_pass=True)
 
     def predict(self, repeats=1):
         '''

--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -79,6 +79,8 @@ class Detector(object):
         enable_mkldnn_bfloat16 (bool): whether to turn on mkldnn bfloat16
         output_dir (str): The path of output
         threshold (float): The threshold of score for visualization
+        delete_shuffle_pass (bool): whether to remove shuffle_channel_detect_pass in TensorRT. 
+                                    Used by action model.
     """
 
     def __init__(self,
@@ -601,6 +603,8 @@ def load_predictor(model_dir,
         trt_opt_shape (int): opt shape for dynamic shape in trt
         trt_calib_mode (bool): If the model is produced by TRT offline quantitative
             calibration, trt_calib_mode need to set True
+        delete_shuffle_pass (bool): whether to remove shuffle_channel_detect_pass in TensorRT. 
+                                    Used by action model.
     Returns:
         predictor (PaddlePredictor): AnalysisPredictor
     Raises:


### PR DESCRIPTION
1. Add timer for keypoint and action model into pphuman pipeline.
2. Add a new parameter `delete_shuffle_pass` for  class `Detector`. It is used to delete `shuffle_channel_detect_pass` for action model STGCN. Or it will throw `ValueError: (InvalidArgument) ShuffleChannel TRT op converter input dims is invalid. The input dims size should be 3, but got 2.` .  Refer to [PaddleVideo](https://github.com/PaddlePaddle/PaddleVideo/blob/develop/tools/predict.py#L109). 