### PR TITLE
fix use_mkldnn defined error

### DIFF
--- a/deploy/cpp/src/main_jde.cc
+++ b/deploy/cpp/src/main_jde.cc
@@ -60,7 +60,7 @@ DEFINE_int32(gpu_id, 0, "Device id of GPU to execute");
 DEFINE_bool(run_benchmark,
             false,
             "Whether to predict a image_file repeatedly for benchmark");
-DEFINE_bool(use_mkldnn, false, "Whether use mkldnn with CPU");
+DEFINE_bool(run_mkldnn, false, "Whether use mkldnn with CPU");
 DEFINE_int32(cpu_threads, 1, "Num of threads with CPU");
 DEFINE_int32(trt_min_shape, 1, "Min shape of TRT DynamicShapeI");
 DEFINE_int32(trt_max_shape, 1280, "Max shape of TRT DynamicShapeI");
@@ -89,7 +89,7 @@ void PrintBenchmarkLog(std::vector<double> det_time, int img_num) {
     LOG(INFO) << "precision: "
               << "fp32";
   }
-  LOG(INFO) << "enable_mkldnn: " << (FLAGS_use_mkldnn ? "True" : "False");
+  LOG(INFO) << "enable_mkldnn: " << (FLAGS_run_mkldnn ? "True" : "False");
   LOG(INFO) << "cpu_math_library_num_threads: " << FLAGS_cpu_threads;
   LOG(INFO) << "----------------------- Data info -----------------------";
   LOG(INFO) << "batch_size: " << FLAGS_batch_size;
@@ -252,7 +252,7 @@ int main(int argc, char** argv) {
   // Do inference on input video or image
   PaddleDetection::JDEDetector mot(FLAGS_model_dir,
                                    FLAGS_device,
-                                   FLAGS_use_mkldnn,
+                                   FLAGS_run_mkldnn,
                                    FLAGS_cpu_threads,
                                    FLAGS_run_mode,
                                    FLAGS_batch_size,

--- a/deploy/cpp/src/main_keypoint.cc
+++ b/deploy/cpp/src/main_keypoint.cc
@@ -68,7 +68,7 @@ DEFINE_int32(gpu_id, 0, "Device id of GPU to execute");
 DEFINE_bool(run_benchmark,
             false,
             "Whether to predict a image_file repeatedly for benchmark");
-DEFINE_bool(use_mkldnn, false, "Whether use mkldnn with CPU");
+DEFINE_bool(run_mkldnn, false, "Whether use mkldnn with CPU");
 DEFINE_int32(cpu_threads, 1, "Num of threads with CPU");
 DEFINE_int32(trt_min_shape, 1, "Min shape of TRT DynamicShapeI");
 DEFINE_int32(trt_max_shape, 1280, "Max shape of TRT DynamicShapeI");
@@ -98,7 +98,7 @@ void PrintBenchmarkLog(std::vector<double> det_time, int img_num) {
     LOG(INFO) << "precision: "
               << "fp32";
   }
-  LOG(INFO) << "enable_mkldnn: " << (FLAGS_use_mkldnn ? "True" : "False");
+  LOG(INFO) << "enable_mkldnn: " << (FLAGS_run_mkldnn ? "True" : "False");
   LOG(INFO) << "cpu_math_library_num_threads: " << FLAGS_cpu_threads;
   LOG(INFO) << "----------------------- Data info -----------------------";
   LOG(INFO) << "batch_size: " << FLAGS_batch_size;
@@ -537,7 +537,7 @@ int main(int argc, char** argv) {
   // Load model and create a object detector
   PaddleDetection::ObjectDetector det(FLAGS_model_dir,
                                       FLAGS_device,
-                                      FLAGS_use_mkldnn,
+                                      FLAGS_run_mkldnn,
                                       FLAGS_cpu_threads,
                                       FLAGS_run_mode,
                                       FLAGS_batch_size,
@@ -551,7 +551,7 @@ int main(int argc, char** argv) {
   if (!FLAGS_model_dir_keypoint.empty()) {
     keypoint = new PaddleDetection::KeyPointDetector(FLAGS_model_dir_keypoint,
                                                      FLAGS_device,
-                                                     FLAGS_use_mkldnn,
+                                                     FLAGS_run_mkldnn,
                                                      FLAGS_cpu_threads,
                                                      FLAGS_run_mode,
                                                      FLAGS_batch_size_keypoint,

--- a/deploy/pptracking/cpp/src/main.cc
+++ b/deploy/pptracking/cpp/src/main.cc
@@ -47,7 +47,7 @@ DEFINE_string(run_mode,
               "paddle",
               "Mode of running(paddle/trt_fp32/trt_fp16/trt_int8)");
 DEFINE_int32(gpu_id, 0, "Device id of GPU to execute");
-DEFINE_bool(use_mkldnn, false, "Whether use mkldnn with CPU");
+DEFINE_bool(run_mkldnn, false, "Whether use mkldnn with CPU");
 DEFINE_int32(cpu_threads, 1, "Num of threads with CPU");
 DEFINE_bool(trt_calib_mode,
             false,
@@ -150,7 +150,7 @@ int main(int argc, char** argv) {
                                      FLAGS_output_dir,
                                      FLAGS_run_mode,
                                      FLAGS_gpu_id,
-                                     FLAGS_use_mkldnn,
+                                     FLAGS_run_mkldnn,
                                      FLAGS_cpu_threads,
                                      FLAGS_trt_calib_mode,
                                      FLAGS_do_entrance_counting,


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
fix the ERROR: "flag 'use_mkldnn' was defined more than once" in cpp inference to adapt the change of Paddle.
```
‘ERROR: flag 'use_mkldnn' was defined more than once (in files '/paddle/paddle/phi/core/flags.cc' and '/workspace/deploy/cpp/src/main_keypoint.cc').’
```

'use_mkldnn' was already defined in https://github.com/PaddlePaddle/Paddle/blob/64ecdc03db38377e37a1c149086c1eb8700c3e04/paddle/phi/core/flags.cc#LL682C30-L682C30
