### PR TITLE
fix video infer(#5107)

### DIFF
--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -329,7 +329,7 @@ class Detector(object):
                 break
             print('detect frame: %d' % (index))
             index += 1
-            results = self.predict_image([frame], visual=False)
+            results = self.predict_image([frame[:, :, ::-1]], visual=False)
 
             im = visualize_box_mask(
                 frame,

--- a/deploy/python/keypoint_infer.py
+++ b/deploy/python/keypoint_infer.py
@@ -266,7 +266,7 @@ class KeyPointDetector(Detector):
                 break
             print('detect frame: %d' % (index))
             index += 1
-            results = self.predict_image([frame], visual=False)
+            results = self.predict_image([frame[:, :, ::-1]], visual=False)
             im_results = {}
             im_results['keypoint'] = [results['keypoint'], results['score']]
             im = visualize_pose(

--- a/deploy/python/mot_jde_infer.py
+++ b/deploy/python/mot_jde_infer.py
@@ -296,7 +296,7 @@ class JDE_Detector(Detector):
             timer.tic()
             seq_name = video_out_name.split('.')[0]
             mot_results = self.predict_image(
-                [frame], visual=False, seq_name=seq_name)
+                [frame[:, :, ::-1]], visual=False, seq_name=seq_name)
             timer.toc()
 
             online_tlwhs, online_scores, online_ids = mot_results[0]

--- a/deploy/python/mot_keypoint_unite_infer.py
+++ b/deploy/python/mot_keypoint_unite_infer.py
@@ -167,7 +167,10 @@ def mot_topdown_unite_predict_video(mot_detector,
 
         # mot model
         timer_mot.tic()
-        mot_results = mot_detector.predict_image([frame], visual=False)
+
+        frame2 = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+
+        mot_results = mot_detector.predict_image([frame2], visual=False)
         timer_mot.toc()
         online_tlwhs, online_scores, online_ids = mot_results[0]
         results = convert_mot_to_det(
@@ -179,7 +182,7 @@ def mot_topdown_unite_predict_video(mot_detector,
         # keypoint model
         timer_kp.tic()
         keypoint_res = predict_with_given_det(
-            frame, results, topdown_keypoint_detector, keypoint_batch_size,
+            frame2, results, topdown_keypoint_detector, keypoint_batch_size,
             FLAGS.run_benchmark)
         timer_kp.toc()
         timer_mot_kp.toc()

--- a/deploy/python/mot_sde_infer.py
+++ b/deploy/python/mot_sde_infer.py
@@ -414,7 +414,7 @@ class SDE_Detector(Detector):
             timer.tic()
             seq_name = video_out_name.split('.')[0]
             mot_results = self.predict_image(
-                [frame], visual=False, seq_name=seq_name)
+                [frame[:, :, ::-1]], visual=False, seq_name=seq_name)
             timer.toc()
 
             # bs=1 in MOT model

--- a/docs/tutorials/PrepareDataSet_en.md
+++ b/docs/tutorials/PrepareDataSet_en.md
@@ -48,7 +48,7 @@ ppdet_root=$(pwd)
 #### VOC Data
 
 VOC data is used in [Pascal VOC](http://host.robots.ox.ac.uk/pascal/VOC/) competition. Pascal VOC competition not only contains image classification task, but also contains object detection and object segmentation et al., the annotation file contains the ground truth of multiple tasks.
-VOC dataset denotes the data of PAscal VOC competition. when customizeing VOC data, For non mandatory fields in the XML file, please select whether to label or use the default value according to the actual situation.
+VOC dataset denotes the data of Pascal VOC competition. when customizeing VOC data, For non mandatory fields in the XML file, please select whether to label or use the default value according to the actual situation.
 
 ##### VOC Dataset Download  
 
@@ -108,13 +108,6 @@ VOC dataset denotes the data of PAscal VOC competition. when customizeing VOC da
     >>cat test.txt
     VOCdevkit/VOC2007/JPEGImages/000001.jpg VOCdevkit/VOC2007/Annotations/000001.xml
     ...
-
-    # label_list.txt voc list of classes name
-    >>cat label_list.txt
-
-    aeroplane
-    bicycle
-    ...
     ```
 - If the VOC dataset has been downloaded
     You can organize files according to the above data file organization structure.
@@ -136,7 +129,7 @@ The XML file contains the following fields：
         <depth>3</depth>
     </size>
     ```
-- object field, indict each object, including:
+- object field, indicating each object, including:
 
     |      Label       |                                                        Explanation                                                         |
     | :--------------: | :------------------------------------------------------------------------------------------------------------------------: |
@@ -144,7 +137,7 @@ The XML file contains the following fields：
     |       pose       |                               attitude description of the target object (non required field)                               |
     |    truncated     | If the occlusion of the object exceeds 15-20% and is outside the bounding box，mark it as `truncated` (non required field) |
     |    difficult     |                   objects that are difficult to recognize are marked as`difficult` (non required field)                    |
-    | bndbox son laebl |                            (xmin,ymin) top left coordinate, (xmax,ymax) bottom right coordinate                            |
+    | bndbox sub-label |                            (xmin,ymin) top left coordinate, (xmax,ymax) bottom right coordinate                            |
 
 
 #### COCO Data

--- a/ppdet/core/workspace.py
+++ b/ppdet/core/workspace.py
@@ -210,9 +210,17 @@ def create(cls_or_name, **kwargs):
     assert type(cls_or_name) in [type, str
                                  ], "should be a class or name of a class"
     name = type(cls_or_name) == str and cls_or_name or cls_or_name.__name__
-    assert name in global_config and \
-        isinstance(global_config[name], SchemaDict), \
-        "the module {} is not registered".format(name)
+    if name in global_config:
+        if isinstance(global_config[name], SchemaDict):
+            pass
+        elif hasattr(global_config[name], "__dict__"):
+            # support instance return directly
+            return global_config[name]
+        else:
+            raise ValueError("The module {} is not registered".format(name))
+    else:
+        raise ValueError("The module {} is not registered".format(name))
+
     config = global_config[name]
     cls = getattr(config.pymodule, name)
     cls_kwargs = {}

--- a/ppdet/data/source/__init__.py
+++ b/ppdet/data/source/__init__.py
@@ -27,3 +27,4 @@ from .category import *
 from .keypoint_coco import *
 from .mot import *
 from .sniper_coco import SniperCOCODataSet
+from .dataset import ImageFolder

--- a/ppdet/data/source/dataset.py
+++ b/ppdet/data/source/dataset.py
@@ -23,6 +23,7 @@ from paddle.io import Dataset
 from ppdet.core.workspace import register, serializable
 from ppdet.utils.download import get_dataset_path
 import copy
+import ppdet.data.source as source
 
 
 @serializable
@@ -59,6 +60,9 @@ class DetDataset(Dataset):
 
     def __len__(self, ):
         return len(self.roidbs)
+
+    def __call__(self, *args, **kwargs):
+        return self
 
     def __getitem__(self, idx):
         # data batch
@@ -198,3 +202,40 @@ class ImageFolder(DetDataset):
     def set_images(self, images):
         self.image_dir = images
         self.roidbs = self._load_images()
+
+
+@register
+class CommonDataset(object):
+    def __init__(self, **dataset_args):
+        super(CommonDataset, self).__init__()
+        dataset_args = copy.deepcopy(dataset_args)
+        type = dataset_args.pop("name")
+        self.dataset = getattr(source, type)(**dataset_args)
+
+    def __call__(self):
+        return self.dataset
+
+
+@register
+class TrainDataset(CommonDataset):
+    pass
+
+
+@register
+class EvalMOTDataset(CommonDataset):
+    pass
+
+
+@register
+class TestMOTDataset(CommonDataset):
+    pass
+
+
+@register
+class EvalDataset(CommonDataset):
+    pass
+
+
+@register
+class TestDataset(CommonDataset):
+    pass

--- a/ppdet/engine/trainer.py
+++ b/ppdet/engine/trainer.py
@@ -67,10 +67,13 @@ class Trainer(object):
         self.is_loaded_weights = False
 
         # build data loader
+        capital_mode = self.mode.capitalize()
         if cfg.architecture in MOT_ARCH and self.mode in ['eval', 'test']:
-            self.dataset = cfg['{}MOTDataset'.format(self.mode.capitalize())]
+            self.dataset = self.cfg['{}MOTDataset'.format(
+                capital_mode)] = create('{}MOTDataset'.format(capital_mode))()
         else:
-            self.dataset = cfg['{}Dataset'.format(self.mode.capitalize())]
+            self.dataset = self.cfg['{}Dataset'.format(capital_mode)] = create(
+                '{}Dataset'.format(capital_mode))()
 
         if cfg.architecture == 'DeepSORT' and self.mode == 'train':
             logger.error('DeepSORT has no need of training on mot dataset.')
@@ -81,7 +84,7 @@ class Trainer(object):
             self.dataset.set_images(images)
 
         if self.mode == 'train':
-            self.loader = create('{}Reader'.format(self.mode.capitalize()))(
+            self.loader = create('{}Reader'.format(capital_mode))(
                 self.dataset, cfg.worker_num)
 
         if cfg.architecture == 'JDE' and self.mode == 'train':
@@ -370,6 +373,8 @@ class Trainer(object):
     def train(self, validate=False):
         assert self.mode == 'train', "Model not in 'train' mode"
         Init_mark = False
+        if validate:
+            self.cfg.EvalDataset = create("EvalDataset")()
 
         sync_bn = (getattr(self.cfg, 'norm_type', None) == 'sync_bn' and
                    self.cfg.use_gpu and self._nranks > 1)

--- a/ppdet/modeling/post_process.py
+++ b/ppdet/modeling/post_process.py
@@ -179,7 +179,7 @@ class BBoxPostProcess(object):
 
 @register
 class MaskPostProcess(object):
-    __shared__ = ['export_onnx']
+    __shared__ = ['export_onnx', 'assign_on_cpu']
     """
     refer to:
     https://github.com/facebookresearch/detectron2/layers/mask_ops.py
@@ -187,10 +187,14 @@ class MaskPostProcess(object):
     Get Mask output according to the output from model
     """
 
-    def __init__(self, binary_thresh=0.5, export_onnx=False):
+    def __init__(self,
+                 binary_thresh=0.5,
+                 export_onnx=False,
+                 assign_on_cpu=False):
         super(MaskPostProcess, self).__init__()
         self.binary_thresh = binary_thresh
         self.export_onnx = export_onnx
+        self.assign_on_cpu = assign_on_cpu
 
     def paste_mask(self, masks, boxes, im_h, im_w):
         """
@@ -207,6 +211,8 @@ class MaskPostProcess(object):
         img_x = (img_x - x0) / (x1 - x0) * 2 - 1
         # img_x, img_y have shapes (N, w), (N, h)
 
+        if self.assign_on_cpu:
+            paddle.set_device('cpu')
         gx = img_x[:, None, :].expand(
             [N, paddle.shape(img_y)[1], paddle.shape(img_x)[1]])
         gy = img_y[:, :, None].expand(
@@ -233,6 +239,7 @@ class MaskPostProcess(object):
         """
         num_mask = mask_out.shape[0]
         origin_shape = paddle.cast(origin_shape, 'int32')
+        device = paddle.device.get_device()
 
         if self.export_onnx:
             h, w = origin_shape[0][0], origin_shape[0][1]
@@ -261,6 +268,8 @@ class MaskPostProcess(object):
                 pred_result[id_start:id_start + bbox_num[i], :im_h, :
                             im_w] = pred_mask
                 id_start += bbox_num[i]
+        if self.assign_on_cpu:
+            paddle.set_device(device)
 
         return pred_result
 

--- a/ppdet/modeling/proposal_generator/target.py
+++ b/ppdet/modeling/proposal_generator/target.py
@@ -74,9 +74,11 @@ def label_box(anchors,
               is_crowd=None,
               assign_on_cpu=False):
     if assign_on_cpu:
+        device = paddle.device.get_device()
         paddle.set_device("cpu")
         iou = bbox_overlaps(gt_boxes, anchors)
-        paddle.set_device("gpu")
+        paddle.set_device(device)
+
     else:
         iou = bbox_overlaps(gt_boxes, anchors)
     n_gt = gt_boxes.shape[0]

--- a/ppdet/optimizer.py
+++ b/ppdet/optimizer.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import sys
 import math
 import weakref
 import paddle
@@ -25,6 +26,7 @@ import paddle.optimizer as optimizer
 import paddle.regularizer as regularizer
 
 from ppdet.core.workspace import register, serializable
+import copy
 
 __all__ = ['LearningRate', 'OptimizerBuilder']
 
@@ -252,7 +254,18 @@ class LearningRate(object):
                  schedulers=[PiecewiseDecay(), LinearWarmup()]):
         super(LearningRate, self).__init__()
         self.base_lr = base_lr
-        self.schedulers = schedulers
+        self.schedulers = []
+
+        schedulers = copy.deepcopy(schedulers)
+        for sched in schedulers:
+            if isinstance(sched, dict):
+                # support dict sched instantiate
+                module = sys.modules[__name__]
+                type = sched.pop("name")
+                scheduler = getattr(module, type)(**sched)
+                self.schedulers.append(scheduler)
+            else:
+                self.schedulers.append(sched)
 
     def __call__(self, step_per_epoch):
         assert len(self.schedulers) >= 1


### PR DESCRIPTION
While inferring video, the image is not converted to RGB mode
preprocess操作对视频与图片的处理不一致，如果预测图片，则用opencv读入图片后要进行BGR到RGB颜色空间的转换，如果预测视频，则对帧图片不做任何处理就返回