### PR TITLE
[Dy2St]Fix cascade_rcnn export model problem

### DIFF
--- a/ppdet/modeling/heads/cascade_head.py
+++ b/ppdet/modeling/heads/cascade_head.py
@@ -302,9 +302,9 @@ class CascadeHead(BBoxHead):
             num_prop.append(p.shape[0])
 
         # NOTE(dev): num_prob will be tagged as LoDTensorArray because it
-        # depends on batch_size. However the argument num_or_sections in
-        # paddle.split does not support LoDTensorArray, so we use [-1]
-        # to replace it and whitout lossing correctness.
+        # depends on batch_size under @to_static. However the argument
+        # num_or_sections in paddle.split does not support LoDTensorArray,
+        # so we use [-1] to replace it and whitout lossing correctness.
         num_prop = [-1] if len(num_prop) == 1 else num_prop
         return pred_bbox.split(num_prop)
 

--- a/ppdet/modeling/heads/cascade_head.py
+++ b/ppdet/modeling/heads/cascade_head.py
@@ -300,6 +300,12 @@ class CascadeHead(BBoxHead):
         num_prop = []
         for p in proposals:
             num_prop.append(p.shape[0])
+
+        # NOTE(dev): num_prob will be tagged as LoDTensorArray because it
+        # depends on batch_size. However the argument num_or_sections in
+        # paddle.split does not support LoDTensorArray, so we use [-1]
+        # to replace it and whitout lossing correctness.
+        num_prop = [-1] if len(num_prop) == 1 else num_prop
         return pred_bbox.split(num_prop)
 
     def get_prediction(self, head_out_list):


### PR DESCRIPTION
修复了cascade_rcnn在develop分支上模型导出报错的问题，之前2.3分支导出预测没有问题。

经过详细定位发现cascade_rcnn 其实是不支持batch_size为动态值的模型导出的，仅能支持batch_size = 1 导出和预测。

因为split中的 num_or_section 并不支持LoDTensorArray，相关代码如下：

```python
    # proposals 在上游是一个长度依赖batch_size的list，在转program时会变成LoDTensorArray

    def _get_pred_bbox(self, deltas, proposals, weights):
        pred_proposals = paddle.concat(proposals) if len(
            proposals) > 1 else proposals[0]
        pred_bbox = delta2bbox(deltas, pred_proposals, weights)
        pred_bbox = paddle.reshape(pred_bbox, [-1, deltas.shape[-1]])
        num_prop = []
        for p in proposals:     # <------- 此处会转为控制流while_loop，因为proposals的长度是变长的
            num_prop.append(p.shape[0])    # <------- 此处num_prop会转为LoDTensorArray

        # NOTE(dev): num_prob will be tagged as LoDTensorArray because it
        # depends on batch_size. However the argument num_or_sections in
        # paddle.split does not support LoDTensorArray, so we use [-1]
        # to replace it and whitout lossing correctness.
        num_prop = [-1] if len(num_prop) == 1 else num_prop
        return pred_bbox.split(num_prop)   # <------- split中的 num_or_section 并不支持LoDTensorArray
```

因此我们在代码里加了`num_prop = [-1] if len(num_prop) == 1 else num_prop`以对齐2.3版本正确导出和预测。