### PR TITLE
fix class init when import ppdet files

### DIFF
--- a/ppdet/modeling/cls_utils.py
+++ b/ppdet/modeling/cls_utils.py
@@ -1,0 +1,40 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def _get_class_default_kwargs(cls, *args, **kwargs):
+    """
+    Get default arguments of a class in dict format, if args and
+    kwargs is specified, it will replace default arguments
+    """
+    varnames = cls.__init__.__code__.co_varnames
+    argcount = cls.__init__.__code__.co_argcount
+    keys = varnames[:argcount]
+    assert keys[0] == 'self'
+    keys = keys[1:]
+
+    values = list(cls.__init__.__defaults__)
+    assert len(values) == len(keys)
+
+    if len(args) > 0:
+        for i, arg in enumerate(args):
+            values[i] = arg
+
+    default_kwargs = dict(zip(keys, values))
+
+    if len(kwargs) > 0:
+        for k, v in kwargs.items():
+            default_kwargs[k] = v
+
+    return default_kwargs

--- a/ppdet/modeling/heads/bbox_head.py
+++ b/ppdet/modeling/heads/bbox_head.py
@@ -24,6 +24,7 @@ from ppdet.core.workspace import register, create
 from .roi_extractor import RoIAlign
 from ..shape_spec import ShapeSpec
 from ..bbox_utils import bbox2delta
+from ..cls_utils import _get_class_default_kwargs
 from ppdet.modeling.layers import ConvNormLayer
 
 __all__ = ['TwoFCHead', 'XConvNormHead', 'BBoxHead']
