### PR TITLE
update tools/x2coco.py shell

### DIFF
--- a/tools/x2coco.py
+++ b/tools/x2coco.py
@@ -190,7 +190,7 @@ def deal_json(ds_type, img_path, json_path):
 
 def voc_get_label_anno(ann_dir_path, ann_ids_path, labels_path):
     with open(labels_path, 'r') as f:
-        labels_str = f.read().split()
+        labels_str = f.read().split("\n")
     labels_ids = list(range(1, len(labels_str) + 1))
 
     with open(ann_ids_path, 'r') as f:


### PR DESCRIPTION
line 193 was " labels_str = f.read().split()", this will lead to a wrong result when use it for voc dataset transfer to coco, because the image labels in the file are segment by '\n" when wrote to the file. if use a default seg(" "）， when the label is like "haski dog", will result to error!