### PR TITLE
improve amp training and fix nan error

### DIFF
--- a/configs/keypoint/tiny_pose/tinypose_128x96.yml
+++ b/configs/keypoint/tiny_pose/tinypose_128x96.yml
@@ -14,6 +14,9 @@ trainsize: &trainsize [*train_width, *train_height]
 hmsize: &hmsize [24, 32]
 flip_perm: &flip_perm [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12], [13, 14], [15, 16]]
 
+# AMP training
+init_loss_scaling: 32752
+master_grad: true
 
 #####model
 architecture: TopDownHRNet

--- a/configs/ppyolo/_base_/ppyolov2_r50vd_dcn.yml
+++ b/configs/ppyolo/_base_/ppyolov2_r50vd_dcn.yml
@@ -4,6 +4,9 @@ norm_type: sync_bn
 use_ema: true
 ema_decay: 0.9998
 
+# AMP training
+master_grad: true
+
 YOLOv3:
   backbone: ResNet
   neck: PPYOLOPAN

--- a/configs/ppyolo/ppyolo_mbv3_large_coco.yml
+++ b/configs/ppyolo/ppyolo_mbv3_large_coco.yml
@@ -9,6 +9,9 @@ _BASE_: [
 snapshot_epoch: 10
 weights: output/ppyolo_mbv3_large_coco/model_final
 
+# AMP training
+master_grad: true
+
 TrainReader:
   inputs_def:
     num_max_boxes: 90

--- a/ppdet/engine/trainer.py
+++ b/ppdet/engine/trainer.py
@@ -72,6 +72,7 @@ class Trainer(object):
         self.amp_level = self.cfg.get('amp_level', 'O1')
         self.custom_white_list = self.cfg.get('custom_white_list', None)
         self.custom_black_list = self.cfg.get('custom_black_list', None)
+        self.use_master_grad = self.cfg.get('master_grad', False)
         if 'slim' in cfg and cfg['slim_type'] == 'PTQ':
             self.cfg['TestDataset'] = create('TestDataset')()
 
@@ -179,10 +180,19 @@ class Trainer(object):
                 self.pruner = create('UnstructuredPruner')(self.model,
                                                            steps_per_epoch)
         if self.use_amp and self.amp_level == 'O2':
-            self.model, self.optimizer = paddle.amp.decorate(
-                models=self.model,
-                optimizers=self.optimizer,
-                level=self.amp_level)
+            paddle_version = paddle.__version__[:3]
+            # paddle version >= 2.5.0 or develop
+            if paddle_version in ["2.5", "0.0"]:
+                self.model, self.optimizer = paddle.amp.decorate(
+                    models=self.model,
+                    optimizers=self.optimizer,
+                    level=self.amp_level,
+                    master_grad=self.use_master_grad)
+            else:
+                self.model, self.optimizer = paddle.amp.decorate(
+                    models=self.model,
+                    optimizers=self.optimizer,
+                    level=self.amp_level)
         self.use_ema = ('use_ema' in cfg and cfg['use_ema'])
         if self.use_ema:
             ema_decay = self.cfg.get('ema_decay', 0.9998)

--- a/ppdet/modeling/layers.py
+++ b/ppdet/modeling/layers.py
@@ -362,6 +362,8 @@ class DropBlock(nn.Layer):
                 padding=self.block_size // 2,
                 data_format=self.data_format)
             mask = 1. - mask_inv
+            mask = mask.astype('float32')
+            x = x.astype('float32')
             y = x * mask * (mask.numel() / mask.sum())
             return y
 

--- a/ppdet/modeling/losses/yolo_loss.py
+++ b/ppdet/modeling/losses/yolo_loss.py
@@ -190,8 +190,9 @@ class YOLOv3Loss(nn.Layer):
         self.distill_pairs.clear()
         for x, t, anchor, downsample in zip(inputs, gt_targets, anchors,
                                             self.downsample):
-            yolo_loss = self.yolov3_loss(x, t, gt_box, anchor, downsample,
-                                         self.scale_x_y)
+            yolo_loss = self.yolov3_loss(
+                x.astype('float32'), t, gt_box, anchor, downsample,
+                self.scale_x_y)
             for k, v in yolo_loss.items():
                 if k in yolo_losses:
                     yolo_losses[k] += v

