### PR TITLE
[TIPC]Change worker_num to 4 to speed up tipc training

### DIFF
--- a/test_tipc/configs/yolov3/yolov3_darknet53_270e_coco_train_infer_python.txt
+++ b/test_tipc/configs/yolov3/yolov3_darknet53_270e_coco_train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:./dataset/coco/test2017/
 filename:null
 ##
 trainer:norm_train
-norm_train:tools/train.py -c configs/yolov3/yolov3_darknet53_270e_coco.yml -o
+norm_train:tools/train.py -c configs/yolov3/yolov3_darknet53_270e_coco.yml -o worker_num=4
 pact_train:tools/train.py -c configs/yolov3/yolov3_darknet53_270e_coco.yml --slim_config configs/slim/quant/yolov3_darknet_qat.yml -o
 fpgm_train:tools/train.py -c configs/yolov3/yolov3_darknet53_270e_coco.yml --slim_config configs/slim/prune/yolov3_darknet_prune_fpgm.yml -o
 distill_train:null


### PR DESCRIPTION
- yolov3模型在tipc监控上将worker_num从2修改为4，与torch的对应监控配置对齐。
- 本地测试速度从32.220 images/s提高到59.869 images/s