### PR TITLE
[NPU] fix yolov3 error on NPU, test=develop

### DIFF
--- a/static/tools/eval.py
+++ b/static/tools/eval.py
@@ -58,6 +58,7 @@ def main():
     """
     Main evaluate function
     """
+    env = os.environ
     cfg = load_config(FLAGS.config)
     merge_config(FLAGS.opt)
     check_config(cfg)
@@ -84,13 +85,22 @@ def main():
 
     multi_scale_test = getattr(cfg, 'MultiScaleTEST', None)
 
+    if cfg.use_gpu and 'FLAGS_selected_gpus' in env:
+        device_id = int(env['FLAGS_selected_gpus'])
+    elif cfg.use_npu and 'FLAGS_selected_npus' in env:
+        device_id = int(env['FLAGS_selected_npus'])
+    elif use_xpu and 'FLAGS_selected_xpus' in env:
+        device_id = int(env['FLAGS_selected_xpus'])
+    else:
+        device_id = 0
+
     # define executor
     if cfg.use_gpu:
-        place = fluid.CUDAPlace(0)
+        place = fluid.CUDAPlace(device_id)
     elif cfg.use_npu:
-        place = fluid.NPUPlace(0)
+        place = fluid.NPUPlace(device_id)
     elif use_xpu:
-        place = fluid.XPUPlace(0)
+        place = fluid.XPUPlace(device_id)
     else:
         place = fluid.CPUPlace()
     exe = fluid.Executor(place)

--- a/static/tools/infer.py
+++ b/static/tools/infer.py
@@ -103,6 +103,7 @@ def get_test_images(infer_dir, infer_img):
 
 
 def main():
+    env = os.environ
     cfg = load_config(FLAGS.config)
 
     merge_config(FLAGS.opt)
@@ -127,12 +128,22 @@ def main():
     test_images = get_test_images(FLAGS.infer_dir, FLAGS.infer_img)
     dataset.set_images(test_images)
 
+    if cfg.use_gpu and 'FLAGS_selected_gpus' in env:
+        device_id = int(env['FLAGS_selected_gpus'])
+    elif cfg.use_npu and 'FLAGS_selected_npus' in env:
+        device_id = int(env['FLAGS_selected_npus'])
+    elif use_xpu and 'FLAGS_selected_xpus' in env:
+        device_id = int(env['FLAGS_selected_xpus'])
+    else:
+        device_id = 0
+
+    # define executor
     if cfg.use_gpu:
-        place = fluid.CUDAPlace(0)
+        place = fluid.CUDAPlace(device_id)
     elif cfg.use_npu:
-        place = fluid.NPUPlace(0)
-    elif cfg.use_xpu:
-        place = fluid.XPUPlace(0)
+        place = fluid.NPUPlace(device_id)
+    elif use_xpu:
+        place = fluid.XPUPlace(device_id)
     else:
         place = fluid.CPUPlace()
     exe = fluid.Executor(place)

--- a/static/tools/infer.py
+++ b/static/tools/infer.py
@@ -132,7 +132,7 @@ def main():
         device_id = int(env['FLAGS_selected_gpus'])
     elif cfg.use_npu and 'FLAGS_selected_npus' in env:
         device_id = int(env['FLAGS_selected_npus'])
-    elif use_xpu and 'FLAGS_selected_xpus' in env:
+    elif cfg.use_xpu and 'FLAGS_selected_xpus' in env:
         device_id = int(env['FLAGS_selected_xpus'])
     else:
         device_id = 0
@@ -142,7 +142,7 @@ def main():
         place = fluid.CUDAPlace(device_id)
     elif cfg.use_npu:
         place = fluid.NPUPlace(device_id)
-    elif use_xpu:
+    elif cfg.use_xpu:
         place = fluid.XPUPlace(device_id)
     else:
         place = fluid.CPUPlace()


### PR DESCRIPTION
When setting "export FLAGS_selected_npus=2" in environment.

Running the following command will throw error as following:

Command:

```bash
python -u tools/eval.py -c configs/yolov3_darknet_roadsign.yml \
       -o use_npu=True # 评估

python -u tools/infer.py -c configs/yolov3_darknet_roadsign.yml -o use_npu=True \
       --infer_img dataset/roadsign_voc/images/road843.png # 推理
```

Error msg as following

```
----------------------
Error Message Summary:
----------------------
UnimplementedError: Place Place(npu:0) is not supported. Please check that your paddle compiles with WITH_GPU, WITH_XPU, WITH_IPU, WITH_MLU or WITH_ASCEND_CL option or check that your train process set the correct device id if you use Executor. (at /workspace/Paddle/paddle/fluid/platform/device_context.cc:146)
  [operator < gaussian_random > error]
I0403 04:20:14.487136 18343 device_context.cc:133] ----- DeviceContextPool::Get:start ----
I0403 04:20:14.487174 18343 device_context.cc:135] dev_ctx.place = Place(cpu)
I0403 04:20:14.487187 18343 device_context.cc:135] dev_ctx.place = Place(npu:2)
I0403 04:20:14.487242 18343 device_context.cc:137] ----- DeviceContextPool::Get:end ----
I0403 04:20:16.391681 18343 device_context.cc:133] ----- DeviceContextPool::Get:start ----
I0403 04:20:16.391744 18343 device_context.cc:135] dev_ctx.place = Place(cpu)
I0403 04:20:16.391770 18343 device_context.cc:135] dev_ctx.place = Place(npu:2)
I0403 04:20:16.391793 18343 device_context.cc:137] ----- DeviceContextPool::Get:end ----
```
