### PR TITLE
add attrs visualize in mtmct process

### DIFF
--- a/deploy/pphuman/mtmct.py
+++ b/deploy/pphuman/mtmct.py
@@ -100,7 +100,8 @@ def get_mtmct_matching_results(pred_mtmct_file, secs_interval=0.5,
     return camera_results, cid_tid_fid_results
 
 
-def save_mtmct_vis_results(camera_results, captures, multi_res, output_dir):
+def save_mtmct_vis_results(camera_results, captures, output_dir,
+                           multi_res=None):
     # camera_results: 'cid, tid, fid, x1, y1, w, h'
     camera_ids = list(camera_results.keys())
 
@@ -358,4 +359,8 @@ def mtmct_process(multi_res, captures, mtmct_vis=True, output_dir="output"):
         camera_results, cid_tid_fid_res = get_mtmct_matching_results(
             pred_mtmct_file)
 
-        save_mtmct_vis_results(camera_results, captures, output_dir=output_dir)
+        save_mtmct_vis_results(
+            camera_results,
+            captures,
+            output_dir=output_dir,
+            multi_res=cid_tid_dict)

--- a/deploy/pphuman/mtmct.py
+++ b/deploy/pphuman/mtmct.py
@@ -143,20 +143,22 @@ def save_mtmct_vis_results(camera_results, captures, output_dir,
             image = plot_tracking(frame, boxes, ids, frame_id=frame_id, fps=fps)
 
             # add attr vis
-            attr_res = []
-            tid_list = [
-                'c' + str(idx) + '_' + 't' + str(int(j))
-                for j in range(1, len(ids) + 1)
-            ]  # c0_t1, c0_t2...
-            for k in tid_list:
-                if (frame_id - 1) >= len(multi_res[k]['attrs']):
-                    t_attr = None
-                else:
-                    t_attr = multi_res[k]['attrs'][frame_id - 1]
-                    attr_res.append(t_attr)
-            image = visualize_attr(image, attr_res, boxes, is_mtmct=True)
+            if not multi_res:
+                attr_res = []
+                tid_list = [
+                    'c' + str(idx) + '_' + 't' + str(int(j))
+                    for j in range(1, len(ids) + 1)
+                ]  # c0_t1, c0_t2...
+                for k in tid_list:
+                    if 'attrs' in multi_res[k]:
+                        if (frame_id - 1) >= len(multi_res[k]['attrs']):
+                            t_attr = None
+                        else:
+                            t_attr = multi_res[k]['attrs'][frame_id - 1]
+                            attr_res.append(t_attr)
+                image = visualize_attr(image, attr_res, boxes, is_mtmct=True)
 
-            writer.write(image)
+                writer.write(image)
         writer.release()
 
 

--- a/deploy/pphuman/mtmct.py
+++ b/deploy/pphuman/mtmct.py
@@ -143,7 +143,7 @@ def save_mtmct_vis_results(camera_results, captures, output_dir,
             image = plot_tracking(frame, boxes, ids, frame_id=frame_id, fps=fps)
 
             # add attr vis
-            if not multi_res:
+            if multi_res:
                 attr_res = []
                 tid_list = [
                     'c' + str(idx) + '_' + 't' + str(int(j))
@@ -158,7 +158,7 @@ def save_mtmct_vis_results(camera_results, captures, output_dir,
                             attr_res.append(t_attr)
                 image = visualize_attr(image, attr_res, boxes, is_mtmct=True)
 
-                writer.write(image)
+            writer.write(image)
         writer.release()
 
 

--- a/deploy/python/visualize.py
+++ b/deploy/python/visualize.py
@@ -331,7 +331,7 @@ def visualize_pose(imgfile,
     plt.close()
 
 
-def visualize_attr(im, results, boxes=None):
+def visualize_attr(im, results, boxes=None, is_mtmct=False):
     if isinstance(im, str):
         im = Image.open(im)
         im = np.ascontiguousarray(np.copy(im))
@@ -349,9 +349,13 @@ def visualize_attr(im, results, boxes=None):
             text_w = 3
             text_h = 1
         else:
-            box = boxes[i]
+            box = boxes[i]  # single camera, bbox is 0, 0, x,y, w,h
             text_w = int(box[2]) + 3
             text_h = int(box[3])
+        if is_mtmct:  # multi camera, bbox is x,y, w,h
+            box = boxes[i]  # box: x, y, w, h
+            text_w = int(box[0]) + 3
+            text_h = int(box[1])
         for text in res:
             text_h += int(line_inter)
             text_loc = (text_w, text_h)

--- a/deploy/python/visualize.py
+++ b/deploy/python/visualize.py
@@ -348,14 +348,14 @@ def visualize_attr(im, results, boxes=None, is_mtmct=False):
         if boxes is None:
             text_w = 3
             text_h = 1
-        else:
-            box = boxes[i]  # single camera, bbox is 0, 0, x,y, w,h
-            text_w = int(box[2]) + 3
-            text_h = int(box[3])
-        if is_mtmct:  # multi camera, bbox is x,y, w,h
-            box = boxes[i]  # box: x, y, w, h
+        elif is_mtmct:
+            box = boxes[i]  # multi camera, bbox shape is x,y, w,h
             text_w = int(box[0]) + 3
             text_h = int(box[1])
+        else:
+            box = boxes[i]  # single camera, bbox shape is 0, 0, x,y, w,h
+            text_w = int(box[2]) + 3
+            text_h = int(box[3])
         for text in res:
             text_h += int(line_inter)
             text_loc = (text_w, text_h)


### PR DESCRIPTION
Add attrs visualize in mtmct process, 2 python file were affect:
1. [deploy/pphuman/mtmct.py] 
  - add : import visualize_attr for attr visualize
  - in save_mtmct_vis_results function, add one parameter: multi_res, which contents the attr result
  - in save_mtmct_vis_results add the attr visualize method
2. [deploy/python/visualize.py]
   - add one optional parameter is_mtmct, defualt value is False, when use it in mtmct process, call it and set the is_mtmct as true.