### PR TITLE
update object_detector.cc

### DIFF
--- a/deploy/cpp/src/object_detector.cc
+++ b/deploy/cpp/src/object_detector.cc
@@ -143,7 +143,7 @@ cv::Mat VisualizeResult(
       std::vector<int> mask_v = results[i].mask;
       if (mask_v.size() > 0) {
         cv::Mat mask = cv::Mat(img_h, img_w, CV_32S);
-        std::memcpy(mask.data, mask_v.data(), mask_v.size() * sizeof(int));
+        std::memcpy(mask.data, mask_v.data(), (img_h * img_w) * sizeof(int));
 
         cv::Mat colored_img = vis_img.clone();
 


### PR DESCRIPTION
输入图片尺寸为1704*1280时出现错误：
malloc_consolidate(): invalid chunk size
Aborted (core dumped)
将
std::memcpy(mask.data, mask_v.data(), mask_v.size()* sizeof(int));
改为
std::memcpy(mask.data, mask_v.data(), (img_h * img_w) * sizeof(int));
以mask的元素数量拷贝，解决此问题