### PR TITLE
fix picoheat channel number bug

### DIFF
--- a/ppdet/modeling/heads/pico_head.py
+++ b/ppdet/modeling/heads/pico_head.py
@@ -112,7 +112,7 @@ class PicoFeat(nn.Layer):
                 cls_conv_pw = self.add_sublayer(
                     'cls_conv_pw{}.{}'.format(stage_idx, i),
                     ConvNormLayer(
-                        ch_in=in_c,
+                        ch_in=feat_out,
                         ch_out=feat_out,
                         filter_size=1,
                         stride=1,


### PR DESCRIPTION
https://github.com/PaddlePaddle/PaddleDetection/blob/release/2.6/ppdet/modeling/heads/pico_head.py
第59行 PicoFeat 类中bug

在第112 行 创建 cls_conv_pw 变量的设置中：入通道为in_c，
但是 cls_conv_pw 接收 上面 cls_conv_dw 的输出作为输入，而cls_conv_dw输出的通道数是feat_out 。这样通道数不一致了。

这里把 115行的 ch_in=in_c 改为 ch_in=feat_out 