### PR TITLE
Patch to make saving model checkpoints optional in W&B Callback

### DIFF
--- a/docs/tutorials/logging_en.md
+++ b/docs/tutorials/logging_en.md
@@ -30,7 +30,7 @@ wandb login
 To use wandb to log metrics while training add the `--use_wandb` flag to the training command and any other arguments for the W&B logger can be provided like this - 
 
 ```
-python tools/train -c config.yml --use_wandb -o wandb-project=MyDetector wandb-entity=MyTeam wandb-save_dir=./logs
+python tools/train -c config.yml --use_wandb -o wandb-project=MyDetector wandb-entity=MyTeam wandb-save_dir=./logs wandb-log_checkpoint=False
 ```
 
 Logging model checkpoints to the W&B dashboard can be done by providing the `log_checkpoint` as `true` or `false`.

--- a/docs/tutorials/logging_en.md
+++ b/docs/tutorials/logging_en.md
@@ -33,6 +33,8 @@ To use wandb to log metrics while training add the `--use_wandb` flag to the tra
 python tools/train -c config.yml --use_wandb -o wandb-project=MyDetector wandb-entity=MyTeam wandb-save_dir=./logs
 ```
 
+Logging model checkpoints to the W&B dashboard can be done by providing the `log_checkpoint` as `true` or `false`.
+
 The arguments to the W&B logger must be proceeded by `-o` and each invidiual argument must contain the prefix "wandb-".
 
 If this is too tedious, an alternative way is to add the arguments to the `config.yml` file under the `wandb` header. For example
@@ -43,4 +45,5 @@ wandb:
     project: MyProject
     entity: MyTeam
     save_dir: ./logs
+    log_checkpoint: true
 ```

--- a/ppdet/engine/callbacks.py
+++ b/ppdet/engine/callbacks.py
@@ -311,6 +311,9 @@ class WandbCallback(Callback):
                     k.lstrip("wandb_"): v
                 })
         
+        self.log_checkpoint = self.wandb_params.get('log_checkpoint', False)
+        self.wandb_params.pop('log_checkpoint')
+
         self._run = None
         if dist.get_world_size() < 2 or dist.get_rank() == 0:
             _ = self.run
@@ -341,6 +344,8 @@ class WandbCallback(Callback):
                 ap=None, 
                 tags=None):
         if dist.get_world_size() < 2 or dist.get_rank() == 0:
+            if self.log_checkpoint == False:
+                return
             model_path = os.path.join(save_dir, save_name)
             metadata = {}
             metadata["last_epoch"] = last_epoch


### PR DESCRIPTION
This PR adds an argument `log_checkpoint` to the `WandbCallback` which is set as `False` by default. Using this users can enable or disable logging model checkpoints to the W&B dashboard.