### PR TITLE
mot_sde_infer.py fix use ocsort_tracker bug

### DIFF
--- a/deploy/pptracking/python/mot_sde_infer.py
+++ b/deploy/pptracking/python/mot_sde_infer.py
@@ -654,6 +654,11 @@ class SDE_Detector(Detector):
             fps = 1. / timer.duration
             if self.use_deepsort_tracker or self.use_ocsort_tracker:
                 # use DeepSORTTracker or OCSORTTracker, only support singe class
+                if isinstance(online_tlwhs, defaultdict):
+                    online_tlwhs = online_tlwhs[0]
+                    online_scores = online_scores[0]
+                    online_ids = online_ids[0]
+
                 results[0].append(
                     (frame_id + 1, online_tlwhs, online_scores, online_ids))
                 im = plot_tracking(


### PR DESCRIPTION
mot_sde_infer.py  line 655:
if self.use_deepsort_tracker or self.use_ocsort_tracker:

deepsort_tracke 输出结果是list, ocsort_tracker 输出结果是字典，不能通用。
修改：增加判断，若为字典，则取key=0的value。（ocsort只支持单类追踪）