### PR TITLE
fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ shapely
 scipy
 terminaltables
 Cython
+protobuf>=3.20.2
 pycocotools
 setuptools
 


### PR DESCRIPTION
ERROR: onnx 1.13.1 has requirement protobuf<4,>=3.20.2, but you'll have protobuf 3.20.0 which is incompatible.