### PR TITLE
pphuman pipeline v2, add model_based to prune extra branchs

### DIFF
--- a/deploy/pphuman/README.md
+++ b/deploy/pphuman/README.md
@@ -67,7 +67,7 @@ PP-Human相关配置位于```deploy/pphuman/config/infer_cfg.yml```中，存放�
 |-------|-------|----------|-----|
 | 图片 | 属性识别 | 目标检测 属性识别 | DET ATTR |
 | 单镜头视频 | 属性识别 | 多目标跟踪 属性识别 | MOT ATTR |
-| 单镜头视频 | 行为识别 | 多目标跟踪 关键点检测 行为识别 | MOT KPT FALLING |
+| 单镜头视频 | 行为识别 | 多目标跟踪 关键点检测 摔倒识别 | MOT KPT SKELETON_ACTION |
 
 例如基于视频输入的属性识别，任务类型包含多目标跟踪和属性识别，具体配置如下：
 
@@ -80,15 +80,18 @@ MOT:
   model_dir: output_inference/mot_ppyoloe_l_36e_pipeline/
   tracker_config: deploy/pphuman/config/tracker_config.yml
   batch_size: 1
+  basemode: "idbased"
 
 ATTR:
   model_dir: output_inference/strongbaseline_r50_30e_pa100k/
   batch_size: 8
+  basemode: "idbased"
+  enable: False
 ```
 
 **注意：**
 
-- 如果用户仅需要实现不同任务，可以在命令行中加入 `--enable_attr=True` 或 `--enable_falling=True`即可，无需修改配置文件
+- 如果用户需要实现不同任务，可以在配置文件对应enable选项设置为True, 其basemode类型会在代码中开启依赖的基础能力模型，比如跟踪模型。
 - 如果用户仅需要修改模型文件路径，可以在命令行中加入 `--model_dir det=ppyoloe/` 即可，无需修改配置文件，详细说明参考下方参数说明文档
 
 
@@ -105,14 +108,14 @@ python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml -
 # 命令行中指定的模型路径优先级高于配置文件
 python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_file=test_video.mp4 --device=gpu --model_dir det=ppyoloe/ [--run_mode trt_fp16]
 
-# 行人属性识别，指定配置文件路径和测试视频
-python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_file=test_video.mp4 --device=gpu --enable_attr=True [--run_mode trt_fp16]
+# 行人属性识别，指定配置文件路径和测试视频，在配置文件中ATTR部分开启enable选项。
+python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_file=test_video.mp4 --device=gpu [--run_mode trt_fp16]
 
-# 行为识别，指定配置文件路径和测试视频
-python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_file=test_video.mp4 --device=gpu --enable_falling=True [--run_mode trt_fp16]
+# 行为识别，指定配置文件路径和测试视频，在配置文件中对应行为识别功能开启enable选项。
+python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_file=test_video.mp4 --device=gpu [--run_mode trt_fp16]
 
-# 行人跨境跟踪，指定配置文件路径和测试视频列表文件夹
-python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_dir=mtmct_dir/ --device=gpu --enable_mtmct=True [--run_mode trt_fp16]
+# 行人跨境跟踪，指定配置文件路径和测试视频列表文件夹，在配置文件中REID部分开启enable选项。
+python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_dir=mtmct_dir/ --device=gpu [--run_mode trt_fp16]
 ```
 
 其他用法请参考[子任务文档](./docs)
@@ -127,9 +130,6 @@ python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml -
 | --image_dir  | Option |  要预测的图片文件夹路径   |
 | --video_file | Option | 需要预测的视频 |
 | --camera_id | Option | 用来预测的摄像头ID，默认为-1(表示不使用摄像头预测，可设置为：0 - (摄像头数目-1) )，预测过程中在可视化界面按`q`退出输出预测结果到：output/output.mp4|
-| --enable_attr| Option | 是否进行属性识别, 默认为False，即不开启属性识别 |
-| --enable_falling| Option | 是否进行行为识别，默认为False，即不开启行为识别 |
-| --enable_mtmct| Option | 是否进行跨境头跟踪，默认为False，即不开启跨境头跟踪 |
 | --device | Option | 运行时的设备，可选择`CPU/GPU/XPU`，默认为`CPU`|
 | --output_dir | Option|可视化结果保存的根目录，默认为output/|
 | --run_mode | Option |使用GPU时，默认为paddle, 可选（paddle/trt_fp32/trt_fp16/trt_int8）|

--- a/deploy/pphuman/README.md
+++ b/deploy/pphuman/README.md
@@ -67,7 +67,7 @@ PP-Human相关配置位于```deploy/pphuman/config/infer_cfg.yml```中，存放�
 |-------|-------|----------|-----|
 | 图片 | 属性识别 | 目标检测 属性识别 | DET ATTR |
 | 单镜头视频 | 属性识别 | 多目标跟踪 属性识别 | MOT ATTR |
-| 单镜头视频 | 行为识别 | 多目标跟踪 关键点检测 行为识别 | MOT KPT ACTION |
+| 单镜头视频 | 行为识别 | 多目标跟踪 关键点检测 行为识别 | MOT KPT FALLING |
 
 例如基于视频输入的属性识别，任务类型包含多目标跟踪和属性识别，具体配置如下：
 
@@ -88,7 +88,7 @@ ATTR:
 
 **注意：**
 
-- 如果用户仅需要实现不同任务，可以在命令行中加入 `--enable_attr=True` 或 `--enable_action=True`即可，无需修改配置文件
+- 如果用户仅需要实现不同任务，可以在命令行中加入 `--enable_attr=True` 或 `--enable_falling=True`即可，无需修改配置文件
 - 如果用户仅需要修改模型文件路径，可以在命令行中加入 `--model_dir det=ppyoloe/` 即可，无需修改配置文件，详细说明参考下方参数说明文档
 
 
@@ -109,10 +109,10 @@ python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml -
 python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_file=test_video.mp4 --device=gpu --enable_attr=True [--run_mode trt_fp16]
 
 # 行为识别，指定配置文件路径和测试视频
-python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_file=test_video.mp4 --device=gpu --enable_action=True [--run_mode trt_fp16]
+python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_file=test_video.mp4 --device=gpu --enable_falling=True [--run_mode trt_fp16]
 
 # 行人跨境跟踪，指定配置文件路径和测试视频列表文件夹
-python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_dir=mtmct_dir/ --device=gpu [--run_mode trt_fp16]
+python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_dir=mtmct_dir/ --device=gpu --enable_mtmct=True [--run_mode trt_fp16]
 ```
 
 其他用法请参考[子任务文档](./docs)
@@ -128,7 +128,8 @@ python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml -
 | --video_file | Option | 需要预测的视频 |
 | --camera_id | Option | 用来预测的摄像头ID，默认为-1(表示不使用摄像头预测，可设置为：0 - (摄像头数目-1) )，预测过程中在可视化界面按`q`退出输出预测结果到：output/output.mp4|
 | --enable_attr| Option | 是否进行属性识别, 默认为False，即不开启属性识别 |
-| --enable_action| Option | 是否进行行为识别，默认为False，即不开启行为识别 |
+| --enable_falling| Option | 是否进行行为识别，默认为False，即不开启行为识别 |
+| --enable_mtmct| Option | 是否进行跨境头跟踪，默认为False，即不开启跨境头跟踪 |
 | --device | Option | 运行时的设备，可选择`CPU/GPU/XPU`，默认为`CPU`|
 | --output_dir | Option|可视化结果保存的根目录，默认为output/|
 | --run_mode | Option |使用GPU时，默认为paddle, 可选（paddle/trt_fp32/trt_fp16/trt_int8）|

--- a/deploy/pphuman/README_en.md
+++ b/deploy/pphuman/README_en.md
@@ -46,8 +46,8 @@ To make users have access to models of different scenarios, PP-Human provides pr
 | Object Detection        | Image/Video Input | mAP: 56.3  | 28.0ms           |[Link](https://bj.bcebos.com/v1/paddledet/models/pipeline/mot_ppyoloe_l_36e_pipeline.pdparams) |[Link](https://bj.bcebos.com/v1/paddledet/models/pipeline/mot_ppyoloe_l_36e_pipeline.zip) |
 | Object Tracking       | Image/Video Input | MOTA: 72.0  | 33.1ms           |[Link](https://bj.bcebos.com/v1/paddledet/models/pipeline/mot_ppyoloe_l_36e_pipeline.pdparams) |[Link](https://bj.bcebos.com/v1/paddledet/models/pipeline/mot_ppyoloe_l_36e_pipeline.zip) |
 | Attribute Recognition    | Image/Video Input  Attribute Recognition | mA: 94.86 |  2ms per person       | - |[Link](https://bj.bcebos.com/v1/paddledet/models/pipeline/strongbaseline_r50_30e_pa100k.zip) |
-| Keypoint Detection    | Video Input  Action Recognition | AP: 87.1 | 2.9ms per person        | [Link](https://bj.bcebos.com/v1/paddledet/models/pipeline/dark_hrnet_w32_256x192.pdparams) |[Link](https://bj.bcebos.com/v1/paddledet/models/pipeline/dark_hrnet_w32_256x192.zip)
-| Action Recognition   |  Video Input  Action Recognition  | Precision 96.43 |  2.7ms per person          | - |[Link](https://bj.bcebos.com/v1/paddledet/models/pipeline/STGCN.zip) |
+| Keypoint Detection    | Video Input  Falling Recognition | AP: 87.1 | 2.9ms per person        | [Link](https://bj.bcebos.com/v1/paddledet/models/pipeline/dark_hrnet_w32_256x192.pdparams) |[Link](https://bj.bcebos.com/v1/paddledet/models/pipeline/dark_hrnet_w32_256x192.zip)
+| Falling Recognition   |  Video Input  Falling Recognition  | Precision 96.43 |  2.7ms per person          | - |[Link](https://bj.bcebos.com/v1/paddledet/models/pipeline/STGCN.zip) |
 | ReID         | Multi-Target Multi-Camera Tracking   | mAP: 98.8 | 1.5ms per person    | - |[Link](https://bj.bcebos.com/v1/paddledet/models/pipeline/reid_model.zip) |
 
 Then, unzip the downloaded model to the folder `./output_inference`.
@@ -68,7 +68,7 @@ Their correspondence is as follows:
 |-------|-------|----------|-----|
 | Image | Attribute Recognition | Object Detection  Attribute Recognition | DET ATTR |
 | Single-Camera Video | Attribute Recognition | Multi-Object Tracking  Attribute Recognition | MOT ATTR |
-| Single-Camera Video | Behavior Recognition | Multi-Object Tracking  Keypoint Detection  Action Recognition | MOT KPT ACTION |
+| Single-Camera Video | Behavior Recognition | Multi-Object Tracking  Keypoint Detection  Falling Recognition | MOT KPT FALLING |
 
 For example, for the attribute recognition with the video input, its task types contain multi-object tracking and attribute recognition, and the config is:
 
@@ -89,7 +89,7 @@ ATTR:
 
 **Note: **
 
-- For different tasks, users could add `--enable_attr=True` or `--enable_action=True` in command line and do not need to set config file.
+- For different tasks, users could add `--enable_attr=True` or `--enable_falling=True` in command line and do not need to set config file.
 - if only need to change the model path, users could add `--model_dir det=ppyoloe/` in command line and do not need to set config file. For details info please refer to doc below.
 
 
@@ -109,11 +109,11 @@ python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml -
 # Attribute recognition. Specify the config file path and test videos
 python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_file=test_video.mp4 --device=gpu --enable_attr=True [--run_mode trt_fp16]
 
-# Action Recognition. Specify the config file path and test videos
-python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_file=test_video.mp4 --device=gpu --enable_action=True [--run_mode trt_fp16]
+# Falling Recognition. Specify the config file path and test videos
+python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_file=test_video.mp4 --device=gpu --enable_falling=True [--run_mode trt_fp16]
 
 # Pedestrian Multi-Target Multi-Camera tracking. Specify the config file path and the directory of test videos
-python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_dir=mtmct_dir/ --device=gpu [--run_mode trt_fp16]
+python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_dir=mtmct_dir/ --device=gpu --enable_mtmct=True [--run_mode trt_fp16]
 
 ```
 
