### PR TITLE
修复静态图多机多卡无法训练bug

### DIFF
--- a/static/tools/train_multi_machine.py
+++ b/static/tools/train_multi_machine.py
@@ -192,7 +192,6 @@ def main():
                                                          extra_keys)
 
     exe.run(startup_prog)
-    compiled_train_prog = fleet.main_program
 
     if FLAGS.eval:
         compiled_eval_prog = fluid.CompiledProgram(eval_prog)
@@ -253,7 +252,7 @@ def main():
         time_cost = np.mean(time_stat)
         eta_sec = (cfg.max_iters - it) * time_cost
         eta = str(datetime.timedelta(seconds=int(eta_sec)))
-        outs = exe.run(compiled_train_prog, fetch_list=train_values)
+        outs = exe.run(train_prog, fetch_list=train_values)
         stats = {k: np.array(v).mean() for k, v in zip(train_keys, outs[:-1])}
 
         # use vdl-paddle to log loss


### PR DESCRIPTION
使用默认的代码，多机多GPU卡训练异常。检查发现分布式API调用有误，作上述修改后，多机多GPU卡训练正常。