### PR TITLE
Toward Devkit Consistency

### DIFF
--- a/configs/slim/quant/mask_rcnn_r50_fpn_1x_qat.yml
+++ b/configs/slim/quant/mask_rcnn_r50_fpn_1x_qat.yml
@@ -8,8 +8,10 @@ QAT:
     'quantizable_layer_type': ['Conv2D', 'Linear']}
   print_model: True
 
-
 epoch: 5
+
+TrainReader:
+  batch_size: 1
 
 LearningRate:
   base_lr: 0.001

--- a/configs/slim/quant/yolov3_darknet_qat.yml
+++ b/configs/slim/quant/yolov3_darknet_qat.yml
@@ -10,6 +10,9 @@ QAT:
 
 epoch: 50
 
+TrainReader:
+  batch_size: 8
+
 LearningRate:
   base_lr: 0.0001
   schedulers:

--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -874,7 +874,7 @@ class PredictConfig():
         model_dir (str): root path of model.yml
     """
 
-    def __init__(self, model_dir, use_fd_format):
+    def __init__(self, model_dir, use_fd_format=False):
         # parsing Yaml config for Preprocess
         if use_fd_format:
             deploy_file = os.path.join(model_dir, 'inference.yml')

--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -876,10 +876,22 @@ class PredictConfig():
 
     def __init__(self, model_dir, use_fd_format=False):
         # parsing Yaml config for Preprocess
+        fd_deploy_file = os.path.join(model_dir, 'inference.yml')
+        ppdet_deploy_file = os.path.join(model_dir, 'infer_cfg.yml')
         if use_fd_format:
-            deploy_file = os.path.join(model_dir, 'inference.yml')
+            if not os.path.exists(fd_deploy_file) and os.path.exists(
+                    ppdet_deploy_file):
+                raise RuntimeError(
+                    "Non-FD format model detected. Please set `use_fd_format` to False."
+                )
+            deploy_file = fd_deploy_file
         else:
-            deploy_file = os.path.join(model_dir, 'infer_cfg.yml')
+            if not os.path.exists(ppdet_deploy_file) and os.path.exists(
+                    fd_deploy_file):
+                raise RuntimeError(
+                    "FD format model detected. Please set `use_fd_format` to False."
+                )
+            deploy_file = ppdet_deploy_file
         with open(deploy_file) as f:
             yml_conf = yaml.safe_load(f)
         self.check_model(yml_conf)

--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -103,7 +103,7 @@ class Detector(object):
                  threshold=0.5,
                  delete_shuffle_pass=False,
                  use_fd_format=False):
-        self.pred_config = self.set_config(model_dir)
+        self.pred_config = self.set_config(model_dir, use_fd_format=use_fd_format)
         self.predictor, self.config = load_predictor(
             model_dir,
             self.pred_config.arch,
@@ -125,10 +125,9 @@ class Detector(object):
         self.batch_size = batch_size
         self.output_dir = output_dir
         self.threshold = threshold
-        self.use_fd_format = use_fd_format
 
-    def set_config(self, model_dir):
-        return PredictConfig(model_dir, use_fd_format=self.use_fd_format)
+    def set_config(self, model_dir, use_fd_format):
+        return PredictConfig(model_dir, use_fd_format=use_fd_format)
 
     def preprocess(self, image_list):
         preprocess_ops = []
@@ -562,7 +561,8 @@ class DetectorSOLOv2(Detector):
             enable_mkldnn=False,
             enable_mkldnn_bfloat16=False,
             output_dir='./',
-            threshold=0.5, ):
+            threshold=0.5, 
+            use_fd_format=False):
         super(DetectorSOLOv2, self).__init__(
             model_dir=model_dir,
             device=device,
@@ -576,7 +576,8 @@ class DetectorSOLOv2(Detector):
             enable_mkldnn=enable_mkldnn,
             enable_mkldnn_bfloat16=enable_mkldnn_bfloat16,
             output_dir=output_dir,
-            threshold=threshold, )
+            threshold=threshold, 
+            use_fd_format=use_fd_format)
 
     def predict(self, repeats=1, run_benchmark=False):
         '''
@@ -652,7 +653,8 @@ class DetectorPicoDet(Detector):
             enable_mkldnn=False,
             enable_mkldnn_bfloat16=False,
             output_dir='./',
-            threshold=0.5, ):
+            threshold=0.5, 
+            use_fd_format=False):
         super(DetectorPicoDet, self).__init__(
             model_dir=model_dir,
             device=device,
@@ -666,7 +668,8 @@ class DetectorPicoDet(Detector):
             enable_mkldnn=enable_mkldnn,
             enable_mkldnn_bfloat16=enable_mkldnn_bfloat16,
             output_dir=output_dir,
-            threshold=threshold, )
+            threshold=threshold, 
+            use_fd_format=use_fd_format)
 
     def postprocess(self, inputs, result):
         # postprocess output of predictor
@@ -747,7 +750,8 @@ class DetectorCLRNet(Detector):
             enable_mkldnn=False,
             enable_mkldnn_bfloat16=False,
             output_dir='./',
-            threshold=0.5, ):
+            threshold=0.5, 
+            use_fd_format=False):
         super(DetectorCLRNet, self).__init__(
             model_dir=model_dir,
             device=device,
@@ -761,7 +765,8 @@ class DetectorCLRNet(Detector):
             enable_mkldnn=enable_mkldnn,
             enable_mkldnn_bfloat16=enable_mkldnn_bfloat16,
             output_dir=output_dir,
-            threshold=threshold, )
+            threshold=threshold, 
+            use_fd_format=use_fd_format)
 
         deploy_file = os.path.join(model_dir, 'infer_cfg.yml')
         with open(deploy_file) as f:

--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -982,7 +982,7 @@ def load_predictor(model_dir,
     elif device == 'NPU':
         if config.lite_engine_enabled():
             config.enable_lite_engine()
-        config.enable_npu()
+        config.enable_custom_device('npu')
     else:
         config.disable_gpu()
         config.set_cpu_math_library_num_threads(cpu_threads)

--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -101,7 +101,8 @@ class Detector(object):
                  enable_mkldnn_bfloat16=False,
                  output_dir='output',
                  threshold=0.5,
-                 delete_shuffle_pass=False):
+                 delete_shuffle_pass=False,
+                 use_fd_format=False):
         self.pred_config = self.set_config(model_dir)
         self.predictor, self.config = load_predictor(
             model_dir,
@@ -124,9 +125,10 @@ class Detector(object):
         self.batch_size = batch_size
         self.output_dir = output_dir
         self.threshold = threshold
+        self.use_fd_format = use_fd_format
 
     def set_config(self, model_dir):
-        return PredictConfig(model_dir)
+        return PredictConfig(model_dir, use_fd_format=self.use_fd_format)
 
     def preprocess(self, image_list):
         preprocess_ops = []
@@ -867,9 +869,12 @@ class PredictConfig():
         model_dir (str): root path of model.yml
     """
 
