### PR TITLE
fix CE arange not support float16

### DIFF
--- a/ppdet/modeling/bbox_utils.py
+++ b/ppdet/modeling/bbox_utils.py
@@ -343,11 +343,8 @@ def xywh2xyxy(box):
 
 
 def make_grid(h, w, dtype):
-    yv, xv = paddle.meshgrid(
-        [paddle.arange(
-            h, dtype=dtype), paddle.arange(
-                w, dtype=dtype)])
-    return paddle.stack((xv, yv), 2)
+    yv, xv = paddle.meshgrid([paddle.arange(h), paddle.arange(w)])
+    return paddle.stack((xv, yv), 2).cast(dtype=dtype)
 
 
 def decode_yolo(box, anchor, downsample_ratio):


### PR DESCRIPTION
fix CE error because arange kernel does not support dtype float16, revert to original using, maybe do this optimization after supported in Paddle later.
<img width="1207" alt="30dd560242d420699d651923c723c4bf" src="https://user-images.githubusercontent.com/5997715/208630392-9448daa9-bad4-4e6c-9db5-5adb93a05a49.png">