@@ -130,7 +130,7 @@ Other usage please refer to [sub-task docs](./docs)
 | --video_file | Option | Videos to-be-predicted |
 | --camera_id | Option | ID of the inference camera is -1 by default (means inference without cameras，and it can be set to 0 - (number of cameras-1)), and during the inference, click `q` on the visual interface to exit and output the inference result to output/output.mp4|
 | --enable_attr| Option | Enable attribute recognition or not |
-| --enable_action| Option | Enable action recognition or not |
+| --enable_falling| Option | Enable action recognition or not |
 | --device | Option | During the operation，available devices are `CPU/GPU/XPU`，and the default is `CPU`|
 | --output_dir | Option| The default root directory which stores the visualization result is output/|
 | --run_mode | Option | When using GPU，the default one is paddle, and all these are available（paddle/trt_fp32/trt_fp16/trt_int8）.|
@@ -169,8 +169,8 @@ The overall solution of PP-Human is as follows:
 - Use StrongBaseline（a multi-class model）to conduct attribute recognition, and the main attributes include age, gender, hats, eyes, clothing, and backpacks.
 - For details, please refer to [Attribute Recognition](docs/attribute_en.md)
 
-### 5. Action Recognition
+### 5. Falling Recognition
 - Use PP-YOLOE + Bytetrack to track humans
 - Use HRNet for keypoint detection and get the information of the 17 key points in the human body
 - According to the changes of the key points of the same person within 50 frames, judge whether the action made by the person within 50 frames is a fall with the help of ST-GCN
-- For details, please refer to [Action Recognition](docs/action_en.md)
+- For details, please refer to [Falling Recognition](docs/action_en.md)

--- a/deploy/pphuman/README_en.md
+++ b/deploy/pphuman/README_en.md
@@ -68,7 +68,7 @@ Their correspondence is as follows:
 |-------|-------|----------|-----|
 | Image | Attribute Recognition | Object Detection  Attribute Recognition | DET ATTR |
 | Single-Camera Video | Attribute Recognition | Multi-Object Tracking  Attribute Recognition | MOT ATTR |
-| Single-Camera Video | Behavior Recognition | Multi-Object Tracking  Keypoint Detection  Falling Recognition | MOT KPT FALLING |
+| Single-Camera Video | Behavior Recognition | Multi-Object Tracking  Keypoint Detection  Falling Recognition | MOT KPT SKELETON_ACTION |
 
 For example, for the attribute recognition with the video input, its task types contain multi-object tracking and attribute recognition, and the config is:
 
@@ -89,7 +89,7 @@ ATTR:
 
 **Note: **
 
-- For different tasks, users could add `--enable_attr=True` or `--enable_falling=True` in command line and do not need to set config file.
+- For different tasks, users should set the "enable" to "True" in coresponding configs in the infer_cfg.yml file.
 - if only need to change the model path, users could add `--model_dir det=ppyoloe/` in command line and do not need to set config file. For details info please refer to doc below.
 
 
@@ -106,14 +106,14 @@ python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml -
 # The model path specified on the command line prioritizes over the config file
 python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_file=test_video.mp4 --device=gpu --model_dir det=ppyoloe/ [--run_mode trt_fp16]
 
-# Attribute recognition. Specify the config file path and test videos
-python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_file=test_video.mp4 --device=gpu --enable_attr=True [--run_mode trt_fp16]
+# Attribute recognition. Specify the config file path and test videos, and set the "enable" to "True" in ATTR of infer_cfg.yml
+python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_file=test_video.mp4 --device=gpu [--run_mode trt_fp16]
 
-# Falling Recognition. Specify the config file path and test videos
-python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_file=test_video.mp4 --device=gpu --enable_falling=True [--run_mode trt_fp16]
+# Action Recognition. Specify the config file path and test videos, and set the "enable" to "True" in corresponding action configs of infer_cfg.yml
+python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_file=test_video.mp4 --device=gpu [--run_mode trt_fp16]
 
