### PR TITLE
add yml for single npu and polish call to paddle api

### DIFF
--- a/configs/yolov3/yolov3_darknet53_original_320e_coco_1p.yml
+++ b/configs/yolov3/yolov3_darknet53_original_320e_coco_1p.yml
@@ -1,0 +1,59 @@
+_BASE_: [
+  '../datasets/coco_detection.yml',
+  '../runtime.yml',
+  '_base_/yolov3_darknet53.yml',
+  '_base_/yolov3_reader.yml',
+]
+
+snapshot_epoch: 5
+weights: output/yolov3_darknet53_270e_coco/model_final
+
+norm_type: bn
+
+YOLOv3Loss:
+  ignore_thresh: 0.5
+  downsample: [32, 16, 8]
+  label_smooth: false
+
+worker_num: 8
+TrainReader:
+  inputs_def:
+    num_max_boxes: 50
+  sample_transforms:
+    - Decode: {}
+    - RandomDistort: {}
+    - RandomExpand: {fill_value: [123.675, 116.28, 103.53], ratio: 2.0}
+    - RandomCrop: {}
+    - RandomFlip: {}
+  batch_transforms:
+    - BatchRandomResize: {target_size: [416], random_size: True, random_interp: True, keep_ratio: False}
+    - NormalizeBox: {}
+    - PadBox: {num_max_boxes: 50}
+    - BboxXYXY2XYWH: {}
+    - NormalizeImage: {mean: [0.485, 0.456, 0.406], std: [0.229, 0.224, 0.225], is_scale: True}
+    - Permute: {}
+    - Gt2YoloTarget: {anchor_masks: [[6, 7, 8], [3, 4, 5], [0, 1, 2]], anchors: [[10, 13], [16, 30], [33, 23], [30, 61], [62, 45], [59, 119], [116, 90], [156, 198], [373, 326]], downsample_ratios: [32, 16, 8], iou_thresh: 0.5}
+  batch_size: 32
+  shuffle: true
+  drop_last: true
+  mixup_epoch: -1
+  use_shared_memory: true
+
+epoch: 320
+
+LearningRate:
+  base_lr: 0.001
+  schedulers:
+  - !CosineDecay
+    max_epochs: 320
+  - !LinearWarmup
+    start_factor: 0.
+    epochs: 4
+
+OptimizerBuilder:
+  optimizer:
+    momentum: 0.9
+    type: Momentum
+  regularizer:
+    factor: 0.016
+    type: L2

--- a/ppdet/modeling/bbox_utils.py
+++ b/ppdet/modeling/bbox_utils.py
@@ -343,7 +343,10 @@ def xywh2xyxy(box):
 
 
 def make_grid(h, w, dtype):
-    yv, xv = paddle.meshgrid([paddle.arange(h), paddle.arange(w)])
+    yv, xv = paddle.meshgrid(
+        [paddle.arange(
+            h, dtype=dtype), paddle.arange(
+                w, dtype=dtype)])
     return paddle.stack((xv, yv), 2).cast(dtype=dtype)
 
 
@@ -365,8 +368,7 @@ def decode_yolo(box, anchor, downsample_ratio):
     x1 = (x + grid[:, :, :, :, 0:1]) / grid_w
     y1 = (y + grid[:, :, :, :, 1:2]) / grid_h
 
-    anchor = paddle.to_tensor(anchor)
-    anchor = paddle.cast(anchor, x.dtype)
+    anchor = paddle.to_tensor(anchor, dtype=x.dtype)
     anchor = anchor.reshape((1, na, 1, 1, 2))
     w1 = paddle.exp(w) * anchor[:, :, :, :, 0:1] / (downsample_ratio * grid_w)
     h1 = paddle.exp(h) * anchor[:, :, :, :, 1:2] / (downsample_ratio * grid_h)

--- a/ppdet/modeling/bbox_utils.py
+++ b/ppdet/modeling/bbox_utils.py
@@ -347,7 +347,7 @@ def make_grid(h, w, dtype):
         [paddle.arange(
             h, dtype=dtype), paddle.arange(
                 w, dtype=dtype)])
-    return paddle.stack((xv, yv), 2).cast(dtype=dtype)
+    return paddle.stack((xv, yv), 2)
 
 
 def decode_yolo(box, anchor, downsample_ratio):


### PR DESCRIPTION
add yolov3_darknet53_original_320e_coco_1p.yml for single card training.
paddle.range and paddle.to_tensor support dtype, use it to avoid calling cast op.

e.g. when using npu with amp_level=O1:
python -u tools/train.py -c configs/yolov3/yolov3_darknet53_original_320e_coco_1p.yml --amp -o norm_type=bn use_gpu=False use_npu=True amp_level=O1