### PR TITLE
Get sorted images

### DIFF
--- a/tools/infer.py
+++ b/tools/infer.py
@@ -147,7 +147,7 @@ def get_test_images(infer_dir, infer_img):
     exts += [ext.upper() for ext in exts]
     for ext in exts:
         images.update(glob.glob('{}/*.{}'.format(infer_dir, ext)))
-    images = list(images)
+    images = sort(list(images))
 
     assert len(images) > 0, "no image found in {}".format(infer_dir)
     logger.info("Found {} inference images in total.".format(len(images)))

--- a/tools/infer.py
+++ b/tools/infer.py
@@ -147,7 +147,7 @@ def get_test_images(infer_dir, infer_img):
     exts += [ext.upper() for ext in exts]
     for ext in exts:
         images.update(glob.glob('{}/*.{}'.format(infer_dir, ext)))
-    images = sort(list(images))
+    images = sorted(list(images))
 
     assert len(images) > 0, "no image found in {}".format(infer_dir)
     logger.info("Found {} inference images in total.".format(len(images)))


### PR DESCRIPTION
原来的infer.py测试生成json文件的图片id是乱序的，跟图片顺序不一致。在获取文件时添加排序功能，使图片id与图片顺序对应起来