### PR TITLE
[npu-tipc] Minimize coco datasets for npu tipc 

### DIFF
--- a/test_tipc/test_train_inference_python_npu.sh
+++ b/test_tipc/test_train_inference_python_npu.sh
@@ -65,6 +65,22 @@ grep -n '.yml' $FILENAME  | cut -d ":" -f 1 \
         sed -i 's/use_gpu/use_npu/g' "$sub_config_path"
     done
 done
+
+
+# NPU lacks operators such as deformable_conv, depthwise_conv2d_transpose, 
+# which will affects ips. Here, we reduce the number of coco training sets 
+# for npu tipc bencnmark. This is a temporary hack.
+# # TODO(duanyanhui): add vision ops for npu 
+train_img_num=`cat $REPO_ROOT_PATH/dataset/coco/annotations/instances_train2017.json | grep -o  file_name | wc -l`
+exp_num=8
+if [ ${train_img_num} != ${exp_num} ];then
+    echo "Replace with npu tipc coco training annotations"
+    mv $REPO_ROOT_PATH/dataset/coco/annotations/instances_train2017.json $REPO_ROOT_PATH/dataset/coco/annotations/instances_train2017_bak.json
+    wget https://raw.githubusercontent.com/YanhuiDua/PaddleDetection/npu_tipc/dataset/coco/annotations/instances_train2017.json
+    mv instances_train2017.json $REPO_ROOT_PATH/dataset/coco/annotations/
+    rm -f instances_train2017.json
+fi
+
 # pass parameters to test_train_inference_python.sh
 cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} $2"
 echo $cmd

--- a/test_tipc/test_train_inference_python_npu.sh
+++ b/test_tipc/test_train_inference_python_npu.sh
@@ -76,7 +76,7 @@ exp_num=8
 if [ ${train_img_num} != ${exp_num} ];then
     echo "Replace with npu tipc coco training annotations"
     mv $REPO_ROOT_PATH/dataset/coco/annotations/instances_train2017.json $REPO_ROOT_PATH/dataset/coco/annotations/instances_train2017_bak.json
-    wget https://raw.githubusercontent.com/YanhuiDua/PaddleDetection/npu_tipc/dataset/coco/annotations/instances_train2017.json
+    wget https://paddle-device.bj.bcebos.com/tipc/instances_train2017.json
     mv instances_train2017.json $REPO_ROOT_PATH/dataset/coco/annotations/
     rm -f instances_train2017.json
 fi


### PR DESCRIPTION
由于目前npu缺失了一些vision op, 例如deformable_conv2, depthwise_conv2d_transpose, generate_proposals, distribute_fpn_proposals等；1个epoch的训练时间为gpu的几十倍，无法支持建设npu tipc benchmask；

此PR临时性地将coco_tipc datasets中train_image的数量由64减少至8，来保证可接受的时间内正常的tipc功能验证；

后续npu kernel支持完成，会将此部分代码删除