### PR TITLE
config use_shard_memory for fcos_reader to speed up data processing

### DIFF
--- a/configs/fcos/_base_/fcos_reader.yml
+++ b/configs/fcos/_base_/fcos_reader.yml
@@ -16,6 +16,7 @@ TrainReader:
   batch_size: 2
   shuffle: True
   drop_last: True
+  use_shared_memory: True
 
 
 EvalReader:


### PR DESCRIPTION
在分析 fcos_r50_fpn_1x_coco_bs8_fp16_DP N1C1 模型的 Timeline 时发现执行过程存在许多空隙，怀疑 fcos 系列模型的数据读取模块未配置优化选项，在开启 use_shared_memory: True 后，模型性能更加稳定且略有提升。