### PR TITLE
Solve the error that 'list(conv)' cannot be quantified.

### DIFF
--- a/ppdet/modeling/heads/pico_head.py
+++ b/ppdet/modeling/heads/pico_head.py
@@ -499,8 +499,8 @@ class PicoHeadV2(GFLHead):
         self.gfl_head_reg = None
         self.scales_regs = None
 
-        self.head_cls_list = []
-        self.head_reg_list = []
+        self.head_cls_list = nn.LayerList()
+        self.head_reg_list = nn.LayerList()
         self.cls_align = nn.LayerList()
 
         for i in range(len(fpn_stride)):


### PR DESCRIPTION
使用python list封装conv将导致量化scale无法更新，量化失败，需要使用nn.LayerList()封装conv，才能正常量化。