### PR TITLE
Change saved result format

### DIFF
--- a/deploy/python/det_keypoint_unite_infer.py
+++ b/deploy/python/det_keypoint_unite_infer.py
@@ -85,8 +85,9 @@ def topdown_unite_predict(detector,
                 FLAGS.run_benchmark)
 
             if save_res:
+                save_name = img_file if isinstance(img_file, str) else i
                 store_res.append([
-                    i, keypoint_res['bbox'],
+                    save_name, keypoint_res['bbox'],
                     [keypoint_res['keypoint'][0], keypoint_res['keypoint'][1]]
                 ])
         else:

--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -691,7 +691,7 @@ def get_test_images(infer_dir, infer_img):
     Get image path list in TEST mode
     """
     assert infer_img is not None or infer_dir is not None, \
-        "--infer_img or --infer_dir should be set"
+        "--image_file or --image_dir should be set"
     assert infer_img is None or os.path.isfile(infer_img), \
             "{} is not a file".format(infer_img)
     assert infer_dir is None or os.path.isdir(infer_dir), \

--- a/deploy/python/mot_keypoint_unite_infer.py
+++ b/deploy/python/mot_keypoint_unite_infer.py
@@ -95,8 +95,9 @@ def mot_topdown_unite_predict(mot_detector,
             FLAGS.run_benchmark)
 
         if save_res:
+            save_name = img_file if isinstance(img_file, str) else i
             store_res.append([
-                i, keypoint_res['bbox'],
+                save_name, keypoint_res['bbox'],
                 [keypoint_res['keypoint'][0], keypoint_res['keypoint'][1]]
             ])
         if FLAGS.run_benchmark:


### PR DESCRIPTION
- Fix throwed error message. From old version `infer_img` & `infer_dir` to `image_file` & `image_dir`
- Change saved result from id to image name when prediction with `--image_dir`.  It is difficult for users to match images with ids. Moreover, when the pictures in the folder are in sequential order, the `id` is not strictly match to file name order since it is get by `glob.glob`.

- before change
```
   1 [
   2     [
   3         0,
   4         [
   5             [
   6                 412,
   7                 88,
   8                 509,
   9                 288
  10             ],
  11             [
  12                 501,
  13                 112,
  14                 599,
  15                 275
  16             ],
```
- after change
```
   1 [
   2     [
   3         "/root/workspace/base/PaddleDetection/image_dir/000000014439.jpg",
   4         [
   5             [
   6                 412,
   7                 88,
   8                 509,
   9                 288
  10             ],
  11             [
  12                 501,
  13                 112,
  14                 599,
  15                 275
  16             ],
```
