### PR TITLE
use link for vehicle model

### DIFF
--- a/deploy/pipeline/config/examples/infer_cfg_human_attr.yml
+++ b/deploy/pipeline/config/examples/infer_cfg_human_attr.yml
@@ -3,6 +3,10 @@ attr_thresh: 0.5
 visual: True
 warmup_frame: 50
 
+DET:
+  model_dir: https://bj.bcebos.com/v1/paddledet/models/pipeline/mot_ppyoloe_l_36e_pipeline.zip
+  batch_size: 1
+
 MOT:
   model_dir: https://bj.bcebos.com/v1/paddledet/models/pipeline/mot_ppyoloe_l_36e_pipeline.zip
   tracker_config: deploy/pipeline/config/tracker_config.yml

--- a/deploy/pipeline/config/examples/infer_cfg_vehicle_attr.yml
+++ b/deploy/pipeline/config/examples/infer_cfg_vehicle_attr.yml
@@ -10,21 +10,11 @@ MOT:
   model_dir: https://bj.bcebos.com/v1/paddledet/models/pipeline/mot_ppyoloe_l_36e_ppvehicle.zip
   tracker_config: deploy/pipeline/config/tracker_config.yml
   batch_size: 1
-  enable: False
-
-VEHICLE_PLATE:
-  det_model_dir: https://bj.bcebos.com/v1/paddledet/models/pipeline/ch_PP-OCRv3_det_infer.tar.gz
-  det_limit_side_len: 736
-  det_limit_type: "min"
-  rec_model_dir: https://bj.bcebos.com/v1/paddledet/models/pipeline/ch_PP-OCRv3_rec_infer.tar.gz
-  rec_image_shape: [3, 48, 320]
-  rec_batch_num: 6
-  word_dict_path: deploy/pipeline/ppvehicle/rec_word_dict.txt
-  enable: False
+  enable: True
 
 VEHICLE_ATTR:
   model_dir: https://bj.bcebos.com/v1/paddledet/models/pipeline/vehicle_attribute_model.zip
   batch_size: 8
   color_threshold: 0.5
   type_threshold: 0.5
-  enable: False
+  enable: True

--- a/deploy/pipeline/config/examples/infer_cfg_vehicle_plate.yml
+++ b/deploy/pipeline/config/examples/infer_cfg_vehicle_plate.yml
@@ -10,7 +10,7 @@ MOT:
   model_dir: https://bj.bcebos.com/v1/paddledet/models/pipeline/mot_ppyoloe_l_36e_ppvehicle.zip
   tracker_config: deploy/pipeline/config/tracker_config.yml
   batch_size: 1
-  enable: False
+  enable: True
 
 VEHICLE_PLATE:
   det_model_dir: https://bj.bcebos.com/v1/paddledet/models/pipeline/ch_PP-OCRv3_det_infer.tar.gz
@@ -20,11 +20,4 @@ VEHICLE_PLATE:
   rec_image_shape: [3, 48, 320]
   rec_batch_num: 6
   word_dict_path: deploy/pipeline/ppvehicle/rec_word_dict.txt
-  enable: False
-
-VEHICLE_ATTR:
-  model_dir: https://bj.bcebos.com/v1/paddledet/models/pipeline/vehicle_attribute_model.zip
-  batch_size: 8
-  color_threshold: 0.5
-  type_threshold: 0.5
-  enable: False
+  enable: True


### PR DESCRIPTION
- change path to url link for vehicle models, so that models can be auto-downloaded when running command.
- add example configuration files of `vehicle_attr / vehicle_plate`
- add `DET` field for `human_attr / vehicle_attr / vehicle_plate`, or there will be a `model-not-found` error when input is a single image.