@@ -178,7 +179,7 @@ class BBoxHead(nn.Layer):
     def __init__(self,
                  head,
                  in_channel,
-                 roi_extractor=RoIAlign().__dict__,
+                 roi_extractor=_get_class_default_kwargs(RoIAlign),
                  bbox_assigner='BboxAssigner',
                  with_pool=False,
                  num_classes=80,

--- a/ppdet/modeling/heads/cascade_head.py
+++ b/ppdet/modeling/heads/cascade_head.py
@@ -22,6 +22,7 @@ from .bbox_head import BBoxHead, TwoFCHead, XConvNormHead
 from .roi_extractor import RoIAlign
 from ..shape_spec import ShapeSpec
 from ..bbox_utils import delta2bbox, clip_bbox, nonempty_bbox
+from ..cls_utils import _get_class_default_kwargs
 
 __all__ = ['CascadeTwoFCHead', 'CascadeXConvNormHead', 'CascadeHead']
 
@@ -153,7 +154,7 @@ class CascadeHead(BBoxHead):
     def __init__(self,
                  head,
                  in_channel,
-                 roi_extractor=RoIAlign().__dict__,
+                 roi_extractor=_get_class_default_kwargs(RoIAlign),
                  bbox_assigner='BboxAssigner',
                  num_classes=80,
                  bbox_weight=[[10., 10., 5., 5.], [20.0, 20.0, 10.0, 10.0],

--- a/ppdet/modeling/heads/face_head.py
+++ b/ppdet/modeling/heads/face_head.py
@@ -40,8 +40,7 @@ class FaceHead(nn.Layer):
     def __init__(self,
                  num_classes=80,
                  in_channels=[96, 96],
-                 anchor_generator=_get_class_default_kwargs(
-                                                AnchorGeneratorSSD),
+                 anchor_generator=_get_class_default_kwargs(AnchorGeneratorSSD),
                  kernel_size=3,
                  padding=1,
                  conv_decay=0.,

--- a/ppdet/modeling/heads/face_head.py
+++ b/ppdet/modeling/heads/face_head.py
@@ -17,6 +17,7 @@ import paddle.nn as nn
 
 from ppdet.core.workspace import register
 from ..layers import AnchorGeneratorSSD
+from ..cls_utils import _get_class_default_kwargs
 
 
 @register
@@ -39,7 +40,8 @@ class FaceHead(nn.Layer):
     def __init__(self,
                  num_classes=80,
                  in_channels=[96, 96],
-                 anchor_generator=AnchorGeneratorSSD().__dict__,
+                 anchor_generator=_get_class_default_kwargs(
+                                                AnchorGeneratorSSD),
                  kernel_size=3,
                  padding=1,
                  conv_decay=0.,

--- a/ppdet/modeling/heads/mask_head.py
+++ b/ppdet/modeling/heads/mask_head.py
@@ -20,6 +20,7 @@ from paddle.nn.initializer import KaimingNormal
 from ppdet.core.workspace import register, create
 from ppdet.modeling.layers import ConvNormLayer
 from .roi_extractor import RoIAlign
+from ..cls_utils import _get_class_default_kwargs
 
 
 @register
@@ -120,7 +121,7 @@ class MaskHead(nn.Layer):
 
     def __init__(self,
                  head,
-                 roi_extractor=RoIAlign().__dict__,
+                 roi_extractor=_get_class_default_kwargs(RoIAlign),
                  mask_assigner='MaskAssigner',
                  num_classes=80,
                  share_bbox_feat=False,

--- a/ppdet/modeling/heads/s2anet_head.py
+++ b/ppdet/modeling/heads/s2anet_head.py
@@ -23,6 +23,7 @@ from ppdet.core.workspace import register
 from ppdet.modeling import ops
 from ppdet.modeling import bbox_utils
 from ppdet.modeling.proposal_generator.target_layer import RBoxAssigner
+from ..cls_utils import _get_class_default_kwargs
 import numpy as np
 
 
@@ -230,7 +231,7 @@ class S2ANetHead(nn.Layer):
                  align_conv_type='AlignConv',
                  align_conv_size=3,
                  use_sigmoid_cls=True,
-                 anchor_assign=RBoxAssigner().__dict__,
+                 anchor_assign=_get_class_default_kwargs(RBoxAssigner),
                  reg_loss_weight=[1.0, 1.0, 1.0, 1.0, 1.1],
                  cls_loss_weight=[1.1, 1.05],
                  reg_loss_type='l1'):

--- a/ppdet/modeling/heads/ssd_head.py
+++ b/ppdet/modeling/heads/ssd_head.py
@@ -114,8 +114,7 @@ class SSDHead(nn.Layer):
     def __init__(self,
                  num_classes=80,
                  in_channels=(512, 1024, 512, 256, 256, 256),
-                 anchor_generator=_get_class_default_kwargs(
-                                        AnchorGeneratorSSD),
+                 anchor_generator=_get_class_default_kwargs(AnchorGeneratorSSD),
                  kernel_size=3,
                  padding=1,
                  use_sepconv=False,

--- a/ppdet/modeling/heads/ssd_head.py
+++ b/ppdet/modeling/heads/ssd_head.py
@@ -20,6 +20,7 @@ from paddle.regularizer import L2Decay
 from paddle import ParamAttr
 
 from ..layers import AnchorGeneratorSSD
+from ..cls_utils import _get_class_default_kwargs
 
 
 class SepConvLayer(nn.Layer):
@@ -113,7 +114,8 @@ class SSDHead(nn.Layer):
     def __init__(self,
                  num_classes=80,
                  in_channels=(512, 1024, 512, 256, 256, 256),
-                 anchor_generator=AnchorGeneratorSSD().__dict__,
+                 anchor_generator=_get_class_default_kwargs(
+                                        AnchorGeneratorSSD),
                  kernel_size=3,
                  padding=1,
                  use_sepconv=False,

--- a/ppdet/modeling/proposal_generator/rpn_head.py
+++ b/ppdet/modeling/proposal_generator/rpn_head.py
@@ -21,6 +21,7 @@ from ppdet.core.workspace import register
 from .anchor_generator import AnchorGenerator
 from .target_layer import RPNTargetAssign
 from .proposal_generator import ProposalGenerator
+from ..cls_utils import _get_class_default_kwargs
 
 
 class RPNFeat(nn.Layer):
@@ -69,10 +70,11 @@ class RPNHead(nn.Layer):
     __shared__ = ['export_onnx']
 
     def __init__(self,
-                 anchor_generator=AnchorGenerator().__dict__,
-                 rpn_target_assign=RPNTargetAssign().__dict__,
-                 train_proposal=ProposalGenerator(12000, 2000).__dict__,
-                 test_proposal=ProposalGenerator().__dict__,
+                 anchor_generator=_get_class_default_kwargs(AnchorGenerator),
+                 rpn_target_assign=_get_class_default_kwargs(RPNTargetAssign),
+                 train_proposal=_get_class_default_kwargs(
+                                        ProposalGenerator, 12000, 2000),
+                 test_proposal=_get_class_default_kwargs(ProposalGenerator),
                  in_channel=1024,
                  export_onnx=False):
         super(RPNHead, self).__init__()

--- a/ppdet/modeling/proposal_generator/rpn_head.py
+++ b/ppdet/modeling/proposal_generator/rpn_head.py
@@ -72,8 +72,8 @@ class RPNHead(nn.Layer):
     def __init__(self,
                  anchor_generator=_get_class_default_kwargs(AnchorGenerator),
                  rpn_target_assign=_get_class_default_kwargs(RPNTargetAssign),
-                 train_proposal=_get_class_default_kwargs(
-                                        ProposalGenerator, 12000, 2000),
+                 train_proposal=_get_class_default_kwargs(ProposalGenerator,
+                                                          12000, 2000),
                  test_proposal=_get_class_default_kwargs(ProposalGenerator),
                  in_channel=1024,
                  export_onnx=False):


### PR DESCRIPTION
**fix class init when import ppdet files**
fix use class instance `.__dict__()` to get the default key word arguments of a class in module initialization. This may cause:
1. class instance will be generated when import files under ppdet, which may cause extra CPU/GPU memory costs
2. class like `AnchorGenerator` will call `paddle.to_tensor` on file importing, which may cause error in `xpu` mode
![image](https://user-images.githubusercontent.com/12605721/168944803-be9c08c5-8753-41af-a987-ad42568fc80c.png)
change to get default keyword arguments from class code spec

tests init dict of Faster RCNN, Mask RCNN, Cascade RCNN, SSD, S2ANet ok