### PR TITLE
update mtmct.py and visualize.py for multi-camera attrs visualize

### DIFF
--- a/deploy/pipeline/pphuman/mtmct.py
+++ b/deploy/pipeline/pphuman/mtmct.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 from pptracking.python.mot.visualize import plot_tracking
+from python.visualize import visualize_attr
 import os
 import re
 import cv2

--- a/deploy/pipeline/pphuman/mtmct.py
+++ b/deploy/pipeline/pphuman/mtmct.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from pptracking.python.mot.visualize import plot_tracking
 from python.visualize import visualize_attr
 import os
@@ -149,19 +148,24 @@ def save_mtmct_vis_results(camera_results, captures, output_dir,
 
             # add attr vis
             if multi_res:
-                attr_res = []
                 tid_list = [
                     'c' + str(idx) + '_' + 't' + str(int(j))
                     for j in range(1, len(ids) + 1)
                 ]  # c0_t1, c0_t2...
-                for k in tid_list:
-                    if 'attrs' in multi_res[k]:
+                all_attr_result = [multi_res[i]["attrs"]
+                                   for i in tid_list]  # all cid_tid result
+                if any(
+                        all_attr_result
+                ):  # at least one cid_tid[attrs] is not None will goes to attrs_vis
+                    attr_res = []
+                    for k in tid_list:
                         if (frame_id - 1) >= len(multi_res[k]['attrs']):
                             t_attr = None
                         else:
                             t_attr = multi_res[k]['attrs'][frame_id - 1]
                             attr_res.append(t_attr)
-                image = visualize_attr(image, attr_res, boxes, is_mtmct=True)
+                    image = visualize_attr(
+                        image, attr_res, boxes, is_mtmct=True)
 
             writer.write(image)
         writer.release()

--- a/deploy/python/visualize.py
+++ b/deploy/python/visualize.py
@@ -331,7 +331,7 @@ def visualize_pose(imgfile,
     plt.close()
 
 
-def visualize_attr(im, results, boxes=None):
+def visualize_attr(im, results, boxes=None, is_mtmct=False):
     if isinstance(im, str):
         im = Image.open(im)
         im = np.ascontiguousarray(np.copy(im))
@@ -348,8 +348,12 @@ def visualize_attr(im, results, boxes=None):
         if boxes is None:
             text_w = 3
             text_h = 1
+        elif is_mtmct:
+            box = boxes[i]  # multi camera, bbox shape is x,y, w,h
+            text_w = int(box[0]) + 3
+            text_h = int(box[1])
         else:
-            box = boxes[i]
+            box = boxes[i]  # single camera, bbox shape is 0, 0, x,y, w,h
             text_w = int(box[2]) + 3
             text_h = int(box[3])
         for text in res:


### PR DESCRIPTION
add multi-camera person attrs visualize, 2 files changed:
1. pipeline/mtmct.py:
  - add one para: multi_res in the <save_mtmct_vis_results> method, multi_res content the attrs result
  - add the attrs visualize method for each frame
2. [deploy/python/visualize.py]
 - add one optional parameter is_mtmct, defualt value is False, when use it in mtmct process, call it and set the is_mtmct as true.