### PR TITLE
Add RandomDistort Prob Notes

### DIFF
--- a/ppdet/data/transform/operators.py
+++ b/ppdet/data/transform/operators.py
@@ -457,6 +457,10 @@ class GridMask(BaseOperator):
 @register_op
 class RandomDistort(BaseOperator):
     """Random color distortion.
+    Note:
+        The 'probability' in [lower, upper, probability] is the probability of not using this transformation,
+        not the probability of using this transformation. And this only applies in this operator(RandomDistort),
+        'probability' in other BaseOperator means the probability of using that transformation.
     Args:
         hue (list): hue settings. in [lower, upper, probability] format.
         saturation (list): saturation settings. in [lower, upper, probability] format.


### PR DESCRIPTION
原算子中RandomDistort的prob在代码中为不使用该种变换的概率，而应当是使用该种变换的概率。为了避免修改代码导致出现个别模型不收敛，因此在原代码中加入了对probability的额外注释。