--- a/ppdet/optimizer/ema.py
+++ b/ppdet/optimizer/ema.py
@@ -69,9 +69,9 @@ class ModelEMA(object):
         self.state_dict = dict()
         for k, v in model.state_dict().items():
             if k in self.ema_black_list:
-                self.state_dict[k] = v
+                self.state_dict[k] = v.astype('float32')
             else:
-                self.state_dict[k] = paddle.zeros_like(v)
+                self.state_dict[k] = paddle.zeros_like(v, dtype='float32')
 
         self._model_state = {
             k: weakref.ref(p)
@@ -114,7 +114,7 @@ class ModelEMA(object):
 
         for k, v in self.state_dict.items():
             if k not in self.ema_black_list:
-                v = decay * v + (1 - decay) * model_dict[k]
+                v = decay * v + (1 - decay) * model_dict[k].astype('float32')
                 v.stop_gradient = True
                 self.state_dict[k] = v
         self.step += 1
@@ -123,13 +123,15 @@ class ModelEMA(object):
         if self.step == 0:
             return self.state_dict
         state_dict = dict()
+        model_dict = {k: p() for k, p in self._model_state.items()}
         for k, v in self.state_dict.items():
             if k in self.ema_black_list:
                 v.stop_gradient = True
-                state_dict[k] = v
+                state_dict[k] = v.astype(model_dict[k].dtype)
             else:
                 if self.ema_decay_type != 'exponential':
                     v = v / (1 - self._decay**self.step)
+                    v = v.astype(model_dict[k].dtype)
                 v.stop_gradient = True
                 state_dict[k] = v
         self.epoch += 1


### PR DESCRIPTION
背景：ppyoloe、ppyolo、ppyolov2、picodet、mask_rcnn、tinypose在Paddle2.4版本上amp-o2会训练nan，或者精度无法对齐。本PR修复这几个模型，并且已经自测了当前修复后的精度，可以达到和fp32训练对齐的效果。主要修复的问题如下：


（1）**一些模型特定的模块计算结果上溢出，不适合fp16**：
- ppyoloe、ppyolo、ppyolov2、picodet、mask_rcnn这些模型中发现，IoU计算、DropBlock、YoLoLoss、PicoHeadV2等多个部分计算结果已经远超fp16上限，因此导致模型运行nan。
- 在旧版本上，amp-o2采用的是almost fp16，即只要算子支持fp16就使用fp16计算，较为激进。而Paddle2.5版本和当前的develop分支上，除了conv等白名单算子会默认采用fp16计算加速，其他算子当输入全是fp16类型才会使用fp16计算。因此能够避免一些模块出现上溢出，例如mask rcnn模型原始需要对IoU部分关掉amp，但在Paddle2.5上由于该模块算子输入存在fp32类型，则自动选择fp32计算，无需修改模型。 

（2）**一些模型需要手动将部分算子输入提升到fp32类型**：如PR中修改，某些模块依然会在Paddle2.5上出现溢出，但基于升级后的O2，我们只需要将算子输入手动cast到fp32就能保证算子使用fp32计算了。而在过去需要手动cast+auto_cast(enable=False)2步修改。

（3）**一些模型梯度过小导致训练指标无法对齐**：tinypose模型梯度非常小，套件采用了1024的初始loss scale，会导致梯度大部分在fp16表示下为0，参数得不到更新，表现在训练开始后loss没有下降也没有nan。另外在反向传播过程中权重梯度尽管可以通过调大的loss scale被放大，但在参数更新前需要unscale权重的梯度，此时权重梯度在fp16表示下依然会变为0，导致梯度更新受影响。因此我们新增了master_grad的功能解决此问题：当启用该功能后，每一个迭代，在反向传播结束，权重梯度会被cast到fp32，并且用这份fp32梯度替换原始的fp16梯度，以此来保证后续通过param.grad拿到的是fp32梯度，避免unscale后数值下溢出为0

（4）**一些模型梯度过大导致训练nan**：ppyolo、ppyolov2权重梯度较大，在grad_clip阶段，会导致在fp16计算下出现inf。该问题也可以通过启用master_grad去解决。

（5）**EAM在amp-o2模式下，需要使用fp32存储权重，并且使用fp32计算更新权重**：原始的实现EMA部分在O2模式下采用的fp16的权重存储和计算，随着迭代误差积累会发现训练loss正常下降，但是eval时指标接近于0。