### PR TITLE
fix benchmark

### DIFF
--- a/test_tipc/configs/mot/fairmot_dla34_30e_1088x608_train_infer_python.txt
+++ b/test_tipc/configs/mot/fairmot_dla34_30e_1088x608_train_infer_python.txt
@@ -52,7 +52,7 @@ inference:./deploy/pptracking/python/mot_jde_infer.py
 ===========================train_benchmark_params==========================
 batch_size:6|22
 fp_items:fp32|fp16
-epoch:1
+epoch:2
 --profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
 flags:null
 ===========================infer_benchmark_params===========================


### PR DESCRIPTION
为降低benchmark模型的性能波动，适当增加部分模型的epoch数产出更多有效log