### PR TITLE
remove one line redundant code

### DIFF
--- a/ppdet/modeling/layers.py
+++ b/ppdet/modeling/layers.py
@@ -832,7 +832,6 @@ class TTFBox(object):
         # batch size is 1
         scores_r = paddle.reshape(scores, [cat, -1])
         topk_scores, topk_inds = paddle.topk(scores_r, k)
-        topk_scores, topk_inds = paddle.topk(scores_r, k)
         topk_ys = topk_inds // width
         topk_xs = topk_inds % width
 


### PR DESCRIPTION
就是这一行代码重复两遍，我觉得可能是一个误修改，没看出其有什么实际用处
`topk_scores, topk_inds = paddle.topk(scores_r, k)`