### PR TITLE
it seems a bug that an array is indexed twice.

### DIFF
--- a/ppdet/modeling/proposal_generator/target.py
+++ b/ppdet/modeling/proposal_generator/target.py
@@ -356,7 +356,7 @@ def generate_mask_target(gt_segms, rois, labels_int32, sampled_gt_inds,
         fg_inds_new = fg_inds.reshape([-1]).numpy()
         results = []
         if len(gt_segms_per_im) > 0:
-            for j in range(len(gt_segms_per_im)):
+            for j in range(len(fg_inds_new)):
                 results.append(
                     rasterize_polygons_within_box(new_segm[j], boxes[j],
                                                   resolution))

--- a/ppdet/modeling/proposal_generator/target.py
+++ b/ppdet/modeling/proposal_generator/target.py
@@ -356,7 +356,7 @@ def generate_mask_target(gt_segms, rois, labels_int32, sampled_gt_inds,
         fg_inds_new = fg_inds.reshape([-1]).numpy()
         results = []
         if len(gt_segms_per_im) > 0:
-            for j in fg_inds_new:
+            for j in range(len(gt_segms_per_im)):
                 results.append(
                     rasterize_polygons_within_box(new_segm[j], boxes[j],
                                                   resolution))


### PR DESCRIPTION
‘paddle.gather’ has been applyed on array 'boxes' in the above code. 
(which is named as fg_inds before transform from tensor to numpy.array)
so, i think it should loop with sequnce index here.