-# Pedestrian Multi-Target Multi-Camera tracking. Specify the config file path and the directory of test videos
-python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_dir=mtmct_dir/ --device=gpu --enable_mtmct=True [--run_mode trt_fp16]
+# Pedestrian Multi-Target Multi-Camera tracking. Specify the config file path and the directory of test videos, and set the "enable" to "True" in REID in infer_cfg.yml
+python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_dir=mtmct_dir/ --device=gpu [--run_mode trt_fp16]
 
 ```
 
@@ -129,8 +129,6 @@ Other usage please refer to [sub-task docs](./docs)
 | --image_dir  | Option |  The path of folders of to-be-predicted images  |
 | --video_file | Option | Videos to-be-predicted |
 | --camera_id | Option | ID of the inference camera is -1 by default (means inference without cameras，and it can be set to 0 - (number of cameras-1)), and during the inference, click `q` on the visual interface to exit and output the inference result to output/output.mp4|
-| --enable_attr| Option | Enable attribute recognition or not |
-| --enable_falling| Option | Enable action recognition or not |
 | --device | Option | During the operation，available devices are `CPU/GPU/XPU`，and the default is `CPU`|
 | --output_dir | Option| The default root directory which stores the visualization result is output/|
 | --run_mode | Option | When using GPU，the default one is paddle, and all these are available（paddle/trt_fp32/trt_fp16/trt_int8）.|

--- a/deploy/pphuman/config/infer_cfg.yml
+++ b/deploy/pphuman/config/infer_cfg.yml
@@ -11,23 +11,27 @@ DET:
 ATTR:
   model_dir: output_inference/strongbaseline_r50_30e_pa100k/
   batch_size: 8
+  basemode: "idbased"
 
 MOT:
   model_dir: output_inference/mot_ppyoloe_l_36e_pipeline/
   tracker_config: deploy/pphuman/config/tracker_config.yml
   batch_size: 1
+  basemode: "idbased"
 
 KPT:
   model_dir: output_inference/dark_hrnet_w32_256x192/
   batch_size: 8
 
-ACTION:
+FALLING:
   model_dir: output_inference/STGCN
   batch_size: 1
   max_frames: 50
   display_frames: 80
   coord_size: [384, 512]
+  basemode: "skeletonbased"
 
 REID:
   model_dir: output_inference/reid_model/
   batch_size: 16
+  basemode: "idbased"

--- a/deploy/pphuman/config/infer_cfg.yml
+++ b/deploy/pphuman/config/infer_cfg.yml
@@ -41,11 +41,13 @@ SKELETON_ACTION:
 ID_BASED_DETACTION:
   model_dir: output_inference/detector
   batch_size: 1
+  basemode: "idbased"
   enable: False
 
 ID_BASED_CLSACTION:
   model_dir: output_inference/classification
   batch_size: 1
+  basemode: "idbased"
   enable: False
 
 REID:

--- a/deploy/pphuman/config/infer_cfg.yml
+++ b/deploy/pphuman/config/infer_cfg.yml
@@ -8,11 +8,6 @@ DET:
   model_dir: output_inference/mot_ppyoloe_l_36e_pipeline/
   batch_size: 1
 
-ATTR:
-  model_dir: output_inference/strongbaseline_r50_30e_pa100k/
-  batch_size: 8
-  basemode: "idbased"
-
 MOT:
   model_dir: output_inference/mot_ppyoloe_l_36e_pipeline/
   tracker_config: deploy/pphuman/config/tracker_config.yml
@@ -23,15 +18,23 @@ KPT:
   model_dir: output_inference/dark_hrnet_w32_256x192/
   batch_size: 8
 
-FALLING:
+ATTR:
+  model_dir: output_inference/strongbaseline_r50_30e_pa100k/
+  batch_size: 8
+  basemode: "idbased"
+  enable: False
+
+SKELETON_ACTION:
   model_dir: output_inference/STGCN
   batch_size: 1
   max_frames: 50
   display_frames: 80
   coord_size: [384, 512]
   basemode: "skeletonbased"
+  enable: False
 
 REID:
   model_dir: output_inference/reid_model/
   batch_size: 16
   basemode: "idbased"
+  enable: False

--- a/deploy/pphuman/config/infer_cfg.yml
+++ b/deploy/pphuman/config/infer_cfg.yml
@@ -24,6 +24,11 @@ ATTR:
   basemode: "idbased"
   enable: False
 
+VIDEO_ACTION:
+  model_dir: output_inference/pp-stm
+  batch_size: 1
+  enable: False
+
 SKELETON_ACTION:
   model_dir: output_inference/STGCN
   batch_size: 1
@@ -31,6 +36,16 @@ SKELETON_ACTION:
   display_frames: 80
   coord_size: [384, 512]
   basemode: "skeletonbased"
+  enable: False
+
+ID_BASED_DETACTION:
+  model_dir: output_inference/detector
+  batch_size: 1
+  enable: False
+
+ID_BASED_CLSACTION:
+  model_dir: output_inference/classification
+  batch_size: 1
   enable: False
 
 REID:

--- a/deploy/pphuman/datacollector.py
+++ b/deploy/pphuman/datacollector.py
@@ -23,7 +23,7 @@ class Result(object):
             'mot': dict(),
             'attr': dict(),
             'kpt': dict(),
-            'falling': dict(),
+            'skeleton_action': dict(),
             'reid': dict()
         }
 
@@ -53,13 +53,13 @@ class DataCollector(object):
       - qualities(list of float): Nx[float]
       - attrs(list of attr): refer to attrs for details
       - kpts(list of kpts): refer to kpts for details
-      - falling(list of falling): refer to falling for details
+      - skeleton_action(list of skeleton_action): refer to skeleton_action for details
     ...
     - [idN]
   """
 
     def __init__(self):
-        #id, frame, rect, score, label, attrs, kpts, falling
+        #id, frame, rect, score, label, attrs, kpts, skeleton_action
         self.mots = {
             "frames": [],
             "rects": [],
@@ -67,7 +67,7 @@ class DataCollector(object):
             "kpts": [],
             "features": [],
             "qualities": [],
-            "falling": []
+            "skeleton_action": []
         }
         self.collector = {}
 
@@ -75,7 +75,7 @@ class DataCollector(object):
         mot_res = Result.get('mot')
         attr_res = Result.get('attr')
         kpt_res = Result.get('kpt')
-        falling_res = Result.get('falling')
+        skeleton_action_res = Result.get('skeleton_action')
         reid_res = Result.get('reid')
 
         rects = []
@@ -95,11 +95,12 @@ class DataCollector(object):
             if kpt_res:
                 self.collector[ids]["kpts"].append(
                     [kpt_res['keypoint'][0][idx], kpt_res['keypoint'][1][idx]])
-            if falling_res and (idx + 1) in falling_res:
-                self.collector[ids]["falling"].append(falling_res[idx + 1])
+            if skeleton_action_res and (idx + 1) in skeleton_action_res:
+                self.collector[ids]["skeleton_action"].append(
+                    skeleton_action_res[idx + 1])
             else:
                 # action model generate result per X frames, Not available every frames
-                self.collector[ids]["falling"].append(None)
+                self.collector[ids]["skeleton_action"].append(None)
             if reid_res:
                 self.collector[ids]["features"].append(reid_res['features'][
                     idx])

--- a/deploy/pphuman/datacollector.py
+++ b/deploy/pphuman/datacollector.py
@@ -23,7 +23,7 @@ class Result(object):
             'mot': dict(),
             'attr': dict(),
             'kpt': dict(),
-            'action': dict(),
+            'falling': dict(),
             'reid': dict()
         }
 
@@ -53,13 +53,13 @@ class DataCollector(object):
       - qualities(list of float): Nx[float]
       - attrs(list of attr): refer to attrs for details
       - kpts(list of kpts): refer to kpts for details
-      - actions(list of actions): refer to actions for details
+      - falling(list of falling): refer to falling for details
     ...
     - [idN]
   """
 
     def __init__(self):
-        #id, frame, rect, score, label, attrs, kpts, actions
+        #id, frame, rect, score, label, attrs, kpts, falling
         self.mots = {
             "frames": [],
             "rects": [],
@@ -67,7 +67,7 @@ class DataCollector(object):
             "kpts": [],
             "features": [],
             "qualities": [],
-            "actions": []
+            "falling": []
         }
         self.collector = {}
 
@@ -75,10 +75,15 @@ class DataCollector(object):
         mot_res = Result.get('mot')
         attr_res = Result.get('attr')
         kpt_res = Result.get('kpt')
-        action_res = Result.get('action')
+        falling_res = Result.get('falling')
         reid_res = Result.get('reid')
 
-        rects = reid_res['rects'] if reid_res is not None else mot_res['boxes']
+        rects = []
+        if reid_res is not None:
+            rects = reid_res['rects']
+        elif mot_res is not None:
+            rects = mot_res['boxes']
+
         for idx, mot_item in enumerate(rects):
             ids = int(mot_item[0])
             if ids not in self.collector:
@@ -90,11 +95,11 @@ class DataCollector(object):
             if kpt_res:
                 self.collector[ids]["kpts"].append(
                     [kpt_res['keypoint'][0][idx], kpt_res['keypoint'][1][idx]])
-            if action_res and (idx + 1) in action_res:
-                self.collector[ids]["actions"].append(action_res[idx + 1])
+            if falling_res and (idx + 1) in falling_res:
+                self.collector[ids]["falling"].append(falling_res[idx + 1])
             else:
                 # action model generate result per X frames, Not available every frames
-                self.collector[ids]["actions"].append(None)
+                self.collector[ids]["falling"].append(None)
             if reid_res:
                 self.collector[ids]["features"].append(reid_res['features'][
                     idx])

--- a/deploy/pphuman/docs/action.md
+++ b/deploy/pphuman/docs/action.md
@@ -28,32 +28,32 @@
 ## 配置说明
 [配置文件](../config/infer_cfg.yml)中与行为识别相关的参数如下：
 ```
-FALLING:
+SKELETON_ACTION:
   model_dir: output_inference/STGCN  # 模型所在路径
   batch_size: 1 # 预测批大小。 当前仅支持为1进行推理
   max_frames: 50 # 动作片段对应的帧数。在行人ID对应时序骨骼点结果时达到该帧数后，会通过行为识别模型判断该段序列的动作类型。与训练设置一致时效果最佳。
   display_frames: 80 # 显示帧数。当预测结果为摔倒时，在对应人物ID中显示状态的持续时间。
   coord_size: [384, 512] # 坐标统一缩放到的尺度大小。与训练设置一致时效果最佳。
+  basemode: "skeletonbased" #模型基于的路线分支，是否需要skeleton作为输入
+  enable: False #是否开启该功能
 ```
 
 ## 使用方法
 1. 从上表链接中下载模型并解压到```./output_inference```路径下。
-2. 目前行为识别模块仅支持视频输入，启动命令如下：
+2. 目前行为识别模块仅支持视频输入，设置infer_cfg.yml中`SKELETON_ACTION`的enable: True, 然后启动命令如下：
 ```python
 python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml \
                                                    --video_file=test_video.mp4 \
                                                    --device=gpu \
-                                                   --enable_falling=True
 ```
 3. 若修改模型路径，有以下两种方式：
 
-    - ```./deploy/pphuman/config/infer_cfg.yml```下可以配置不同模型路径，关键点模型和行为识别模型分别对应`KPT`和`FALLING`字段，修改对应字段下的路径为实际期望的路径即可。
+    - ```./deploy/pphuman/config/infer_cfg.yml```下可以配置不同模型路径，关键点模型和摔倒行为识别模型分别对应`KPT`和`SKELETON_ACTION`字段，修改对应字段下的路径为实际期望的路径即可。
     - 命令行中增加`--model_dir`修改模型路径：
 ```python
 python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml \
                                                    --video_file=test_video.mp4 \
                                                    --device=gpu \
