### PR TITLE
fix: float number in `color` caused exception for PIL

### DIFF
--- a/ppdet/utils/visualizer.py
+++ b/ppdet/utils/visualizer.py
@@ -95,7 +95,7 @@ def draw_bbox(image, im_id, catid2name, bboxes, threshold):
         if catid not in catid2color:
             idx = np.random.randint(len(color_list))
             catid2color[catid] = color_list[idx]
-        color = tuple(catid2color[catid])
+        color = tuple(int(val) for val in catid2color[catid])
 
         # draw bbox
         if len(bbox) == 4:


### PR DESCRIPTION
Fix the following error:

![image](https://user-images.githubusercontent.com/18085551/186122673-7ba593d1-d974-48ca-903c-2e995d093d70.png)


The numbers in `color` are float numbers, but PIL doesn't like it(I don't know why). 


![image](https://user-images.githubusercontent.com/18085551/186122521-2d1d85b0-bbde-4a8d-bce8-a7cbfd39fcd2.png)


This PR makes PIL happy.