### PR TITLE
[Fix] Update faster_rcnn_swin_reader.yml

### DIFF
--- a/configs/faster_rcnn/_base_/faster_rcnn_swin_reader.yml
+++ b/configs/faster_rcnn/_base_/faster_rcnn_swin_reader.yml
@@ -29,13 +29,13 @@ EvalReader:
 
 
 TestReader:
-  inputs_def:
-    image_shape: [-1, 3, 640, 640]
   sample_transforms:
   - Decode: {}
-  - LetterBoxResize: {target_size: 640}
+  - Resize: {interp: 2, target_size: [800, 1333], keep_ratio: True}
   - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
   - Permute: {}
+  batch_transforms:
+  - PadBatch: {pad_to_stride: 32}
   batch_size: 1
   shuffle: false
   drop_last: false


### PR DESCRIPTION
Keep the same configuration during training and inference to avoid possible bounding box misalignment.