-    def __init__(self, model_dir):
+    def __init__(self, model_dir, use_fd_format):
         # parsing Yaml config for Preprocess
-        deploy_file = os.path.join(model_dir, 'infer_cfg.yml')
+        if use_fd_format:
+            deploy_file = os.path.join(model_dir, 'inference.yml')
+        else:
+            deploy_file = os.path.join(model_dir, 'infer_cfg.yml')
         with open(deploy_file) as f:
             yml_conf = yaml.safe_load(f)
         self.check_model(yml_conf)
@@ -972,7 +977,7 @@ def load_predictor(model_dir,
     elif device == 'NPU':
         if config.lite_engine_enabled():
             config.enable_lite_engine()
-        config.enable_custom_device('npu')
+        config.enable_npu()
     else:
         config.disable_gpu()
         config.set_cpu_math_library_num_threads(cpu_threads)
@@ -1121,7 +1126,10 @@ def print_arguments(args):
 
 
 def main():
-    deploy_file = os.path.join(FLAGS.model_dir, 'infer_cfg.yml')
+    if FLAGS.use_fd_format:
+        deploy_file = os.path.join(FLAGS.model_dir, 'inference.yml')
+    else:
+        deploy_file = os.path.join(FLAGS.model_dir, 'infer_cfg.yml')
     with open(deploy_file) as f:
         yml_conf = yaml.safe_load(f)
     arch = yml_conf['arch']
@@ -1146,7 +1154,8 @@ def main():
         enable_mkldnn=FLAGS.enable_mkldnn,
         enable_mkldnn_bfloat16=FLAGS.enable_mkldnn_bfloat16,
         threshold=FLAGS.threshold,
-        output_dir=FLAGS.output_dir)
+        output_dir=FLAGS.output_dir,
+        use_fd_format=FLAGS.use_fd_format)
 
     # predict from video file or camera video stream
     if FLAGS.video_file is not None or FLAGS.camera_id != -1:

