### PR TITLE
support stride and speed up

### DIFF
--- a/ppdet/modeling/assigners/simota_assigner.py
+++ b/ppdet/modeling/assigners/simota_assigner.py
@@ -241,8 +241,8 @@ class SimOTAAssigner(object):
         pos_inds, neg_inds, pos_gt_bboxes, pos_assigned_gt_inds \
             = self.get_sample(assigned_gt_inds, gt_bboxes.numpy())
 
-        bbox_target = np.zeros_like(flatten_bboxes)
-        bbox_weight = np.zeros_like(flatten_bboxes)
+        bbox_target = np.zeros(flatten_bboxes.shape, paddle.fluid.data_feeder.convert_dtype(flatten_bboxes.dtype))
+        bbox_weight = np.zeros_like(bbox_target)
         label = np.ones([num_bboxes], dtype=np.int64) * self.num_classes
         label_weight = np.zeros([num_bboxes], dtype=np.float32)
 

--- a/ppdet/modeling/assigners/simota_assigner.py
+++ b/ppdet/modeling/assigners/simota_assigner.py
@@ -241,7 +241,7 @@ class SimOTAAssigner(object):
         pos_inds, neg_inds, pos_gt_bboxes, pos_assigned_gt_inds \
             = self.get_sample(assigned_gt_inds, gt_bboxes.numpy())
 
-        bbox_target = np.zeros(flatten_bboxes.shape, paddle.fluid.data_feeder.convert_dtype(flatten_bboxes.dtype))
+        bbox_target = np.zeros(flatten_bboxes.shape, paddle.common_ops_import.convert_dtype(flatten_bboxes.dtype))
         bbox_weight = np.zeros_like(bbox_target)
         label = np.ones([num_bboxes], dtype=np.int64) * self.num_classes
         label_weight = np.zeros([num_bboxes], dtype=np.float32)

--- a/ppdet/modeling/transformers/matchers.py
+++ b/ppdet/modeling/transformers/matchers.py
@@ -176,7 +176,7 @@ class HungarianMatcher(nn.Layer):
         C = [a.squeeze(0) for a in C.chunk(bs)]
         sizes = [a.shape[0] for a in gt_bbox]
         indices = [
-            linear_sum_assignment(c.split(sizes, -1)[i].numpy())
+            linear_sum_assignment(c.split(sizes, -1)[i].contiguous().numpy())
             for i, c in enumerate(C)
         ]
         return [(paddle.to_tensor(

--- a/ppdet/modeling/transformers/matchers.py
+++ b/ppdet/modeling/transformers/matchers.py
@@ -175,10 +175,16 @@ class HungarianMatcher(nn.Layer):
         C = C.reshape([bs, num_queries, -1])
         C = [a.squeeze(0) for a in C.chunk(bs)]
         sizes = [a.shape[0] for a in gt_bbox]
-        indices = [
-            linear_sum_assignment(c.split(sizes, -1)[i].contiguous().numpy())
-            for i, c in enumerate(C)
-        ]
+        if hasattr(paddle.Tensor, "contiguous"):
+            indices = [
+                linear_sum_assignment(c.split(sizes, -1)[i].contiguous().numpy())
+                for i, c in enumerate(C)
+            ]
+        else:
+            indices = [
+                linear_sum_assignment(c.split(sizes, -1)[i].numpy())
+                for i, c in enumerate(C)
+            ]
         return [(paddle.to_tensor(
             i, dtype=paddle.int64), paddle.to_tensor(
                 j, dtype=paddle.int64)) for i, j in indices]


### PR DESCRIPTION
Paddle支持stride后，slice、split等共享显存。小Tensor的numpy会拷贝全部的大Tensor的显存。竞品也是这么做的。这有时候会导致numpy()的速度变慢进而进行模型的性能。本PR修复两个这样的问题。