-                                                   --enable_falling=True \
                                                    --model_dir kpt=./dark_hrnet_w32_256x192 action=./STGCN
 ```
 
@@ -78,7 +78,7 @@ python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml \
 ## 参考文献
 ```
 @inproceedings{stgcn2018aaai,
-  title     = {Spatial Temporal Graph Convolutional Networks for Skeleton-Based Falling Recognition},
+  title     = {Spatial Temporal Graph Convolutional Networks for Skeleton-Based Action Recognition},
   author    = {Sijie Yan and Yuanjun Xiong and Dahua Lin},
   booktitle = {AAAI},
   year      = {2018},

--- a/deploy/pphuman/docs/action.md
+++ b/deploy/pphuman/docs/action.md
@@ -28,7 +28,7 @@
 ## 配置说明
 [配置文件](../config/infer_cfg.yml)中与行为识别相关的参数如下：
 ```
-ACTION:
+FALLING:
   model_dir: output_inference/STGCN  # 模型所在路径
   batch_size: 1 # 预测批大小。 当前仅支持为1进行推理
   max_frames: 50 # 动作片段对应的帧数。在行人ID对应时序骨骼点结果时达到该帧数后，会通过行为识别模型判断该段序列的动作类型。与训练设置一致时效果最佳。
@@ -43,17 +43,17 @@ ACTION:
 python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml \
                                                    --video_file=test_video.mp4 \
                                                    --device=gpu \
-                                                   --enable_action=True
+                                                   --enable_falling=True
 ```
 3. 若修改模型路径，有以下两种方式：
 
-    - ```./deploy/pphuman/config/infer_cfg.yml```下可以配置不同模型路径，关键点模型和行为识别模型分别对应`KPT`和`ACTION`字段，修改对应字段下的路径为实际期望的路径即可。
+    - ```./deploy/pphuman/config/infer_cfg.yml```下可以配置不同模型路径，关键点模型和行为识别模型分别对应`KPT`和`FALLING`字段，修改对应字段下的路径为实际期望的路径即可。
     - 命令行中增加`--model_dir`修改模型路径：
 ```python
 python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml \
                                                    --video_file=test_video.mp4 \
                                                    --device=gpu \
-                                                   --enable_action=True \
+                                                   --enable_falling=True \
                                                    --model_dir kpt=./dark_hrnet_w32_256x192 action=./STGCN
 ```
 
@@ -78,7 +78,7 @@ python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml \
 ## 参考文献
 ```
 @inproceedings{stgcn2018aaai,
-  title     = {Spatial Temporal Graph Convolutional Networks for Skeleton-Based Action Recognition},
+  title     = {Spatial Temporal Graph Convolutional Networks for Skeleton-Based Falling Recognition},
   author    = {Sijie Yan and Yuanjun Xiong and Dahua Lin},
   booktitle = {AAAI},
   year      = {2018},

--- a/deploy/pphuman/docs/action_en.md
+++ b/deploy/pphuman/docs/action_en.md
@@ -35,12 +35,14 @@ Note:
 Parameters related to action recognition in the [config file](../config/infer_cfg.yml) are as follow:
 
 ```
-FALLING:
+SKELETON_ACTION:
   model_dir: output_inference/STGCN  # Path of the model
   batch_size: 1 # The size of the inference batch. The only avilable size for inference is 1.
   max_frames: 50 # The number of frames of action segments. When frames of time-ordered skeleton keypoints of each pedestrian ID achieve the max value,the action type will be judged by the action recognition model. If the setting is the same as the training, there will be an ideal inference result.
   display_frames: 80 # The number of display frames. When the inferred action type is falling down, the time length of the act will be displayed in the ID.
   coord_size: [384, 512] # The unified size of the coordinate, which is the best when it is the same as the training setting.
+  basemode: "skeletonbased" #the models which is based on，whether we need the skeleton model.
+  enable: False #whether to enable this function
 ```
 
 
@@ -50,18 +52,17 @@ FALLING:
 
 - Download models from the links of the above table and unzip them to ```./output_inference```.
 
-- Now the only available input is the video input in the action recognition module. The start command is:
+- Now the only available input is the video input in the action recognition module. set the "enable: True" in SKELETON_ACTION of infer_cfg.yml. And then run the command:
 
   ```python
   python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml \
                                                      --video_file=test_video.mp4 \
-                                                     --device=gpu \
-                                                     --enable_falling=True
+                                                     --device=gpu
   ```
 
 - There are two ways to modify the model path:
 
-  - In ```./deploy/pphuman/config/infer_cfg.yml```, you can configurate different model paths，which is proper only if you match keypoint models and action recognition models with the fields of `KPT` and `FALLING`respectively, and modify the corresponding path of each field into the expected path.
+  - In ```./deploy/pphuman/config/infer_cfg.yml```, you can configurate different model paths，which is proper only if you match keypoint models and action recognition models with the fields of `KPT` and `SKELETON_ACTION` respectively, and modify the corresponding path of each field into the expected path.
 
   - Add `--model_dir` in the command line to revise the model path：
 
@@ -69,7 +70,6 @@ FALLING:
     python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml \
                                                        --video_file=test_video.mp4 \
                                                        --device=gpu \
-                                                       --enable_falling=True \
                                                        --model_dir kpt=./dark_hrnet_w32_256x192 action=./STGCN
     ```
 
@@ -108,7 +108,7 @@ The pretrained models are provided and can be used directly, including pedestria
 
 ```
 @inproceedings{stgcn2018aaai,
-  title     = {Spatial Temporal Graph Convolutional Networks for Skeleton-Based Falling Recognition},
+  title     = {Spatial Temporal Graph Convolutional Networks for Skeleton-Based Action Recognition},
   author    = {Sijie Yan and Yuanjun Xiong and Dahua Lin},
   booktitle = {AAAI},
   year      = {2018},

--- a/deploy/pphuman/docs/action_en.md
+++ b/deploy/pphuman/docs/action_en.md
@@ -1,8 +1,8 @@
 English | [简体中文](action.md)
 
-# Action Recognition Module of PP-Human
+# Falling Recognition Module of PP-Human
 
-Action Recognition is widely used in the intelligent community/smart city, and security monitoring. PP-Human provides the module of skeleton-based action recognition.
+Falling Recognition is widely used in the intelligent community/smart city, and security monitoring. PP-Human provides the module of skeleton-based action recognition.
 
 <div align="center">  <img src="./images/action.gif" width='1000'/> <center>Data source and copyright owner：Skyinfor
 Technology. Thanks for the provision of actual scenario data, which are only
@@ -18,7 +18,7 @@ There are multiple available pretrained models including pedestrian detection/tr
 |:----------------------------- |:---------:|:-------------------------:|:-----------------------------------:| :-----------------:  |:-----------------------------------------------------------------------------------------:|
 | Pedestrian Detection/Tracking | PP-YOLOE  | mAP: 56.3 <br> MOTA: 72.0 | Detection: 28ms <br>Tracking：33.1ms |[Link](https://bj.bcebos.com/v1/paddledet/models/pipeline/mot_ppyoloe_l_36e_pipeline.pdparams) |[Link](https://bj.bcebos.com/v1/paddledet/models/pipeline/mot_ppyoloe_l_36e_pipeline.zip) |
 | Keypoint Detection            | HRNet     | AP: 87.1                  | Single Person 2.9ms                 |[Link](https://bj.bcebos.com/v1/paddledet/models/pipeline/dark_hrnet_w32_256x192.pdparams) |[Link](https://bj.bcebos.com/v1/paddledet/models/pipeline/dark_hrnet_w32_256x192.zip)     |
-| Action Recognition            | ST-GCN    | Precision Rate: 96.43     | Single Person 2.7ms                 | - |[Link](https://bj.bcebos.com/v1/paddledet/models/pipeline/STGCN.zip)                      |
+| Falling Recognition            | ST-GCN    | Precision Rate: 96.43     | Single Person 2.7ms                 | - |[Link](https://bj.bcebos.com/v1/paddledet/models/pipeline/STGCN.zip)                      |
 
 Note:
 
@@ -35,7 +35,7 @@ Note:
 Parameters related to action recognition in the [config file](../config/infer_cfg.yml) are as follow:
 
 ```
-ACTION:
+FALLING:
   model_dir: output_inference/STGCN  # Path of the model
   batch_size: 1 # The size of the inference batch. The only avilable size for inference is 1.
   max_frames: 50 # The number of frames of action segments. When frames of time-ordered skeleton keypoints of each pedestrian ID achieve the max value,the action type will be judged by the action recognition model. If the setting is the same as the training, there will be an ideal inference result.
@@ -56,12 +56,12 @@ ACTION:
   python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml \
                                                      --video_file=test_video.mp4 \
                                                      --device=gpu \
-                                                     --enable_action=True
+                                                     --enable_falling=True
   ```
 
 - There are two ways to modify the model path:
 
-  - In ```./deploy/pphuman/config/infer_cfg.yml```, you can configurate different model paths，which is proper only if you match keypoint models and action recognition models with the fields of `KPT` and `ACTION`respectively, and modify the corresponding path of each field into the expected path.
+  - In ```./deploy/pphuman/config/infer_cfg.yml```, you can configurate different model paths，which is proper only if you match keypoint models and action recognition models with the fields of `KPT` and `FALLING`respectively, and modify the corresponding path of each field into the expected path.
 
   - Add `--model_dir` in the command line to revise the model path：
 
@@ -69,7 +69,7 @@ ACTION:
     python deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml \
                                                        --video_file=test_video.mp4 \
                                                        --device=gpu \
-                                                       --enable_action=True \
+                                                       --enable_falling=True \
                                                        --model_dir kpt=./dark_hrnet_w32_256x192 action=./STGCN
     ```
 
@@ -93,7 +93,7 @@ ACTION:
 4. The action recognition model uses [ST-GCN](https://arxiv.org/abs/1801.07455), and employ the [PaddleVideo](https://github.com/PaddlePaddle/PaddleVideo/blob/develop/docs/zh-CN/model_zoo/recognition/stgcn.md) toolkit to complete model training.
 
 
-## Custom Action Training
+## Custom Falling Training
 
 The pretrained models are provided and can be used directly, including pedestrian detection/ tracking, keypoint detection and fall recognition. If users need to train custom action or optimize the model performance, please refer the link below.
 
@@ -108,7 +108,7 @@ The pretrained models are provided and can be used directly, including pedestria
 
 ```
 @inproceedings{stgcn2018aaai,
-  title     = {Spatial Temporal Graph Convolutional Networks for Skeleton-Based Action Recognition},
+  title     = {Spatial Temporal Graph Convolutional Networks for Skeleton-Based Falling Recognition},
   author    = {Sijie Yan and Yuanjun Xiong and Dahua Lin},
   booktitle = {AAAI},
   year      = {2018},

--- a/deploy/pphuman/docs/mtmct.md
+++ b/deploy/pphuman/docs/mtmct.md
@@ -9,9 +9,9 @@ PP-Human跨镜头跟踪模块主要目的在于提供一套简洁、高效的跨
 
 1. 下载模型 [REID模型](https://bj.bcebos.com/v1/paddledet/models/pipeline/reid_model.zip) 并解压到```./output_inference```路径下, MOT模型请参考[mot说明](./mot.md)文件下载。
 
-2. 跨镜头跟踪模式下，要求输入的多个视频放在同一目录下，命令如下：
+2. 跨镜头跟踪模式下，要求输入的多个视频放在同一目录下，同时开启infer_cfg.yml 中的REID选择中的enable=True, 命令如下：
 ```python
-python3 deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_dir=[your_video_file_directory] --device=gpu --enable_mtmct=True
+python3 deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_dir=[your_video_file_directory] --device=gpu
 ```
 
 3. 相关配置在`./deploy/pphuman/config/infer_cfg.yml`文件中修改：

--- a/deploy/pphuman/docs/mtmct.md
+++ b/deploy/pphuman/docs/mtmct.md
@@ -11,7 +11,7 @@ PP-Human跨镜头跟踪模块主要目的在于提供一套简洁、高效的跨
 
 2. 跨镜头跟踪模式下，要求输入的多个视频放在同一目录下，命令如下：
 ```python
-python3 deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_dir=[your_video_file_directory] --device=gpu
+python3 deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_dir=[your_video_file_directory] --device=gpu --enable_mtmct=True
 ```
 
 3. 相关配置在`./deploy/pphuman/config/infer_cfg.yml`文件中修改：

--- a/deploy/pphuman/docs/mtmct_en.md
+++ b/deploy/pphuman/docs/mtmct_en.md
@@ -9,7 +9,7 @@ The MTMCT module of PP-Human aims to provide a multi-target multi-camera pipleli
 
 1. Download [REID model](https://bj.bcebos.com/v1/paddledet/models/pipeline/reid_model.zip) and unzip it to ```./output_inference```. For the MOT model, please refer to [mot description](./mot.md).
 
-2. In the MTMCT mode, input videos are required to be put in the same directory. The command line is:
+2. In the MTMCT mode, input videos are required to be put in the same directory. set the REID "enable: True" in the infer_cfg.yml. The command line is:
 ```python
 python3 deploy/pphuman/pipeline.py --config deploy/pphuman/config/infer_cfg.yml --video_dir=[your_video_file_directory] --device=gpu
 ```

--- a/deploy/pphuman/pipe_utils.py
+++ b/deploy/pphuman/pipe_utils.py
@@ -58,21 +58,6 @@ def argsparser():
         default=-1,
         help="device id of camera to predict.")
     parser.add_argument(
-        "--enable_attr",
-        type=ast.literal_eval,
-        default=False,
-        help="Whether use attribute recognition.")
-    parser.add_argument(
-        "--enable_falling",
-        type=ast.literal_eval,
-        default=False,
-        help="Whether use action recognition.")
-    parser.add_argument(
-        "--enable_mtmct",
-        type=ast.literal_eval,
-        default=False,
-        help="Whether to enable multi-camera reid track.")
-    parser.add_argument(
         "--output_dir",
         type=str,
         default="output",
@@ -167,7 +152,7 @@ class PipeTimer(Times):
             'mot': Times(),
             'attr': Times(),
             'kpt': Times(),
-            'falling': Times(),
+            'skeleton_action': Times(),
             'reid': Times()
         }
         self.img_num = 0
@@ -212,9 +197,9 @@ class PipeTimer(Times):
         dic['kpt'] = round(self.module_time['kpt'].value() /
                            max(1, self.img_num),
                            4) if average else self.module_time['kpt'].value()
-        dic['falling'] = round(
-            self.module_time['falling'].value() / max(1, self.img_num),
-            4) if average else self.module_time['falling'].value()
+        dic['skeleton_action'] = round(
+            self.module_time['skeleton_action'].value() / max(1, self.img_num),
+            4) if average else self.module_time['skeleton_action'].value()
 
         dic['img_num'] = self.img_num
         return dic
@@ -222,7 +207,7 @@ class PipeTimer(Times):
 
 def merge_model_dir(args, model_dir):
     # set --model_dir DET=ppyoloe/ to overwrite the model_dir in config file
-    task_set = ['DET', 'ATTR', 'MOT', 'KPT', 'FALLING', 'REID']
+    task_set = ['DET', 'ATTR', 'MOT', 'KPT', 'SKELETON_ACTION', 'REID']
     if not model_dir:
         return args
     for md in model_dir:

--- a/deploy/pphuman/pipe_utils.py
+++ b/deploy/pphuman/pipe_utils.py
@@ -63,10 +63,15 @@ def argsparser():
         default=False,
         help="Whether use attribute recognition.")
     parser.add_argument(
-        "--enable_action",
+        "--enable_falling",
         type=ast.literal_eval,
         default=False,
         help="Whether use action recognition.")
+    parser.add_argument(
+        "--enable_mtmct",
+        type=ast.literal_eval,
+        default=False,
+        help="Whether to enable multi-camera reid track.")
     parser.add_argument(
         "--output_dir",
         type=str,
@@ -162,7 +167,7 @@ class PipeTimer(Times):
             'mot': Times(),
             'attr': Times(),
             'kpt': Times(),
-            'action': Times(),
+            'falling': Times(),
             'reid': Times()
         }
         self.img_num = 0
@@ -207,9 +212,9 @@ class PipeTimer(Times):
         dic['kpt'] = round(self.module_time['kpt'].value() /
                            max(1, self.img_num),
                            4) if average else self.module_time['kpt'].value()
-        dic['action'] = round(
-            self.module_time['action'].value() / max(1, self.img_num),
-            4) if average else self.module_time['action'].value()
+        dic['falling'] = round(
+            self.module_time['falling'].value() / max(1, self.img_num),
+            4) if average else self.module_time['falling'].value()
 
         dic['img_num'] = self.img_num
         return dic
@@ -217,7 +222,7 @@ class PipeTimer(Times):
 
 def merge_model_dir(args, model_dir):
     # set --model_dir DET=ppyoloe/ to overwrite the model_dir in config file
-    task_set = ['DET', 'ATTR', 'MOT', 'KPT', 'ACTION', 'REID']
+    task_set = ['DET', 'ATTR', 'MOT', 'KPT', 'FALLING', 'REID']
     if not model_dir:
         return args
     for md in model_dir:

--- a/deploy/pphuman/pipeline.py
+++ b/deploy/pphuman/pipeline.py
@@ -266,12 +266,27 @@ class PipePredictor(object):
         self.with_skeleton_action = cfg.get(
             'SKELETON_ACTION', False)['enable'] if cfg.get('SKELETON_ACTION',
                                                            False) else False
+        self.with_video_action = cfg.get(
+            'VIDEO_ACTION', False)['enable'] if cfg.get('VIDEO_ACTION',
+                                                        False) else False
+        self.with_idbased_detaction = cfg.get(
+            'ID_BASED_DETACTION', False)['enable'] if cfg.get(
+                'ID_BASED_DETACTION', False) else False
+        self.with_idbased_clsaction = cfg.get(
+            'ID_BASED_CLSACTION', False)['enable'] if cfg.get(
+                'ID_BASED_CLSACTION', False) else False
         self.with_mtmct = cfg.get('REID', False)['enable'] if cfg.get(
             'REID', False) else False
         if self.with_attr:
             print('Attribute Recognition enabled')
         if self.with_skeleton_action:
             print('SkeletonAction Recognition enabled')
+        if self.with_video_action:
+            print('VideoAction Recognition enabled')
+        if self.with_idbased_detaction:
+            print('IDBASED Detection Action Recognition enabled')
+        if self.with_idbased_clsaction:
+            print('IDBASED Classification Action Recognition enabled')
         if self.with_mtmct:
             print("MTMCT enabled")
 
@@ -547,6 +562,7 @@ class PipePredictor(object):
 
                 self.pipeline_res.update(mot_res, 'mot')
                 if self.with_attr or self.with_skeleton_action:
+                    #todo: move this code to each class's predeal function
                     crop_input, new_bboxes, ori_bboxes = crop_image_with_mot(
                         frame, mot_res)
 
@@ -558,6 +574,18 @@ class PipePredictor(object):
                     if frame_id > self.warmup_frame:
                         self.pipe_timer.module_time['attr'].end()
                     self.pipeline_res.update(attr_res, 'attr')
+
+                if self.with_idbased_detaction:
+                    #predeal, get what your model need
+                    #predict, model preprocess\run\postprocess
+                    #postdeal, interact with pipeline
+                    pass
+
+                if self.with_idbased_clsaction:
+                    #predeal, get what your model need
+                    #predict, model preprocess\run\postprocess
+                    #postdeal, interact with pipeline
+                    pass
 
                 if self.with_skeleton_action:
                     if self.modebase["skeletonbased"]:
@@ -621,10 +649,10 @@ class PipePredictor(object):
                 else:
                     self.pipeline_res.clear('reid')
 
-            if self.modebase["videobased"]:
-                pass
-
-            if self.modebase["framebased"]:
+            if self.with_video_action:
+                #predeal, get what your model need
+                #predict, model preprocess\run\postprocess
+                #postdeal, interact with pipeline
                 pass
 
             self.collector.append(frame_id, self.pipeline_res)

--- a/deploy/pphuman/pipeline.py
+++ b/deploy/pphuman/pipeline.py
@@ -36,8 +36,8 @@ from python.infer import Detector, DetectorPicoDet
 from python.attr_infer import AttrDetector
 from python.keypoint_infer import KeyPointDetector
 from python.keypoint_postprocess import translate_to_ori_images
-from python.action_infer import ActionRecognizer
-from python.action_utils import KeyPointBuff, ActionVisualHelper
+from python.action_infer import FallingRecognizer
+from python.action_utils import KeyPointBuff, FallingVisualHelper
 
 from pipe_utils import argsparser, print_arguments, merge_cfg, PipeTimer
 from pipe_utils import get_test_images, crop_image_with_det, crop_image_with_mot, parse_mot_res, parse_mot_keypoint
@@ -61,7 +61,7 @@ class Pipeline(object):
         video_file (string|None): the path of video file, default as None
         camera_id (int): the device id of camera to predict, default as -1
         enable_attr (bool): whether use attribute recognition, default as false
-        enable_action (bool): whether use action recognition, default as false
+        enable_falling (bool): whether use action recognition, default as false
         device (string): the device to predict, options are: CPU/GPU/XPU, 
             default as CPU
         run_mode (string): the mode of prediction, options are: 
@@ -89,7 +89,8 @@ class Pipeline(object):
                  video_dir=None,
                  camera_id=-1,
                  enable_attr=False,
-                 enable_action=True,
+                 enable_falling=False,
+                 enable_mtmct=False,
                  device='CPU',
                  run_mode='paddle',
                  trt_min_shape=1,
@@ -103,6 +104,7 @@ class Pipeline(object):
                  secs_interval=10,
                  do_entrance_counting=False):
         self.multi_camera = False
+        self.enable_mtmct = enable_mtmct
         self.is_video = False
         self.output_dir = output_dir
         self.vis_result = cfg['visual']
@@ -116,7 +118,8 @@ class Pipeline(object):
                     is_video=True,
                     multi_camera=True,
                     enable_attr=enable_attr,
-                    enable_action=enable_action,
+                    enable_falling=enable_falling,
+                    enable_mtmct=enable_mtmct,
                     device=device,
                     run_mode=run_mode,
                     trt_min_shape=trt_min_shape,
@@ -133,7 +136,8 @@ class Pipeline(object):
                 cfg,
                 self.is_video,
                 enable_attr=enable_attr,
-                enable_action=enable_action,
+                enable_falling=enable_falling,
+                enable_mtmct=enable_mtmct,
                 device=device,
                 run_mode=run_mode,
                 trt_min_shape=trt_min_shape,
@@ -199,11 +203,12 @@ class Pipeline(object):
                 predictor.run(input)
                 collector_data = predictor.get_result()
                 multi_res.append(collector_data)
-            mtmct_process(
-                multi_res,
-                self.input,
-                mtmct_vis=self.vis_result,
-                output_dir=self.output_dir)
+            if self.enable_mtmct:
+                mtmct_process(
+                    multi_res,
+                    self.input,
+                    mtmct_vis=self.vis_result,
+                    output_dir=self.output_dir)
 
         else:
             self.predictor.run(self.input)
@@ -222,7 +227,7 @@ class PipePredictor(object):
 
         1. Tracking
         2. Tracking -> Attribute
-        3. Tracking -> KeyPoint -> Action Recognition
+        3. Tracking -> KeyPoint -> Falling Recognition
 
     Args:
         cfg (dict): config of models in pipeline
@@ -231,7 +236,7 @@ class PipePredictor(object):
             default as False
         camera_id (int): the device id of camera to predict, default as -1
         enable_attr (bool): whether use attribute recognition, default as false
-        enable_action (bool): whether use action recognition, default as false
+        enable_falling (bool): whether use action recognition, default as false
         device (string): the device to predict, options are: CPU/GPU/XPU, 
             default as CPU
         run_mode (string): the mode of prediction, options are: 
@@ -256,7 +261,8 @@ class PipePredictor(object):
                  is_video=True,
                  multi_camera=False,
                  enable_attr=False,
-                 enable_action=False,
+                 enable_falling=False,
+                 enable_mtmct=False,
                  device='CPU',
                  run_mode='paddle',
                  trt_min_shape=1,
@@ -273,20 +279,20 @@ class PipePredictor(object):
         if enable_attr and not cfg.get('ATTR', False):
             ValueError(
                 'enable_attr is set to True, please set ATTR in config file')
-        if enable_action and (not cfg.get('ACTION', False) or
-                              not cfg.get('KPT', False)):
+        if enable_falling and (not cfg.get('FALLING', False) or
+                               not cfg.get('KPT', False)):
             ValueError(
-                'enable_action is set to True, please set KPT and ACTION in config file'
+                'enable_falling is set to True, please set KPT and FALLING in config file'
             )
 
         self.with_attr = cfg.get('ATTR', False) and enable_attr
-        self.with_action = cfg.get('ACTION', False) and enable_action
-        self.with_mtmct = cfg.get('REID', False) and multi_camera
+        self.with_falling = cfg.get('FALLING', False) and enable_falling
+        self.with_mtmct = cfg.get('REID', False) and enable_mtmct
         if self.with_attr:
             print('Attribute Recognition enabled')
-        if self.with_action:
-            print('Action Recognition enabled')
-        if multi_camera:
+        if self.with_falling:
+            print('Falling Recognition enabled')
+        if enable_mtmct:
             if not self.with_mtmct:
                 print(
                     'Warning!!! MTMCT enabled, but cannot find REID config in [infer_cfg.yml], please check!'
@@ -294,6 +300,12 @@ class PipePredictor(object):
             else:
                 print("MTMCT enabled")
 
+        self.modebase = {
+            "framebased": False,
+            "videobased": False,
+            "idbased": False,
+            "skeletonbased": False
+        }
         self.is_video = is_video
         self.multi_camera = multi_camera
         self.cfg = cfg
@@ -320,6 +332,8 @@ class PipePredictor(object):
                 attr_cfg = self.cfg['ATTR']
                 model_dir = attr_cfg['model_dir']
                 batch_size = attr_cfg['batch_size']
+                basemode = attr_cfg['basemode']
+                self.modebase[basemode] = True
                 self.attr_predictor = AttrDetector(
                     model_dir, device, run_mode, batch_size, trt_min_shape,
                     trt_max_shape, trt_opt_shape, trt_calib_mode, cpu_threads,
@@ -330,6 +344,8 @@ class PipePredictor(object):
             model_dir = mot_cfg['model_dir']
             tracker_config = mot_cfg['tracker_config']
             batch_size = mot_cfg['batch_size']
+            basemode = mot_cfg['basemode']
+            self.modebase[basemode] = True
             self.mot_predictor = SDE_Detector(
                 model_dir,
                 tracker_config,
@@ -349,49 +365,53 @@ class PipePredictor(object):
                 attr_cfg = self.cfg['ATTR']
                 model_dir = attr_cfg['model_dir']
                 batch_size = attr_cfg['batch_size']
+                basemode = attr_cfg['basemode']
+                self.modebase[basemode] = True
                 self.attr_predictor = AttrDetector(
                     model_dir, device, run_mode, batch_size, trt_min_shape,
                     trt_max_shape, trt_opt_shape, trt_calib_mode, cpu_threads,
                     enable_mkldnn)
-            if self.with_action:
-                kpt_cfg = self.cfg['KPT']
-                kpt_model_dir = kpt_cfg['model_dir']
-                kpt_batch_size = kpt_cfg['batch_size']
-                action_cfg = self.cfg['ACTION']
-                action_model_dir = action_cfg['model_dir']
-                action_batch_size = action_cfg['batch_size']
-                action_frames = action_cfg['max_frames']
-                display_frames = action_cfg['display_frames']
-                self.coord_size = action_cfg['coord_size']
+            if self.with_falling:
+                falling_cfg = self.cfg['FALLING']
+                falling_model_dir = falling_cfg['model_dir']
+                falling_batch_size = falling_cfg['batch_size']
+                falling_frames = falling_cfg['max_frames']
+                display_frames = falling_cfg['display_frames']
+                self.coord_size = falling_cfg['coord_size']
+                basemode = falling_cfg['basemode']
+                self.modebase[basemode] = True
 
-                self.kpt_predictor = KeyPointDetector(
-                    kpt_model_dir,
+                self.falling_predictor = FallingRecognizer(
+                    falling_model_dir,
                     device,
                     run_mode,
-                    kpt_batch_size,
+                    falling_batch_size,
                     trt_min_shape,
                     trt_max_shape,
                     trt_opt_shape,
                     trt_calib_mode,
                     cpu_threads,
                     enable_mkldnn,
-                    use_dark=False)
-                self.kpt_buff = KeyPointBuff(action_frames)
+                    window_size=falling_frames)
+                self.falling_visual_helper = FallingVisualHelper(display_frames)
 
-                self.action_predictor = ActionRecognizer(
-                    action_model_dir,
-                    device,
-                    run_mode,
-                    action_batch_size,
-                    trt_min_shape,
-                    trt_max_shape,
-                    trt_opt_shape,
-                    trt_calib_mode,
-                    cpu_threads,
-                    enable_mkldnn,
-                    window_size=action_frames)
-
-                self.action_visual_helper = ActionVisualHelper(display_frames)
+                if self.modebase["skeletonbased"]:
+                    kpt_cfg = self.cfg['KPT']
+                    kpt_model_dir = kpt_cfg['model_dir']
+                    kpt_batch_size = kpt_cfg['batch_size']
+                    self.kpt_predictor = KeyPointDetector(
+                        kpt_model_dir,
+                        device,
+                        run_mode,
+                        kpt_batch_size,
+                        trt_min_shape,
+                        trt_max_shape,
+                        trt_opt_shape,
+                        trt_calib_mode,
+                        cpu_threads,
+                        enable_mkldnn,
+                        use_dark=False)
+                    self.kpt_buff = KeyPointBuff(falling_frames)
 
         if self.with_mtmct:
             reid_cfg = self.cfg['REID']
@@ -507,117 +527,126 @@ class PipePredictor(object):
             if not ret:
                 break
 
-            if frame_id > self.warmup_frame:
-                self.pipe_timer.total_time.start()
-                self.pipe_timer.module_time['mot'].start()
-            res = self.mot_predictor.predict_image(
-                [copy.deepcopy(frame)], visual=False)
-
-            if frame_id > self.warmup_frame:
-                self.pipe_timer.module_time['mot'].end()
-
-            # mot output format: id, class, score, xmin, ymin, xmax, ymax
-            mot_res = parse_mot_res(res)
-
-            # flow_statistic only support single class MOT
-            boxes, scores, ids = res[0]  # batch size = 1 in MOT
-            mot_result = (frame_id + 1, boxes[0], scores[0],
-                          ids[0])  # single class
-            statistic = flow_statistic(
-                mot_result, self.secs_interval, self.do_entrance_counting,
-                video_fps, entrance, id_set, interval_id_set, in_id_list,
-                out_id_list, prev_center, records)
-            records = statistic['records']
-
-            # nothing detected
-            if len(mot_res['boxes']) == 0:
-                frame_id += 1
+            if self.modebase["idbased"] or self.modebase["skeletonbased"]:
                 if frame_id > self.warmup_frame:
-                    self.pipe_timer.img_num += 1
-                    self.pipe_timer.total_time.end()
-                if self.cfg['visual']:
-                    _, _, fps = self.pipe_timer.get_total_time()
-                    im = self.visualize_video(frame, mot_res, frame_id, fps,
-                                              entrance, records,
-                                              center_traj)  # visualize
-                    writer.write(im)
-                    if self.file_name is None:  # use camera_id
-                        cv2.imshow('PPHuman', im)
-                        if cv2.waitKey(1) & 0xFF == ord('q'):
-                            break
+                    self.pipe_timer.total_time.start()
+                    self.pipe_timer.module_time['mot'].start()
+                res = self.mot_predictor.predict_image(
+                    [copy.deepcopy(frame)], visual=False)
 
-                continue
-
-            self.pipeline_res.update(mot_res, 'mot')
-            if self.with_attr or self.with_action:
-                crop_input, new_bboxes, ori_bboxes = crop_image_with_mot(
-                    frame, mot_res)
-
-            if self.with_attr:
                 if frame_id > self.warmup_frame:
-                    self.pipe_timer.module_time['attr'].start()
-                attr_res = self.attr_predictor.predict_image(
-                    crop_input, visual=False)
-                if frame_id > self.warmup_frame:
-                    self.pipe_timer.module_time['attr'].end()
-                self.pipeline_res.update(attr_res, 'attr')
+                    self.pipe_timer.module_time['mot'].end()
 
-            if self.with_action:
-                if frame_id > self.warmup_frame:
-                    self.pipe_timer.module_time['kpt'].start()
-                kpt_pred = self.kpt_predictor.predict_image(
-                    crop_input, visual=False)
-                keypoint_vector, score_vector = translate_to_ori_images(
-                    kpt_pred, np.array(new_bboxes))
-                kpt_res = {}
-                kpt_res['keypoint'] = [
-                    keypoint_vector.tolist(), score_vector.tolist()
-                ] if len(keypoint_vector) > 0 else [[], []]
-                kpt_res['bbox'] = ori_bboxes
-                if frame_id > self.warmup_frame:
-                    self.pipe_timer.module_time['kpt'].end()
+                # mot output format: id, class, score, xmin, ymin, xmax, ymax
+                mot_res = parse_mot_res(res)
 
-                self.pipeline_res.update(kpt_res, 'kpt')
+                # flow_statistic only support single class MOT
+                boxes, scores, ids = res[0]  # batch size = 1 in MOT
+                mot_result = (frame_id + 1, boxes[0], scores[0],
+                              ids[0])  # single class
+                statistic = flow_statistic(
+                    mot_result, self.secs_interval, self.do_entrance_counting,
+                    video_fps, entrance, id_set, interval_id_set, in_id_list,
+                    out_id_list, prev_center, records)
+                records = statistic['records']
 
-                self.kpt_buff.update(kpt_res, mot_res)  # collect kpt output
-                state = self.kpt_buff.get_state(
-                )  # whether frame num is enough or lost tracker
-
-                action_res = {}
-                if state:
+                # nothing detected
+                if len(mot_res['boxes']) == 0:
+                    frame_id += 1
                     if frame_id > self.warmup_frame:
-                        self.pipe_timer.module_time['action'].start()
-                    collected_keypoint = self.kpt_buff.get_collected_keypoint(
-                    )  # reoragnize kpt output with ID
-                    action_input = parse_mot_keypoint(collected_keypoint,
-                                                      self.coord_size)
-                    action_res = self.action_predictor.predict_skeleton_with_mot(
-                        action_input)
+                        self.pipe_timer.img_num += 1
+                        self.pipe_timer.total_time.end()
+                    if self.cfg['visual']:
+                        _, _, fps = self.pipe_timer.get_total_time()
+                        im = self.visualize_video(frame, mot_res, frame_id, fps,
+                                                  entrance, records,
+                                                  center_traj)  # visualize
+                        writer.write(im)
+                        if self.file_name is None:  # use camera_id
+                            cv2.imshow('PPHuman', im)
+                            if cv2.waitKey(1) & 0xFF == ord('q'):
+                                break
+
+                    continue
+
+                self.pipeline_res.update(mot_res, 'mot')
+                if self.with_attr or self.with_falling:
+                    crop_input, new_bboxes, ori_bboxes = crop_image_with_mot(
+                        frame, mot_res)
+
+                if self.with_attr:
                     if frame_id > self.warmup_frame:
-                        self.pipe_timer.module_time['action'].end()
-                    self.pipeline_res.update(action_res, 'action')
+                        self.pipe_timer.module_time['attr'].start()
+                    attr_res = self.attr_predictor.predict_image(
+                        crop_input, visual=False)
+                    if frame_id > self.warmup_frame:
+                        self.pipe_timer.module_time['attr'].end()
+                    self.pipeline_res.update(attr_res, 'attr')
 
-                if self.cfg['visual']:
-                    self.action_visual_helper.update(action_res)
+                if self.with_falling:
+                    if self.modebase["skeletonbased"]:
+                        if frame_id > self.warmup_frame:
+                            self.pipe_timer.module_time['kpt'].start()
+                        kpt_pred = self.kpt_predictor.predict_image(
+                            crop_input, visual=False)
+                        keypoint_vector, score_vector = translate_to_ori_images(
+                            kpt_pred, np.array(new_bboxes))
+                        kpt_res = {}
+                        kpt_res['keypoint'] = [
+                            keypoint_vector.tolist(), score_vector.tolist()
+                        ] if len(keypoint_vector) > 0 else [[], []]
+                        kpt_res['bbox'] = ori_bboxes
+                        if frame_id > self.warmup_frame:
+                            self.pipe_timer.module_time['kpt'].end()
 
-            if self.with_mtmct and frame_id % 10 == 0:
-                crop_input, img_qualities, rects = self.reid_predictor.crop_image_with_mot(
-                    frame, mot_res)
-                if frame_id > self.warmup_frame:
-                    self.pipe_timer.module_time['reid'].start()
-                reid_res = self.reid_predictor.predict_batch(crop_input)
+                        self.pipeline_res.update(kpt_res, 'kpt')
 
-                if frame_id > self.warmup_frame:
-                    self.pipe_timer.module_time['reid'].end()
+                        self.kpt_buff.update(kpt_res,
+                                             mot_res)  # collect kpt output
+                    state = self.kpt_buff.get_state(
+                    )  # whether frame num is enough or lost tracker
 
-                reid_res_dict = {
-                    'features': reid_res,
-                    "qualities": img_qualities,
-                    "rects": rects
-                }
-                self.pipeline_res.update(reid_res_dict, 'reid')
-            else:
-                self.pipeline_res.clear('reid')
+                    falling_res = {}
+                    if state:
+                        if frame_id > self.warmup_frame:
+                            self.pipe_timer.module_time['falling'].start()
+                        collected_keypoint = self.kpt_buff.get_collected_keypoint(
+                        )  # reoragnize kpt output with ID
+                        falling_input = parse_mot_keypoint(collected_keypoint,
+                                                           self.coord_size)
+                        falling_res = self.falling_predictor.predict_skeleton_with_mot(
+                            falling_input)
+                        if frame_id > self.warmup_frame:
+                            self.pipe_timer.module_time['falling'].end()
+                        self.pipeline_res.update(falling_res, 'falling')
+
+                    if self.cfg['visual']:
+                        self.falling_visual_helper.update(falling_res)
+
+                if self.with_mtmct and frame_id % 10 == 0:
+                    crop_input, img_qualities, rects = self.reid_predictor.crop_image_with_mot(
+                        frame, mot_res)
+                    if frame_id > self.warmup_frame:
+                        self.pipe_timer.module_time['reid'].start()
+                    reid_res = self.reid_predictor.predict_batch(crop_input)
+
+                    if frame_id > self.warmup_frame:
+                        self.pipe_timer.module_time['reid'].end()
+
+                    reid_res_dict = {
+                        'features': reid_res,
+                        "qualities": img_qualities,
+                        "rects": rects
+                    }
+                    self.pipeline_res.update(reid_res_dict, 'reid')
+                else:
+                    self.pipeline_res.clear('reid')
+
+            if self.modebase["videobased"]:
+                pass
+
+            if self.modebase["framebased"]:
+                pass
 
             self.collector.append(frame_id, self.pipeline_res)
 
@@ -697,10 +726,10 @@ class PipePredictor(object):
                 visual_thresh=self.cfg['kpt_thresh'],
                 returnimg=True)
 
-        action_res = result.get('action')
-        if action_res is not None:
+        falling_res = result.get('falling')
+        if falling_res is not None:
             image = visualize_action(image, mot_res['boxes'],
-                                     self.action_visual_helper, "Falling")
+                                     self.falling_visual_helper, "Falling")
 
         return image
 
@@ -740,10 +769,11 @@ def main():
     pipeline = Pipeline(
         cfg, FLAGS.image_file, FLAGS.image_dir, FLAGS.video_file,
         FLAGS.video_dir, FLAGS.camera_id, FLAGS.enable_attr,
-        FLAGS.enable_action, FLAGS.device, FLAGS.run_mode, FLAGS.trt_min_shape,
-        FLAGS.trt_max_shape, FLAGS.trt_opt_shape, FLAGS.trt_calib_mode,
-        FLAGS.cpu_threads, FLAGS.enable_mkldnn, FLAGS.output_dir,
-        FLAGS.draw_center_traj, FLAGS.secs_interval, FLAGS.do_entrance_counting)
+        FLAGS.enable_falling, FLAGS.enable_mtmct, FLAGS.device, FLAGS.run_mode,
+        FLAGS.trt_min_shape, FLAGS.trt_max_shape, FLAGS.trt_opt_shape,
+        FLAGS.trt_calib_mode, FLAGS.cpu_threads, FLAGS.enable_mkldnn,
+        FLAGS.output_dir, FLAGS.draw_center_traj, FLAGS.secs_interval,
+        FLAGS.do_entrance_counting)
 
     pipeline.run()
 

--- a/deploy/pphuman/pipeline.py
+++ b/deploy/pphuman/pipeline.py
@@ -361,6 +361,18 @@ class PipePredictor(object):
                     model_dir, device, run_mode, batch_size, trt_min_shape,
                     trt_max_shape, trt_opt_shape, trt_calib_mode, cpu_threads,
                     enable_mkldnn)
+            if self.with_idbased_detaction:
+                idbased_detaction_cfg = self.cfg['SKELETON_ACTION']
+                idbased_detaction_model_dir = idbased_detaction_cfg['model_dir']
+                idbased_detaction_batch_size = idbased_detaction_cfg[
+                    'batch_size']
+                # IDBasedDetActionRecognizer = IDBasedDetActionRecognizer()
+            if self.with_idbased_clsaction:
+                idbased_clsaction_cfg = self.cfg['SKELETON_ACTION']
+                idbased_clsaction_model_dir = idbased_clsaction_cfg['model_dir']
+                idbased_clsaction_batch_size = idbased_clsaction_cfg[
+                    'batch_size']
+                # IDBasedDetActionRecognizer = IDBasedClsActionRecognizer()
             if self.with_skeleton_action:
                 skeleton_action_cfg = self.cfg['SKELETON_ACTION']
                 skeleton_action_model_dir = skeleton_action_cfg['model_dir']
@@ -588,25 +600,23 @@ class PipePredictor(object):
                     pass
 
                 if self.with_skeleton_action:
-                    if self.modebase["skeletonbased"]:
-                        if frame_id > self.warmup_frame:
-                            self.pipe_timer.module_time['kpt'].start()
-                        kpt_pred = self.kpt_predictor.predict_image(
-                            crop_input, visual=False)
-                        keypoint_vector, score_vector = translate_to_ori_images(
-                            kpt_pred, np.array(new_bboxes))
-                        kpt_res = {}
-                        kpt_res['keypoint'] = [
-                            keypoint_vector.tolist(), score_vector.tolist()
-                        ] if len(keypoint_vector) > 0 else [[], []]
-                        kpt_res['bbox'] = ori_bboxes
-                        if frame_id > self.warmup_frame:
-                            self.pipe_timer.module_time['kpt'].end()
+                    if frame_id > self.warmup_frame:
+                        self.pipe_timer.module_time['kpt'].start()
+                    kpt_pred = self.kpt_predictor.predict_image(
+                        crop_input, visual=False)
+                    keypoint_vector, score_vector = translate_to_ori_images(
+                        kpt_pred, np.array(new_bboxes))
+                    kpt_res = {}
+                    kpt_res['keypoint'] = [
+                        keypoint_vector.tolist(), score_vector.tolist()
+                    ] if len(keypoint_vector) > 0 else [[], []]
+                    kpt_res['bbox'] = ori_bboxes
+                    if frame_id > self.warmup_frame:
+                        self.pipe_timer.module_time['kpt'].end()
 
-                        self.pipeline_res.update(kpt_res, 'kpt')
+                    self.pipeline_res.update(kpt_res, 'kpt')
 
-                        self.kpt_buff.update(kpt_res,
-                                             mot_res)  # collect kpt output
+                    self.kpt_buff.update(kpt_res, mot_res)  # collect kpt output
                     state = self.kpt_buff.get_state(
                     )  # whether frame num is enough or lost tracker
 

--- a/deploy/python/action_infer.py
+++ b/deploy/python/action_infer.py
@@ -33,7 +33,7 @@ from benchmark_utils import PaddleInferBenchmark
 from infer import Detector, print_arguments
 
 
-class FallingRecognizer(Detector):
+class SkeletonActionRecognizer(Detector):
     """
     Args:
         model_dir (str): root path of model.pdiparams, model.pdmodel and infer_cfg.yml
@@ -67,8 +67,8 @@ class FallingRecognizer(Detector):
                  threshold=0.5,
                  window_size=100,
                  random_pad=False):
-        assert batch_size == 1, "FallingRecognizer only support batch_size=1 now."
-        super(FallingRecognizer, self).__init__(
+        assert batch_size == 1, "SkeletonActionRecognizer only support batch_size=1 now."
+        super(SkeletonActionRecognizer, self).__init__(
             model_dir=model_dir,
             device=device,
             run_mode=run_mode,
@@ -264,7 +264,7 @@ def get_test_skeletons(input_file):
 
 
 def main():
-    detector = FallingRecognizer(
+    detector = SkeletonActionRecognizer(
         FLAGS.model_dir,
         device=FLAGS.device,
         run_mode=FLAGS.run_mode,
@@ -305,7 +305,7 @@ def main():
         }
         det_log = PaddleInferBenchmark(detector.config, model_info, data_info,
                                        perf_info, mems)
-        det_log('Falling')
+        det_log('SkeletonAction')
 
 
 if __name__ == '__main__':

--- a/deploy/python/action_infer.py
+++ b/deploy/python/action_infer.py
@@ -33,7 +33,7 @@ from benchmark_utils import PaddleInferBenchmark
 from infer import Detector, print_arguments
 
 
-class ActionRecognizer(Detector):
+class FallingRecognizer(Detector):
     """
     Args:
         model_dir (str): root path of model.pdiparams, model.pdmodel and infer_cfg.yml
@@ -67,8 +67,8 @@ class ActionRecognizer(Detector):
                  threshold=0.5,
                  window_size=100,
                  random_pad=False):
-        assert batch_size == 1, "ActionRecognizer only support batch_size=1 now."
-        super(ActionRecognizer, self).__init__(
+        assert batch_size == 1, "FallingRecognizer only support batch_size=1 now."
+        super(FallingRecognizer, self).__init__(
             model_dir=model_dir,
             device=device,
             run_mode=run_mode,
@@ -264,7 +264,7 @@ def get_test_skeletons(input_file):
 
 
 def main():
-    detector = ActionRecognizer(
+    detector = FallingRecognizer(
         FLAGS.model_dir,
         device=FLAGS.device,
         run_mode=FLAGS.run_mode,
@@ -305,7 +305,7 @@ def main():
         }
         det_log = PaddleInferBenchmark(detector.config, model_info, data_info,
                                        perf_info, mems)
-        det_log('Action')
+        det_log('Falling')
 
 
 if __name__ == '__main__':

--- a/deploy/python/action_utils.py
+++ b/deploy/python/action_utils.py
@@ -68,7 +68,7 @@ class KeyPointBuff(object):
 
     def get_collected_keypoint(self):
         """
-            Output (List): List of keypoint results for Falling Recognition task, where 
+            Output (List): List of keypoint results for Skeletonbased Recognition task, where 
                            the format of each element is [tracker_id, KeyPointSequence of tracker_id]
         """
         output = []
@@ -80,7 +80,7 @@ class KeyPointBuff(object):
         return output
 
 
-class FallingVisualHelper(object):
+class SkeletonActionVisualHelper(object):
     def __init__(self, frame_life=20):
         self.frame_life = frame_life
         self.action_history = {}

--- a/deploy/python/action_utils.py
+++ b/deploy/python/action_utils.py
@@ -68,7 +68,7 @@ class KeyPointBuff(object):
 
     def get_collected_keypoint(self):
         """
-            Output (List): List of keypoint results for Action Recognition task, where 
+            Output (List): List of keypoint results for Falling Recognition task, where 
                            the format of each element is [tracker_id, KeyPointSequence of tracker_id]
         """
         output = []
@@ -80,7 +80,7 @@ class KeyPointBuff(object):
         return output
 
 
-class ActionVisualHelper(object):
+class FallingVisualHelper(object):
     def __init__(self, frame_life=20):
         self.frame_life = frame_life
         self.action_history = {}


### PR DESCRIPTION
pphuman pipeline v2, add model_based to prune extra branchs
1. 增加模型路线分支选择功能，基于['idbased'、'skeletonbased'、'videobased'、'framebased']。分别表示需要跟踪结果、关键点结果、独立于跟踪的视频预测、独立于跟踪的帧预测
2. 修改原来的action行为为falling，避免与新增行为识别混淆。
3. 修改跨境头跟踪开启方法，由多视频自动开启修改为使用--enable-mtmct标志。多视频默认不再绑定跨境头。