--- a/deploy/python/keypoint_infer.py
+++ b/deploy/python/keypoint_infer.py
@@ -76,7 +76,8 @@ class KeyPointDetector(Detector):
                  enable_mkldnn=False,
                  output_dir='output',
                  threshold=0.5,
-                 use_dark=True):
+                 use_dark=True,
+                 use_fd_format=False):
         super(KeyPointDetector, self).__init__(
             model_dir=model_dir,
             device=device,
@@ -91,9 +92,10 @@ class KeyPointDetector(Detector):
             output_dir=output_dir,
             threshold=threshold, )
         self.use_dark = use_dark
+        self.use_fd_format = use_fd_format
 
     def set_config(self, model_dir):
-        return PredictConfig_KeyPoint(model_dir)
+        return PredictConfig_KeyPoint(model_dir, use_fd_format=self.use_fd_format)
 
     def get_person_from_rect(self, image, results):
         # crop the person result from image
@@ -302,9 +304,12 @@ class PredictConfig_KeyPoint():
         model_dir (str): root path of model.yml
     """
 
-    def __init__(self, model_dir):
+    def __init__(self, model_dir, use_fd_format):
         # parsing Yaml config for Preprocess
-        deploy_file = os.path.join(model_dir, 'infer_cfg.yml')
+        if use_fd_format:
+            deploy_file = os.path.join(model_dir, 'inference.yml')
+        else:
+            deploy_file = os.path.join(model_dir, 'infer_cfg.yml')
         with open(deploy_file) as f:
             yml_conf = yaml.safe_load(f)
         self.check_model(yml_conf)
@@ -368,7 +373,8 @@ def main():
         enable_mkldnn=FLAGS.enable_mkldnn,
         threshold=FLAGS.threshold,
         output_dir=FLAGS.output_dir,
-        use_dark=FLAGS.use_dark)
+        use_dark=FLAGS.use_dark,
+        use_fd_format=FLAGS.use_fd_format)
 
     # predict from video file or camera video stream
     if FLAGS.video_file is not None or FLAGS.camera_id != -1:

--- a/deploy/python/keypoint_infer.py
+++ b/deploy/python/keypoint_infer.py
@@ -306,10 +306,22 @@ class PredictConfig_KeyPoint():
 
     def __init__(self, model_dir, use_fd_format=False):
         # parsing Yaml config for Preprocess
+        fd_deploy_file = os.path.join(model_dir, 'inference.yml')
+        ppdet_deploy_file = os.path.join(model_dir, 'infer_cfg.yml')
         if use_fd_format:
-            deploy_file = os.path.join(model_dir, 'inference.yml')
+            if not os.path.exists(fd_deploy_file) and os.path.exists(
+                    ppdet_deploy_file):
+                raise RuntimeError(
+                    "Non-FD format model detected. Please set `use_fd_format` to False."
+                )
+            deploy_file = fd_deploy_file
         else:
-            deploy_file = os.path.join(model_dir, 'infer_cfg.yml')
+            if not os.path.exists(ppdet_deploy_file) and os.path.exists(
+                    fd_deploy_file):
+                raise RuntimeError(
+                    "FD format model detected. Please set `use_fd_format` to False."
+                )
+            deploy_file = ppdet_deploy_file
         with open(deploy_file) as f:
             yml_conf = yaml.safe_load(f)
         self.check_model(yml_conf)

--- a/deploy/python/keypoint_infer.py
+++ b/deploy/python/keypoint_infer.py
@@ -304,7 +304,7 @@ class PredictConfig_KeyPoint():
         model_dir (str): root path of model.yml
     """
 
