### PR TITLE
fix bug for rle encoding coco dataset loader

### DIFF
--- a/ppdet/data/source/coco.py
+++ b/ppdet/data/source/coco.py
@@ -178,7 +178,7 @@ class COCODataSet(DetDataset):
                     gt_bbox[i, :] = box['clean_bbox']
                     is_crowd[i][0] = box['iscrowd']
                     # check RLE format 
-                    if 'segmentation' in box and box['iscrowd'] == 1:
+                    if 'segmentation' in box and box['iscrowd'] != 1:
                         gt_poly[i] = [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
                     elif 'segmentation' in box and box['segmentation']:
                         if not np.array(box['segmentation']

--- a/ppdet/data/source/coco.py
+++ b/ppdet/data/source/coco.py
@@ -178,7 +178,7 @@ class COCODataSet(DetDataset):
                     gt_bbox[i, :] = box['clean_bbox']
                     is_crowd[i][0] = box['iscrowd']
                     # check RLE format 
-                    if 'segmentation' in box and box['iscrowd'] != 1:
+                    if 'segmentation' in box and box['iscrowd'] != 1 and box['iscrowd'] != 0:
                         gt_poly[i] = [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
                     elif 'segmentation' in box and box['segmentation']:
                         if not np.array(box['segmentation']


### PR DESCRIPTION
代码中原来的逻辑是当iscrowd为1则设置gt_poly全0，当使用是COCO数据集实例分割编码为poly时，iscrowd为0，则实例分割会进入正确的分支，正常加载数据。但是当coco数据集的编码方式为rle是iscrowd为1，则设置gt_poly为全0会导致无法训练，应将此分支改为当iscrowd既不等于0也不等于1时，即此数据集中无任何实例分割的annotation时，才设置gt_poly为全0