### PR TITLE
fix ShuffleNetV2 config

### DIFF
--- a/ppdet/modeling/backbones/shufflenet_v2.py
+++ b/ppdet/modeling/backbones/shufflenet_v2.py
@@ -192,7 +192,6 @@ class ShuffleNetV2(nn.Layer):
         else:
             raise NotImplementedError("This scale size:[" + str(scale) +
                                       "] is not implemented!")
-
         self._out_channels = []
         self._feature_idx = 0
         # 1. conv1

--- a/ppdet/modeling/backbones/shufflenet_v2.py
+++ b/ppdet/modeling/backbones/shufflenet_v2.py
@@ -188,7 +188,7 @@ class ShuffleNetV2(nn.Layer):
         elif scale == 1.5:
             stage_out_channels = [-1, 24, 176, 352, 704, 1024]
         elif scale == 2.0:
-            stage_out_channels = [-1, 24, 224, 488, 976, 2048]
+            stage_out_channels = [-1, 24, 244, 488, 976, 2048]
         else:
             raise NotImplementedError("This scale size:[" + str(scale) +
                                       "] is not implemented!")


### PR DESCRIPTION
 fix ShuffleNetV2 x2_0 stage_out_channels. [reference](https://github.com/pytorch/vision/blob/main/torchvision/models/shufflenetv2.py#L396)