-    def __init__(self, model_dir, use_fd_format):
+    def __init__(self, model_dir, use_fd_format=False):
         # parsing Yaml config for Preprocess
         if use_fd_format:
             deploy_file = os.path.join(model_dir, 'inference.yml')

--- a/deploy/python/keypoint_infer.py
+++ b/deploy/python/keypoint_infer.py
@@ -90,12 +90,12 @@ class KeyPointDetector(Detector):
             cpu_threads=cpu_threads,
             enable_mkldnn=enable_mkldnn,
             output_dir=output_dir,
-            threshold=threshold, )
+            threshold=threshold, 
+            use_fd_format=use_fd_format)
         self.use_dark = use_dark
-        self.use_fd_format = use_fd_format
 
-    def set_config(self, model_dir):
-        return PredictConfig_KeyPoint(model_dir, use_fd_format=self.use_fd_format)
+    def set_config(self, model_dir, use_fd_format):
+        return PredictConfig_KeyPoint(model_dir, use_fd_format=use_fd_format)
 
     def get_person_from_rect(self, image, results):
         # crop the person result from image

--- a/deploy/python/utils.py
+++ b/deploy/python/utils.py
@@ -211,6 +211,7 @@ def argsparser():
         type=str,
         default="shape_range_info.pbtxt",
         help="Path of a dynamic shape file for tensorrt.")
+    parser.add_argument("--use_fd_format", action="store_true")
     return parser
 
 

--- a/deploy/python/visualize.py
+++ b/deploy/python/visualize.py
@@ -325,7 +325,7 @@ def visualize_pose(imgfile,
     if returnimg:
         return canvas
     save_name = os.path.join(
-        save_dir, os.path.splitext(os.path.basename(imgfile))[0] + '_vis.jpg')
+        save_dir, os.path.splitext(os.path.basename(imgfile))[0] + '.jpg')
     plt.imsave(save_name, canvas[:, :, ::-1])
     print("keypoint visualize image saved to: " + save_name)
     plt.close()

--- a/deploy/python/visualize.py
+++ b/deploy/python/visualize.py
@@ -325,7 +325,7 @@ def visualize_pose(imgfile,
     if returnimg:
         return canvas
     save_name = os.path.join(
-        save_dir, os.path.splitext(os.path.basename(imgfile))[0] + '.jpg')
+        save_dir, os.path.splitext(os.path.basename(imgfile))[0] + '_vis.jpg')
     plt.imsave(save_name, canvas[:, :, ::-1])
     print("keypoint visualize image saved to: " + save_name)
     plt.close()

--- a/ppdet/engine/callbacks.py
+++ b/ppdet/engine/callbacks.py
@@ -160,8 +160,7 @@ class Checkpointer(Callback):
     def __init__(self, model):
         super(Checkpointer, self).__init__(model)
         self.best_ap = -1000.
-        self.save_dir = os.path.join(self.model.cfg.save_dir,
-                                     self.model.cfg.filename)
+        self.save_dir = self.model.cfg.save_dir
         if hasattr(self.model.model, 'student_model'):
             self.weight = self.model.model.student_model
         else:
@@ -323,8 +322,7 @@ class WandbCallback(Callback):
             raise e
 
         self.wandb_params = model.cfg.get('wandb', None)
-        self.save_dir = os.path.join(self.model.cfg.save_dir,
-                                     self.model.cfg.filename)
+        self.save_dir = self.model.cfg.save_dir
         if self.wandb_params is None:
             self.wandb_params = {}
         for k, v in model.cfg.items():

