### PR TITLE
fix video infer release/2.4(#5107)

### DIFF
--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -329,7 +329,7 @@ class Detector(object):
                 break
             print('detect frame: %d' % (index))
             index += 1
-            results = self.predict_image([frame], visual=False)
+            results = self.predict_image([frame[:, :, ::-1]], visual=False)
 
             im = visualize_box_mask(
                 frame,

--- a/deploy/python/keypoint_infer.py
+++ b/deploy/python/keypoint_infer.py
@@ -266,7 +266,7 @@ class KeyPointDetector(Detector):
                 break
             print('detect frame: %d' % (index))
             index += 1
-            results = self.predict_image([frame], visual=False)
+            results = self.predict_image([frame[:, :, ::-1]], visual=False)
             im_results = {}
             im_results['keypoint'] = [results['keypoint'], results['score']]
             im = visualize_pose(

--- a/deploy/python/mot_jde_infer.py
+++ b/deploy/python/mot_jde_infer.py
@@ -296,7 +296,7 @@ class JDE_Detector(Detector):
             timer.tic()
             seq_name = video_out_name.split('.')[0]
             mot_results = self.predict_image(
-                [frame], visual=False, seq_name=seq_name)
+                [frame[:, :, ::-1]], visual=False, seq_name=seq_name)
             timer.toc()
 
             online_tlwhs, online_scores, online_ids = mot_results[0]

--- a/deploy/python/mot_keypoint_unite_infer.py
+++ b/deploy/python/mot_keypoint_unite_infer.py
@@ -167,7 +167,10 @@ def mot_topdown_unite_predict_video(mot_detector,
 
         # mot model
         timer_mot.tic()
-        mot_results = mot_detector.predict_image([frame], visual=False)
+
+        frame2 = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+
+        mot_results = mot_detector.predict_image([frame2], visual=False)
         timer_mot.toc()
         online_tlwhs, online_scores, online_ids = mot_results[0]
         results = convert_mot_to_det(
@@ -179,7 +182,7 @@ def mot_topdown_unite_predict_video(mot_detector,
         # keypoint model
         timer_kp.tic()
         keypoint_res = predict_with_given_det(
-            frame, results, topdown_keypoint_detector, keypoint_batch_size,
+            frame2, results, topdown_keypoint_detector, keypoint_batch_size,
             FLAGS.run_benchmark)
         timer_kp.toc()
         timer_mot_kp.toc()

--- a/deploy/python/mot_sde_infer.py
+++ b/deploy/python/mot_sde_infer.py
@@ -414,7 +414,7 @@ class SDE_Detector(Detector):
             timer.tic()
             seq_name = video_out_name.split('.')[0]
             mot_results = self.predict_image(
-                [frame], visual=False, seq_name=seq_name)
+                [frame[:, :, ::-1]], visual=False, seq_name=seq_name)
             timer.toc()
 
             # bs=1 in MOT model


### PR DESCRIPTION
While inferring video, the image is not converted to RGB mode
preprocess操作对视频与图片的处理不一致，如果预测图片，则用opencv读入图片后要进行BGR到RGB颜色空间的转换，如果预测视频，则对帧图片不做任何处理就返回，故尝试对deploy/python下的所有infer文件的video_infer部分进行修改

我看了deplo/python中所有infer文件，在develop和release/2.4分支下，对比如下：
1. action_infer.py中未找到infer video相关内容
2. attr_infer.py中未找到infer video相关内容
3. det_keypoint_unite_infer.py中找到infer video相关内容，现有代码已经进行了convert，截图如下：
![image](https://user-images.githubusercontent.com/34644177/168243335-68baee8a-417f-459c-865f-b5e8cc4a0b08.png)
4. infer.py未进行convert，已进行修改
5. keypoint_infer.py未进行convert，已进行修改
![image](https://user-images.githubusercontent.com/34644177/168243666-a53c1ded-d44a-4b90-b039-262acdc57f6d.png)
6. mot_jde_infer.py未进行convert，已进行修改
![image](https://user-images.githubusercontent.com/34644177/168243685-30d3960f-7364-4f13-ab69-3a2d3535c643.png)
7. mot_keypoint_unite_infer.py未进行convert，且两次用到frame，参考det_keypoint_unite_infer.py进行修改
![image](https://user-images.githubusercontent.com/34644177/168243710-b4cf2cf6-77d9-4bb2-bfc8-cb6408d8ad2f.png)
8. mot_sde_infer.py未进行convert，已进行修改
![image](https://user-images.githubusercontent.com/34644177/168243729-9224f962-3abd-4a98-8340-1aaa666a088d.png)