### PR TITLE
make solov2 & faster-rcnn adaptive to 0d-output for __getitem__

### DIFF
--- a/ppdet/modeling/heads/solov2_head.py
+++ b/ppdet/modeling/heads/solov2_head.py
@@ -449,7 +449,7 @@ class SOLOv2Head(nn.Layer):
             seg_masks, cate_labels, cate_scores = self.get_seg_single(
                 cate_pred_list, seg_pred_list, kernel_pred_list, featmap_size,
                 im_shape[idx], scale_factor[idx][0])
-            bbox_num = paddle.shape(cate_labels)[0]
+            bbox_num = paddle.shape(cate_labels)[0:1]
         return seg_masks, cate_labels, cate_scores, bbox_num
 
     def get_seg_single(self, cate_preds, seg_preds, kernel_preds, featmap_size,

--- a/ppdet/modeling/heads/solov2_head.py
+++ b/ppdet/modeling/heads/solov2_head.py
@@ -458,8 +458,8 @@ class SOLOv2Head(nn.Layer):
         The code of this function is based on:
             https://github.com/WXinlong/SOLO/blob/master/mmdet/models/anchor_heads/solov2_head.py#L385
         """
-        h = paddle.cast(im_shape[0], 'int32')[0]
-        w = paddle.cast(im_shape[1], 'int32')[0]
+        h = paddle.cast(im_shape[0], 'int32')
+        w = paddle.cast(im_shape[1], 'int32')
         upsampled_size_out = [featmap_size[0] * 4, featmap_size[1] * 4]
 
         y = paddle.zeros(shape=paddle.shape(cate_preds), dtype='float32')
@@ -467,7 +467,7 @@ class SOLOv2Head(nn.Layer):
         inds = paddle.nonzero(inds)
         cate_preds = paddle.reshape(cate_preds, shape=[-1])
         # Prevent empty and increase fake data
-        ind_a = paddle.cast(paddle.shape(kernel_preds)[0], 'int64')
+        ind_a = paddle.cast(paddle.shape(kernel_preds)[0:1], 'int64')
         ind_b = paddle.zeros(shape=[1], dtype='int64')
         inds_end = paddle.unsqueeze(paddle.concat([ind_a, ind_b]), 0)
         inds = paddle.concat([inds, inds_end])
@@ -513,9 +513,9 @@ class SOLOv2Head(nn.Layer):
         keep = paddle.squeeze(keep, axis=[1])
         # Prevent empty and increase fake data
         keep_other = paddle.concat(
-            [keep, paddle.cast(paddle.shape(sum_masks)[0] - 1, 'int64')])
+            [keep, paddle.cast(paddle.shape(sum_masks)[0:1] - 1, 'int64')])
         keep_scores = paddle.concat(
-            [keep, paddle.cast(paddle.shape(sum_masks)[0], 'int64')])
+            [keep, paddle.cast(paddle.shape(sum_masks)[0:1], 'int64')])
         cate_scores_end = paddle.zeros(shape=[1], dtype='float32')
         cate_scores = paddle.concat([cate_scores, cate_scores_end])
 

--- a/ppdet/modeling/layers.py
+++ b/ppdet/modeling/layers.py
@@ -1003,7 +1003,7 @@ class MaskMatrixNMS(object):
         keep = paddle.squeeze(keep, axis=[1])
         # Prevent empty and increase fake data
         keep = paddle.concat(
-            [keep, paddle.cast(paddle.shape(cate_scores)[0] - 1, 'int64')])
+            [keep, paddle.cast(paddle.shape(cate_scores)[0:1] - 1, 'int64')])
 
         seg_preds = paddle.gather(seg_preds, index=keep)
         cate_scores = paddle.gather(cate_scores, index=keep)
@@ -1337,7 +1337,7 @@ class ConvMixer(nn.Layer):
         Seq, ActBn = nn.Sequential, lambda x: Seq(x, nn.GELU(), nn.BatchNorm2D(dim))
         Residual = type('Residual', (Seq, ),
                         {'forward': lambda self, x: self[0](x) + x})
-        return Seq(*[
+        return Seq(* [
             Seq(Residual(
                 ActBn(
                     nn.Conv2D(

--- a/ppdet/modeling/post_process.py
+++ b/ppdet/modeling/post_process.py
@@ -127,8 +127,8 @@ class BBoxPostProcess(object):
                     bbox_num_i = fake_bbox_num
                 else:
                     bboxes_i = bboxes[id_start:id_start + bbox_num[i], :]
-                    bbox_num_i = bbox_num[i]
-                    id_start += bbox_num[i]
+                    bbox_num_i = bbox_num[i:i + 1]
+                    id_start += bbox_num[i:i + 1]
                 bboxes_list.append(bboxes_i)
                 bbox_num_list.append(bbox_num_i)
             bboxes = paddle.concat(bboxes_list)
@@ -142,10 +142,10 @@ class BBoxPostProcess(object):
             # scale_factor: scale_y, scale_x
             for i in range(bbox_num.shape[0]):
                 expand_shape = paddle.expand(origin_shape[i:i + 1, :],
-                                             [bbox_num[i], 2])
-                scale_y, scale_x = scale_factor[i][0], scale_factor[i][1]
+                                             [bbox_num[i:i + 1], 2])
+                scale_y, scale_x = scale_factor[i, 0:1], scale_factor[i, 1:2]
                 scale = paddle.concat([scale_x, scale_y, scale_x, scale_y])
-                expand_scale = paddle.expand(scale, [bbox_num[i], 4])
+                expand_scale = paddle.expand(scale, [bbox_num[i:i + 1], 4])
                 origin_shape_list.append(expand_shape)
                 scale_factor_list.append(expand_scale)
 
@@ -158,8 +158,8 @@ class BBoxPostProcess(object):
             scale = paddle.concat(
                 [scale_x, scale_y, scale_x, scale_y]).unsqueeze(0)
             self.origin_shape_list = paddle.expand(origin_shape,
-                                                   [bbox_num[0], 2])
-            scale_factor_list = paddle.expand(scale, [bbox_num[0], 4])
+                                                   [bbox_num[0:1], 2])
+            scale_factor_list = paddle.expand(scale, [bbox_num[0:1], 4])
 
         # bboxes: [N, 6], label, score, bbox
         pred_label = bboxes[:, 0:1]

--- a/ppdet/modeling/proposal_generator/rpn_head.py
+++ b/ppdet/modeling/proposal_generator/rpn_head.py
@@ -229,7 +229,7 @@ class RPNHead(nn.Layer):
                     topk_prob = rpn_prob_list[0].flatten()
 
                 bs_rois_collect.append(topk_rois)
-                bs_rois_num_collect.append(paddle.shape(topk_rois)[0])
+                bs_rois_num_collect.append(paddle.shape(topk_rois)[0:1])
 
             bs_rois_num_collect = paddle.concat(bs_rois_num_collect)
 


### PR DESCRIPTION
From PaddlePaddle v2.5, if output of API is a **scalar**, semantically, the rank will be 0-D (in the past, it was 1-D), which is same with Pytorch & Numpy.

The indexing API `__getitem__/__setitem__` are also changed (please see PR https://github.com/PaddlePaddle/Paddle/pull/52814  for detail). However, this change makes some error in our model code, (most is `paddle.concat(List-of-0D-Tensor)`). And this PR is to fix the error. 

**Compatibility Issues**
- inference-model exported before Paddle v2.5,  cannot be inferred by Paddle v2.5
- The model code can still run under Paddle before v2.5.

Solov2: 
![solov2-000000014439222](https://user-images.githubusercontent.com/15810355/233039409-69894128-f2de-4f03-b226-74bf96c9406f.jpg)

Faster-Rcnn:
![fasterrcnn-fpn000000014439](https://user-images.githubusercontent.com/15810355/233039437-0948e335-e082-43bb-9a98-7f64a9c7c650.jpg)