### PR TITLE
fix video infer(#5107)

### DIFF
--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -329,7 +329,7 @@ class Detector(object):
                 break
             print('detect frame: %d' % (index))
             index += 1
-            results = self.predict_image([frame], visual=False)
+            results = self.predict_image([frame[:, :, ::-1]], visual=False)
 
             im = visualize_box_mask(
                 frame,

--- a/deploy/python/keypoint_infer.py
+++ b/deploy/python/keypoint_infer.py
@@ -266,7 +266,7 @@ class KeyPointDetector(Detector):
                 break
             print('detect frame: %d' % (index))
             index += 1
-            results = self.predict_image([frame], visual=False)
+            results = self.predict_image([frame[:, :, ::-1]], visual=False)
             im_results = {}
             im_results['keypoint'] = [results['keypoint'], results['score']]
             im = visualize_pose(

--- a/deploy/python/mot_jde_infer.py
+++ b/deploy/python/mot_jde_infer.py
@@ -296,7 +296,7 @@ class JDE_Detector(Detector):
             timer.tic()
             seq_name = video_out_name.split('.')[0]
             mot_results = self.predict_image(
-                [frame], visual=False, seq_name=seq_name)
+                [frame[:, :, ::-1]], visual=False, seq_name=seq_name)
             timer.toc()
 
             online_tlwhs, online_scores, online_ids = mot_results[0]

--- a/deploy/python/mot_keypoint_unite_infer.py
+++ b/deploy/python/mot_keypoint_unite_infer.py
@@ -167,7 +167,10 @@ def mot_topdown_unite_predict_video(mot_detector,
 
         # mot model
         timer_mot.tic()
-        mot_results = mot_detector.predict_image([frame], visual=False)
+
+        frame2 = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+
+        mot_results = mot_detector.predict_image([frame2], visual=False)
         timer_mot.toc()
         online_tlwhs, online_scores, online_ids = mot_results[0]
         results = convert_mot_to_det(
@@ -179,7 +182,7 @@ def mot_topdown_unite_predict_video(mot_detector,
         # keypoint model
         timer_kp.tic()
         keypoint_res = predict_with_given_det(
-            frame, results, topdown_keypoint_detector, keypoint_batch_size,
+            frame2, results, topdown_keypoint_detector, keypoint_batch_size,
             FLAGS.run_benchmark)
         timer_kp.toc()
         timer_mot_kp.toc()

--- a/deploy/python/mot_sde_infer.py
+++ b/deploy/python/mot_sde_infer.py
@@ -414,7 +414,7 @@ class SDE_Detector(Detector):
             timer.tic()
             seq_name = video_out_name.split('.')[0]
             mot_results = self.predict_image(
-                [frame], visual=False, seq_name=seq_name)
+                [frame[:, :, ::-1]], visual=False, seq_name=seq_name)
             timer.toc()
 
             # bs=1 in MOT model


### PR DESCRIPTION
While inferring video, the image is not converted to RGB mode
preprocess操作对视频与图片的处理不一致，如果预测图片，则用opencv读入图片后要进行BGR到RGB颜色空间的转换，如果预测视频，则对帧图片不做任何处理就返回