### PR TITLE
Export ONNX with TensorRT BatchNMS plugin enabled

### DIFF
--- a/deploy/EXPORT_ONNX_MODEL.md
+++ b/deploy/EXPORT_ONNX_MODEL.md
@@ -110,3 +110,13 @@ python deploy/third_engine/onnx/infer.py
             --onnx_file faster_rcnn.onnx \
             --image_file demo/000000014439.jpg
 ```
+
+## TensorRT部署优化策略
+
+Paddle2ONNX已经支持导出TensorRT DynamicBatchNMS插件。开发者在导出类似PPYOLOE+、PPYOLOE、PicoDet等模型，Paddle2ONNX会自动将其中的NMS转成DynamicBatchNMS，从而实现GPU的后处理，大幅提升端到端的部署性能。
+
+导出过程需要注意以下几点：
+- 1. 导出检测模型时，不要去除最后的NMS操作，不要添加--trt等参数，以确保NMS为模型的最后一个OP
+- 2. Paddle2ONNX版本高于或等于1.0.2，转换时添加参数`--deploy_backend tensorrt`
+
+此方式导出的模型支持批量预测。

--- a/deploy/EXPORT_ONNX_MODEL.md
+++ b/deploy/EXPORT_ONNX_MODEL.md
@@ -113,7 +113,7 @@ python deploy/third_engine/onnx/infer.py
 
 ## TensorRT部署优化策略
 
-Paddle2ONNX已经支持导出TensorRT DynamicBatchNMS插件。开发者在导出类似PPYOLOE+、PPYOLOE、PicoDet等模型，Paddle2ONNX会自动将其中的NMS转成DynamicBatchNMS，从而实现GPU的后处理，大幅提升端到端的部署性能。
+Paddle2ONNX已经支持导出TensorRT DynamicBatchNMS插件。开发者在导出类似PPYOLOE+、PPYOLOE、YOLOv3、YOLOX、PicoDet等模型，Paddle2ONNX会自动将其中的NMS转成DynamicBatchNMS，从而实现GPU的后处理，大幅提升端到端的部署性能。
 
 导出过程需要注意以下几点：
 - 1. 导出检测模型时，不要去除最后的NMS操作，不要添加--trt等参数，以确保NMS为模型的最后一个OP


### PR DESCRIPTION
增加NMS导出到TensorRT的支持，大幅提升部署性能

可取代 https://github.com/PaddlePaddle/PaddleDetection/tree/release/2.5/deploy/end2end_ppyoloe 此目录下代码，并支持所有没有控制流，最后一个OP为multiclass_nms的检测模型