### PR TITLE
fix training error for picodet_s_192_lcnet_pedestrian

### DIFF
--- a/configs/picodet/application/pedestrian_detection/picodet_s_192_lcnet_pedestrian.yml
+++ b/configs/picodet/application/pedestrian_detection/picodet_s_192_lcnet_pedestrian.yml
@@ -56,7 +56,7 @@ PicoHeadV2:
   use_align_head: True
   static_assigner:
     name: ATSSAssigner
-    topk: 9
+    topk: 4
     force_gt_matching: False
   assigner:
     name: TaskAlignedAssigner


### PR DESCRIPTION
fix the parameter error in config file of `picodet_s_192_lcnet_pedestrian` , which leads to training error