### PR TITLE
fix the error of defined more than once

### DIFF
--- a/deploy/cpp/src/main.cc
+++ b/deploy/cpp/src/main.cc
@@ -62,7 +62,7 @@ DEFINE_int32(gpu_id, 0, "Device id of GPU to execute");
 DEFINE_bool(run_benchmark,
             false,
             "Whether to predict a image_file repeatedly for benchmark");
-DEFINE_bool(use_mkldnn, false, "Whether use mkldnn with CPU");
+DECLARE_bool(use_mkldnn);
 DEFINE_int32(cpu_threads, 1, "Num of threads with CPU");
 DEFINE_int32(trt_min_shape, 1, "Min shape of TRT DynamicShapeI");
 DEFINE_int32(trt_max_shape, 1280, "Max shape of TRT DynamicShapeI");

--- a/deploy/cpp/src/main.cc
+++ b/deploy/cpp/src/main.cc
@@ -62,7 +62,7 @@ DEFINE_int32(gpu_id, 0, "Device id of GPU to execute");
 DEFINE_bool(run_benchmark,
             false,
             "Whether to predict a image_file repeatedly for benchmark");
-DECLARE_bool(use_mkldnn);
+DEFINE_bool(run_mkldnn, false, "Whether use mkldnn with CPU");
 DEFINE_int32(cpu_threads, 1, "Num of threads with CPU");
 DEFINE_int32(trt_min_shape, 1, "Min shape of TRT DynamicShapeI");
 DEFINE_int32(trt_max_shape, 1280, "Max shape of TRT DynamicShapeI");
@@ -91,7 +91,7 @@ void PrintBenchmarkLog(std::vector<double> det_time, int img_num) {
     LOG(INFO) << "precision: "
               << "fp32";
   }
-  LOG(INFO) << "enable_mkldnn: " << (FLAGS_use_mkldnn ? "True" : "False");
+  LOG(INFO) << "enable_mkldnn: " << (FLAGS_run_mkldnn ? "True" : "False");
   LOG(INFO) << "cpu_math_library_num_threads: " << FLAGS_cpu_threads;
   LOG(INFO) << "----------------------- Data info -----------------------";
   LOG(INFO) << "batch_size: " << FLAGS_batch_size;
@@ -386,7 +386,7 @@ int main(int argc, char** argv) {
   // Load model and create a object detector
   PaddleDetection::ObjectDetector det(FLAGS_model_dir,
                                       FLAGS_device,
-                                      FLAGS_use_mkldnn,
+                                      FLAGS_run_mkldnn,
                                       FLAGS_cpu_threads,
                                       FLAGS_run_mode,
                                       FLAGS_batch_size,


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
fix the ERROR: "flag 'use_mkldnn' was defined more than once" in cpp inference to adapt the change of Paddle.
<img width="384" alt="788a3412c1a1d176b7bbe83e5f910a18" src="https://github.com/PaddlePaddle/PaddleDetection/assets/49938469/23e90f7f-e406-42c4-863b-7f91de5b21e6">

'use_mkldnn' was defined twice in https://github.com/PaddlePaddle/Paddle/blob/64ecdc03db38377e37a1c149086c1eb8700c3e04/paddle/phi/core/flags.cc#LL682C30-L682C30 and https://github.com/PaddlePaddle/PaddleDetection/blob/152b6365f1fc473f2cc9bbfc99f140af995344e4/deploy/cpp/src/main.cc#L65