--- a/ppdet/utils/checkpoint.py
+++ b/ppdet/utils/checkpoint.py
@@ -300,7 +300,8 @@ def save_model(model,
     """
     if paddle.distributed.get_rank() != 0:
         return
-    save_dir = os.path.dirname(os.path.normpath(save_dir))
+        
+    save_dir = os.path.normpath(save_dir)
     if not os.path.exists(save_dir):
         os.makedirs(save_dir)
 

--- a/ppdet/utils/checkpoint.py
+++ b/ppdet/utils/checkpoint.py
@@ -305,9 +305,9 @@ def save_model(model,
         os.makedirs(save_dir)
 
     if save_name == "best_model":
-        uapi_best_model_path = os.path.join(save_dir, 'best_model')
-        if not os.path.exists(uapi_best_model_path):
-            os.makedirs(uapi_best_model_path)
+        best_model_path = os.path.join(save_dir, 'best_model')
+        if not os.path.exists(best_model_path):
+            os.makedirs(best_model_path)
 
     save_path = os.path.join(save_dir, save_name)
     # save model
@@ -330,8 +330,8 @@ def save_model(model,
             best_model = ema_model
 
     if save_name == 'best_model':
-        uapi_best_model_path = os.path.join(uapi_best_model_path, 'model')
-        paddle.save(best_model, uapi_best_model_path + ".pdparams")
+        best_model_path = os.path.join(best_model_path, 'model')
+        paddle.save(best_model, best_model_path + ".pdparams")
     # save optimizer
     state_dict = optimizer.state_dict()
     state_dict['last_epoch'] = last_epoch

--- a/tools/export_model.py
+++ b/tools/export_model.py
@@ -56,6 +56,7 @@ def parse_args():
         default=None,
         type=str,
         help="Configuration file of slim method.")
+    parser.add_argument("--for_fd", action='store_true')
     args = parser.parse_args()
     return args
 
@@ -76,9 +77,10 @@ def run(FLAGS, cfg):
             trainer.load_weights(cfg.weights)
 
     # export model
-    trainer.export(FLAGS.output_dir)
+    trainer.export(FLAGS.output_dir, for_fd=FLAGS.for_fd)
 
     if FLAGS.export_serving_model:
+        assert not FLAGS.for_fd
         from paddle_serving_client.io import inference_model_to_serving
         model_name = os.path.splitext(os.path.split(cfg.filename)[-1])[0]
 


### PR DESCRIPTION
## 目标

修改代码以提升PaddleCV套件一致性，同时适配X项目。修改后，套件应满足如下一致性要求：

1. 将训练过程中最优（一般是验证集上精度最高）的模型权重存储在输出目录的`best_model`子目录中，文件命名为`model.pdparams`。与之相配套的优化器参数（如果存储的话）文件命名为`model.pdopt`，也存储在该目录中。
2. 支持将训练、验证过程中VisualDL产生的.log格式日志文件保存在输出目录中（无嵌套子目录）。
3. 套件根目录存在`requirements.txt`文件，指定使用套件基础功能需要的依赖。在套件根目录可通过`pip install .`或`pip install -e .`方式（至少其中一种）安装套件核心库。
4. 对于模型导出功能，默认支持或通过命令行选项/配置文件等手段支持导出为FD格式。『FD格式』的导出结果通常包含如下文件：
- `inference.pdiparams`：保存权重参数。
- `inference.pdiparams.info`：保存与参数有关的额外信息。
- `inference.pdmodel`：保存模型结构描述信息。
- （可选）`inference.yml`：预处理配置文件。

## 代码变动

1. 【一致性提升】【**不兼容升级**】使训练时检查点存储位置满足一致性要求1。
2. 【一致性提升】`tools/export_model.py`支持`--for_fd`命令行选项，以控制是否将模型导出为FD格式。
3. 【一致性提升】`deploy/python/infer.py`与`deploy/python/keypoint_infer.py`支持`--use_fd_format`命令行选项，能够接受并处理FD格式的导出模型。
4. 【功能增强】修改`configs/slim/quant/mask_rcnn_r50_fpn_1x_qat.yml`与`configs/slim/quant/yolov3_darknet_qat.yml`，以使这两个模型在量化训练时使用合适的batch size。

## 遗留问题

1. 对于代码变动1，**尚未更新相关文档**。若此PR合入，可能需要套件同学进行更新。
2. 由于代码变动1为不兼容升级，若此PR合入，套件RD和QA同学可能需要**更新测试脚本**。
3. 为减小不兼容升级带来的影响，本次改动未完全移除PaddleDetection原有的对最优模型的存储逻辑。因此，输出目录中将存在model.pdparams的两份拷贝。后续需考虑继续优化，使最优模型只保留一份。
4. 目前`best_model`目录中尚未存储`model.pdopt`，尽管后者是可存储的。不过目前的实现也未违背一致性要求1。后续可考虑追加存储优化器参数。

