### PR TITLE
[Bug fix] Correct the use of dist.all_reduce

### DIFF
--- a/ppdet/modeling/heads/gfl_head.py
+++ b/ppdet/modeling/heads/gfl_head.py
@@ -388,12 +388,7 @@ class GFLHead(nn.Layer):
 
         avg_factor = sum(avg_factor)
         try:
-            avg_factor_clone = avg_factor.clone()
-            tmp_avg_factor = paddle.distributed.all_reduce(avg_factor_clone)
-            if tmp_avg_factor is not None:
-                avg_factor = tmp_avg_factor
-            else:
-                avg_factor = avg_factor_clone
+            paddle.distributed.all_reduce(avg_factor)
             avg_factor = paddle.clip(
                 avg_factor / paddle.distributed.get_world_size(), min=1)
         except:

--- a/ppdet/modeling/heads/simota_head.py
+++ b/ppdet/modeling/heads/simota_head.py
@@ -179,15 +179,8 @@ class OTAHead(GFLHead):
                                                    num_level_anchors)
         num_total_pos = sum(pos_num_l)
         try:
-            cloned_num_total_pos = num_total_pos.clone()
-            reduced_cloned_num_total_pos = paddle.distributed.all_reduce(
-                cloned_num_total_pos)
-            if reduced_cloned_num_total_pos is not None:
-                num_total_pos = reduced_cloned_num_total_pos / paddle.distributed.get_world_size(
-                )
-            else:
-                num_total_pos = cloned_num_total_pos / paddle.distributed.get_world_size(
-                )
+            paddle.distributed.all_reduce(num_total_pos)
+            num_total_pos = num_total_pos / paddle.distributed.get_world_size()
         except:
             num_total_pos = max(num_total_pos, 1)
 
@@ -262,12 +255,7 @@ class OTAHead(GFLHead):
 
         avg_factor = sum(avg_factor)
         try:
-            avg_factor_clone = avg_factor.clone()
-            tmp_avg_factor = paddle.distributed.all_reduce(avg_factor_clone)
-            if tmp_avg_factor is not None:
-                avg_factor = tmp_avg_factor
-            else:
-                avg_factor = avg_factor_clone
+            paddle.distributed.all_reduce(avg_factor)
             avg_factor = paddle.clip(
                 avg_factor / paddle.distributed.get_world_size(), min=1)
         except:
@@ -408,15 +396,8 @@ class OTAVFLHead(OTAHead):
                                                    num_level_anchors)
         num_total_pos = sum(pos_num_l)
         try:
-            cloned_num_total_pos = num_total_pos.clone()
-            reduced_cloned_num_total_pos = paddle.distributed.all_reduce(
-                cloned_num_total_pos)
-            if reduced_cloned_num_total_pos is not None:
-                num_total_pos = reduced_cloned_num_total_pos / paddle.distributed.get_world_size(
-                )
-            else:
-                num_total_pos = cloned_num_total_pos / paddle.distributed.get_world_size(
-                )
+            paddle.distributed.all_reduce(num_total_pos)
+            num_total_pos = num_total_pos / paddle.distributed.get_world_size()
         except:
             num_total_pos = max(num_total_pos, 1)
 
@@ -494,12 +475,7 @@ class OTAVFLHead(OTAHead):
 
         avg_factor = sum(avg_factor)
         try:
-            avg_factor_clone = avg_factor.clone()
-            tmp_avg_factor = paddle.distributed.all_reduce(avg_factor_clone)
-            if tmp_avg_factor is not None:
-                avg_factor = tmp_avg_factor
-            else:
-                avg_factor = avg_factor_clone
+            paddle.distributed.all_reduce(avg_factor)
             avg_factor = paddle.clip(
                 avg_factor / paddle.distributed.get_world_size(), min=1)
         except:


### PR DESCRIPTION
新通信库下，通信后的结果会inplace的修改input，同时以task作为返回值。
在像下面的同步通信的语境下，不需要考虑返回的task。