### PR TITLE
Set Limit to Pillow Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ terminaltables
 Cython
 pycocotools
 setuptools
+Pillow <= 9.5.0
 
 # for MOT evaluation and inference
 lap


### PR DESCRIPTION
由于PaddleDetection目前代码不兼容Pillow 10.0.0以上版本，在`requirements.txt`中添加对Pillow库的版本限制。本次改动仅针对release/2.6.1分支，确保其可用，后续建议在develop分支修改API调用语句以适配新版本的Pillow。