### PR TITLE
fix image infer error in pphuman

### DIFF
--- a/deploy/pphuman/pipe_utils.py
+++ b/deploy/pphuman/pipe_utils.py
@@ -297,6 +297,8 @@ def crop_image_with_det(batch_input, det_res, thresh=0.3):
     crop_res = []
     for b_id, input in enumerate(batch_input):
         boxes_num_i = boxes_num[b_id]
+        if boxes_num_i == 0:
+            continue
         boxes_i = boxes[start_idx:start_idx + boxes_num_i, :]
         score_i = score[start_idx:start_idx + boxes_num_i]
         res = []


### PR DESCRIPTION
- fix error when image with no object detected.
```
File "/root/workspace/base/PaddleDetection/deploy/python/attr_infer.py", line 258, in merge_batch_result
    res_key = batch_result[0].keys()
IndexError: list index out of range
```

- since `predict_video` already checks the input, it works well with no-object video.
