### PR TITLE
fix doc link of pphuman

### DIFF
--- a/deploy/pphuman/README.md
+++ b/deploy/pphuman/README.md
@@ -29,7 +29,7 @@ cd PaddleDetection
 pip install -r requirements.txt
 ```
 
-详细安装文档参考[文档](docs/tutorials/INSTALL_cn.md)
+详细安装文档参考[文档](../../docs/tutorials/INSTALL_cn.md)
 
 ## 二、快速开始
 

--- a/deploy/pphuman/README_en.md
+++ b/deploy/pphuman/README_en.md
@@ -28,7 +28,7 @@ cd PaddleDetection
 pip install -r requirements.txt
 ```
 
-For details of the installation, please refer to this [document](docs/tutorials/INSTALL_cn.md)
+For details of the installation, please refer to this [document](../../docs/tutorials/INSTALL.md)
 
 ## II. Quick Start
 
@@ -144,19 +144,19 @@ The overall solution of PP-Human is as follows:
 
 ### 1. Object Detection
 - Use PP-YOLOE L as the model of object detection
-- For details, please refer to [PP-YOLOE](../../configs/ppyoloe/) and [Detection and Tracking](docs/mot_en.md)
+- For details, please refer to [PP-YOLOE](../../configs/ppyoloe/) and [Detection and Tracking](docs/mot.md)
 
 ### 2. Multi-Object Tracking
 - Conduct multi-object tracking with the SDE solution
 - Use PP-YOLOE L as the detection model
 - Use the Bytetrack solution to track modules
-- For details, refer to [Bytetrack](configs/mot/bytetrack) and [Detection and Tracking](docs/mot_en.md)
+- For details, refer to [Bytetrack](configs/mot/bytetrack) and [Detection and Tracking](docs/mot.md)
 
 ### 3. Multi-Camera Tracking
 - Use PP-YOLOE + Bytetrack to obtain the tracks of single-camera multi-object tracking
 - Use ReID（centroid network）to extract features of the detection result of each frame
 - Match the features of multi-camera tracks to get the cross-camera tracking result
-- For details, please refer to [Multi-Camera Tracking](docs/mtmct_en.md)
+- For details, please refer to [Multi-Camera Tracking](docs/mtmct.md)
 
 ### 4. Attribute Recognition
 - Use PP-YOLOE + Bytetrack to track humans
@@ -167,4 +167,4 @@ The overall solution of PP-Human is as follows:
 - Use PP-YOLOE + Bytetrack to track humans
 - Use HRNet for keypoint detection and get the information of the 17 key points in the human body
 - According to the changes of the key points of the same person within 50 frames, judge whether the action made by the person within 50 frames is a fall with the help of ST-GCN
-- For details, please refer to [Action Recognition](docs/action_en.md)
+- For details, please refer to [Action Recognition](docs/action.md)


### PR DESCRIPTION
- Fix the dead link in pphuman
- Since current now there are no English version Doc of DET/MOT/MTMCT/ACTION part, change the link to CN-DOC.