### PR TITLE
fix solov2 not support multi-images

### DIFF
--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -224,7 +224,7 @@ class Detector(object):
             for k, v in res.items():
                 results[k].append(v)
         for k, v in results.items():
-            if k != 'masks':
+            if k not in ['masks', 'segm']:
                 results[k] = np.concatenate(v)
         return results
 


### PR DESCRIPTION
Current now, when execute solov2 inference by `--image_dir` with multiple different shape images, it will raise 
```
File "<__array_function__ internals>", line 6, in concatenate
ValueError: all the input array dimensions for the concatenation axis must match exactly, but along dimension 1, the array at index 0 has size 423 and the array at index 1 has size 404
``` 
This pr is to fix this problem. Note Solov2 is still not support inference with batch size>1