### PR TITLE
Remove eval_input_size of deepsort detector configs

### DIFF
--- a/configs/mot/deepsort/deepsort_ppyoloe_pplcnet.yml
+++ b/configs/mot/deepsort/deepsort_ppyoloe_pplcnet.yml
@@ -92,7 +92,6 @@ PPYOLOEHead:
   grid_cell_offset: 0.5
   static_assigner_epoch: -1 # 100
   use_varifocal_loss: True
-  eval_input_size: [640, 640]
   loss_weight: {class: 1.0, iou: 2.5, dfl: 0.5}
   static_assigner:
     name: ATSSAssigner

--- a/configs/mot/deepsort/deepsort_ppyoloe_resnet.yml
+++ b/configs/mot/deepsort/deepsort_ppyoloe_resnet.yml
@@ -91,7 +91,6 @@ PPYOLOEHead:
   grid_cell_offset: 0.5
   static_assigner_epoch: -1 # 100
   use_varifocal_loss: True
-  eval_input_size: [640, 640]
   loss_weight: {class: 1.0, iou: 2.5, dfl: 0.5}
   static_assigner:
     name: ATSSAssigner

--- a/configs/mot/deepsort/detector/ppyoloe_crn_l_36e_640x640_mot17half.yml
+++ b/configs/mot/deepsort/detector/ppyoloe_crn_l_36e_640x640_mot17half.yml
@@ -62,7 +62,6 @@ PPYOLOEHead:
   grid_cell_offset: 0.5
   static_assigner_epoch: -1 # 100
   use_varifocal_loss: True
-  eval_input_size: [640, 640]
   loss_weight: {class: 1.0, iou: 2.5, dfl: 0.5}
   static_assigner:
     name: ATSSAssigner


### PR DESCRIPTION
* Fixed a bug in the training of deepsort ppyoloe detector
* Remove eval_input_size in the deepsort detector configs
* Reference: https://github.com/PaddlePaddle/PaddleDetection/pull/5610