### PR TITLE
[TIPC] Add scripts for npu and xpu, test=develop

### DIFF
--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -822,8 +822,12 @@ def load_predictor(model_dir,
         # optimize graph and fuse op
         config.switch_ir_optim(True)
     elif device == 'XPU':
+        if config.lite_engine_enabled():
+            config.enable_lite_engine()
         config.enable_xpu(10 * 1024 * 1024)
     elif device == 'NPU':
+        if config.lite_engine_enabled():
+            config.enable_lite_engine()
         config.enable_npu()
     else:
         config.disable_gpu()

--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -428,7 +428,7 @@ class Detector(object):
         if not os.path.exists(self.output_dir):
             os.makedirs(self.output_dir)
         out_path = os.path.join(self.output_dir, video_out_name)
-        fourcc = cv2.VideoWriter_fourcc(* 'mp4v')
+        fourcc = cv2.VideoWriter_fourcc(*'mp4v')
         writer = cv2.VideoWriter(out_path, fourcc, fps, (width, height))
         index = 1
         while (1):
@@ -824,6 +824,9 @@ def load_predictor(model_dir,
     elif device == 'XPU':
         config.enable_lite_engine()
         config.enable_xpu(10 * 1024 * 1024)
+    elif device == 'NPU':
+        config.enable_lite_engine()
+        config.enable_npu()
     else:
         config.disable_gpu()
         config.set_cpu_math_library_num_threads(cpu_threads)
@@ -1023,8 +1026,8 @@ if __name__ == '__main__':
     FLAGS = parser.parse_args()
     print_arguments(FLAGS)
     FLAGS.device = FLAGS.device.upper()
-    assert FLAGS.device in ['CPU', 'GPU', 'XPU'
-                            ], "device should be CPU, GPU or XPU"
+    assert FLAGS.device in ['CPU', 'GPU', 'XPU', 'NPU'
+                            ], "device should be CPU, GPU, XPU or NPU"
     assert not FLAGS.use_gpu, "use_gpu has been deprecated, please use --device"
 
     assert not (

--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -822,10 +822,8 @@ def load_predictor(model_dir,
         # optimize graph and fuse op
         config.switch_ir_optim(True)
     elif device == 'XPU':
-        config.enable_lite_engine()
         config.enable_xpu(10 * 1024 * 1024)
     elif device == 'NPU':
-        config.enable_lite_engine()
         config.enable_npu()
     else:
         config.disable_gpu()

--- a/test_tipc/test_train_inference_python_npu.sh
+++ b/test_tipc/test_train_inference_python_npu.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+source test_tipc/utils_func.sh
+function readlinkf() {
+    perl -MCwd -e 'print Cwd::abs_path shift' "$1";
+}
+function func_parser_config() {
+    strs=$1
+    IFS=" "
+    array=(${strs})
+    tmp=${array[2]}
+    echo ${tmp}
+}
+function func_parser_dir() {
+    strs=$1
+    IFS="/"
+    array=(${strs})
+    len=${#array[*]}
+    dir=""
+    count=1
+    for arr in ${array[*]}; do 
+        if [ ${len} = "${count}" ]; then
+            continue;
+        else
+            dir="${dir}/${arr}"
+            count=$((${count} + 1))
+        fi
+    done
+    echo "${dir}"
+}
+BASEDIR=$(dirname "$0")
+REPO_ROOT_PATH=$(readlinkf ${BASEDIR}/../)
+FILENAME=$1
+ # change gpu to npu in tipc txt configs
+ sed -i "s/use_gpu:True/use_npu:True/g" $FILENAME
+ sed -i "s/--device:gpu|cpu/--device:npu|cpu/g" $FILENAME
+ sed -i "s/trainer:pact_train/trainer:norm_train/g" $FILENAME
+ sed -i "s/trainer:fpgm_train/trainer:norm_train/g" $FILENAME
+ sed -i 's/\"gpu\"/\"npu\"/g' test_tipc/test_train_inference_python.sh
+
+ # parser params
+dataline=`cat $FILENAME`
+IFS=$'\n'
+lines=(${dataline})
+# replace training config file
+grep -n '.yml' $FILENAME  | cut -d ":" -f 1 \
+| while read line_num ; do 
+    train_cmd=$(func_parser_value "${lines[line_num-1]}")
+    trainer_config=$(func_parser_config ${train_cmd})
+    echo ${trainer_config}
+    sed -i 's/use_gpu/use_npu/g' "$REPO_ROOT_PATH/$trainer_config"
+    # fine use_gpu in those included yaml
+    sub_datalinee=`cat $REPO_ROOT_PATH/$trainer_config`
+    IFS=$'\n'
+    sub_lines=(${sub_datalinee})
+    grep -n '.yml' "$REPO_ROOT_PATH/$trainer_config" | cut -d ":" -f 1 \
+    | while read sub_line_num; do
+        sub_config=${sub_lines[sub_line_num-1]} 
+        dst=${#sub_config}-5
+        sub_path=$(func_parser_dir "${trainer_config}")
+        sub_config_path="${REPO_ROOT_PATH}${sub_path}/${sub_config:3:${dst}}"
+        echo ${sub_config_path}
+        sed -i 's/use_gpu/use_npu/g' "$sub_config_path"
+    done
+done
+# pass parameters to test_train_inference_python.sh
+cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} $2"
+echo $cmd
+eval $cmd

--- a/test_tipc/test_train_inference_python_npu.sh
+++ b/test_tipc/test_train_inference_python_npu.sh
@@ -35,6 +35,9 @@ FILENAME=$1
  sed -i "s/--device:gpu|cpu/--device:npu|cpu/g" $FILENAME
  sed -i "s/trainer:pact_train/trainer:norm_train/g" $FILENAME
  sed -i "s/trainer:fpgm_train/trainer:norm_train/g" $FILENAME
+ sed -i "s/--slim_config _template_pact/ /g" $FILENAME
+ sed -i "s/--slim_config _template_fpgm/ /g" $FILENAME
+ sed -i "s/--slim_config _template_kl_quant/ /g" $FILENAME
  sed -i 's/\"gpu\"/\"npu\"/g' test_tipc/test_train_inference_python.sh
 
  # parser params

--- a/test_tipc/test_train_inference_python_xpu.sh
+++ b/test_tipc/test_train_inference_python_xpu.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+ source test_tipc/utils_func.sh
+
+ function readlinkf() {
+     perl -MCwd -e 'print Cwd::abs_path shift' "$1";
+ }
+
+ function func_parser_config() {
+     strs=$1
+     IFS=" "
+     array=(${strs})
+     tmp=${array[2]}
+     echo ${tmp}
+ }
+
+ function func_parser_dir() {
+     strs=$1
+     IFS="/"
+     array=(${strs})
+     len=${#array[*]}
+     dir=""
+     count=1
+     for arr in ${array[*]}; do 
+         if [ ${len} = "${count}" ]; then
+             continue;
+         else
+             dir="${dir}/${arr}"
+             count=$((${count} + 1))
+         fi
+     done
+     echo "${dir}"
+ }
+
+ BASEDIR=$(dirname "$0")
+ REPO_ROOT_PATH=$(readlinkf ${BASEDIR}/../)
+
+ FILENAME=$1
+
+ # change gpu to xpu in tipc txt configs
+ sed -i "s/use_gpu:True/use_xpu:True/g" $FILENAME
+ sed -i "s/--device:gpu|cpu/--device:xpu|cpu/g" $FILENAME
+ sed -i "s/trainer:pact_train/trainer:norm_train/g" $FILENAME
+ sed -i "s/trainer:fpgm_train/trainer:norm_train/g" $FILENAME
+ sed -i 's/\"gpu\"/\"xpu\"/g' test_tipc/test_train_inference_python.sh
+
+ # parser params
+ dataline=`cat $FILENAME`
+ IFS=$'\n'
+ lines=(${dataline})
+
+ # replace training config file
+ grep -n '.yml' $FILENAME  | cut -d ":" -f 1 \
+ | while read line_num ; do 
+     train_cmd=$(func_parser_value "${lines[line_num-1]}")
+     trainer_config=$(func_parser_config ${train_cmd})
+     echo ${trainer_config}
+     sed -i 's/use_gpu/use_xpu/g' "$REPO_ROOT_PATH/$trainer_config"
+     # fine use_gpu in those included yaml
+     sub_datalinee=`cat $REPO_ROOT_PATH/$trainer_config`
+     IFS=$'\n'
+     sub_lines=(${sub_datalinee})
+     grep -n '.yml' "$REPO_ROOT_PATH/$trainer_config" | cut -d ":" -f 1 \
+     | while read sub_line_num; do
+         sub_config=${sub_lines[sub_line_num-1]} 
+         dst=${#sub_config}-5
+         sub_path=$(func_parser_dir "${trainer_config}")
+         sub_config_path="${REPO_ROOT_PATH}${sub_path}/${sub_config:3:${dst}}"
+         echo ${sub_config_path}
+         sed -i 's/use_gpu/use_xpu/g' "$sub_config_path"
+     done
+ done
+
+ # pass parameters to test_train_inference_python.sh
+ cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} $2"
+ echo $cmd
+ eval $cmd

--- a/test_tipc/test_train_inference_python_xpu.sh
+++ b/test_tipc/test_train_inference_python_xpu.sh
@@ -41,6 +41,9 @@
  sed -i "s/--device:gpu|cpu/--device:xpu|cpu/g" $FILENAME
  sed -i "s/trainer:pact_train/trainer:norm_train/g" $FILENAME
  sed -i "s/trainer:fpgm_train/trainer:norm_train/g" $FILENAME
+ sed -i "s/--slim_config _template_pact/ /g" $FILENAME
+ sed -i "s/--slim_config _template_fpgm/ /g" $FILENAME
+ sed -i "s/--slim_config _template_kl_quant/ /g" $FILENAME
  sed -i 's/\"gpu\"/\"xpu\"/g' test_tipc/test_train_inference_python.sh
 
  # parser params

--- a/tools/anchor_cluster.py
+++ b/tools/anchor_cluster.py
@@ -215,6 +215,8 @@ def main():
     merge_config(FLAGS.opt)
     check_config(cfg)
     # check if set use_gpu=True in paddlepaddle cpu version
+    if 'use_gpu' not in cfg:
+        cfg.use_gpu = False
     check_gpu(cfg.use_gpu)
     # check if paddlepaddle version is satisfied
     check_version('develop')

--- a/tools/eval.py
+++ b/tools/eval.py
@@ -168,6 +168,9 @@ def main():
     if 'use_xpu' not in cfg:
         cfg.use_xpu = False
 
+    if 'use_gpu' not in cfg:
+        cfg.use_gpu = False
+
     if cfg.use_gpu:
         place = paddle.set_device('gpu')
     elif cfg.use_npu:

--- a/tools/eval_mot.py
+++ b/tools/eval_mot.py
@@ -112,6 +112,9 @@ def main():
     if 'use_xpu' not in cfg:
         cfg.use_xpu = False
 
+    if 'use_gpu' not in cfg:
+        cfg.use_gpu = False
+
     if cfg.use_gpu:
         place = paddle.set_device('gpu')
     elif cfg.use_npu:

--- a/tools/export_model.py
+++ b/tools/export_model.py
@@ -98,6 +98,8 @@ def main():
     # FIXME: Temporarily solve the priority problem of FLAGS.opt
     merge_config(FLAGS.opt)
     check_config(cfg)
+    if 'use_gpu' not in cfg:
+        cfg.use_gpu = False
     check_gpu(cfg.use_gpu)
     check_version()
 

--- a/tools/infer.py
+++ b/tools/infer.py
@@ -201,6 +201,9 @@ def main():
     if 'use_xpu' not in cfg:
         cfg.use_xpu = False
 
+    if 'use_gpu' not in cfg:
+        cfg.use_gpu = False
+
     if cfg.use_gpu:
         place = paddle.set_device('gpu')
     elif cfg.use_npu:

--- a/tools/infer_mot.py
+++ b/tools/infer_mot.py
@@ -124,6 +124,9 @@ def main():
     if 'use_xpu' not in cfg:
         cfg.use_xpu = False
 
+    if 'use_gpu' not in cfg:
+        cfg.use_gpu = False
+
     if cfg.use_gpu:
         place = paddle.set_device('gpu')
     elif cfg.use_npu:

--- a/tools/post_quant.py
+++ b/tools/post_quant.py
@@ -86,6 +86,8 @@ def main():
     # FIXME: Temporarily solve the priority problem of FLAGS.opt
     merge_config(FLAGS.opt)
     check_config(cfg)
+    if 'use_gpu' not in cfg:
+        cfg.use_gpu = False
     check_gpu(cfg.use_gpu)
     check_version()
 

--- a/tools/train.py
+++ b/tools/train.py
@@ -146,6 +146,9 @@ def main():
     if 'use_xpu' not in cfg:
         cfg.use_xpu = False
 
+    if 'use_gpu' not in cfg:
+        cfg.use_gpu = False
+
     if cfg.use_gpu:
         place = paddle.set_device('gpu')
     elif cfg.use_npu:
@@ -163,6 +166,7 @@ def main():
     check.check_config(cfg)
     check.check_gpu(cfg.use_gpu)
     check.check_npu(cfg.use_npu)
+    check.check_xpu(cfg.use_xpu)
     check.check_version()
 
     run(FLAGS, cfg)


### PR DESCRIPTION
为昇腾和昆仑设备添加 TIPC 脚本:

```
# 准备小数据集
bash test_tipc/prepare.sh ./test_tipc/configs/sparse_rcnn/sparse_rcnn_r50_fpn_3x_pro100_coco_train_infer_python.txt 'lite_train_lite_infer'

# NPU上运行单测模型，注意这里的脚本带 _npu.sh 后缀
bash test_tipc/test_train_inference_python_npu.sh ./test_tipc/configs/sparse_rcnn/sparse_rcnn_r50_fpn_3x_pro100_coco_train_infer_python.txt 'lite_train_lite_infer'

# XPU上运行单测模型，注意这里的脚本带 _xpu.sh 后缀
bash test_tipc/test_train_inference_python_xpu.sh ./test_tipc/configs/sparse_rcnn/sparse_rcnn_r50_fpn_3x_pro100_coco_train_infer_python.txt 'lite_train_lite_infer'
```