### PR TITLE
fix mosaic and autoaug

### DIFF
--- a/ppdet/data/transform/operators.py
+++ b/ppdet/data/transform/operators.py
@@ -3664,7 +3664,7 @@ class Mosaic(BaseOperator):
         mosaic_img, mosaic_labels = self.random_affine_augment(
             mosaic_img,
             mosaic_labels,
-            input_dim=self.input_dim,
+            input_dim=[input_w, input_h],
             degrees=self.degrees,
             translates=self.translate,
             scales=self.scale,


### PR DESCRIPTION
见https://github.com/PaddlePaddle/PaddleDetection/issues/8517
本次修改并测试的算子包括operators.py中的Mosaic，RandomDistort，AutoAugment
autoaugment_utils.py中的policy_v3，其中带only的算子例如TranslateY_Only_BBoxes，ShearY_Only_BBoxes并未纳入本次训练进程的测试中

修改完成的数据增强，通过双3090在COCO数据集通过picodet训练10个epoch得到如下精度
![截图 2023-08-13 11-55-08](https://github.com/PaddlePaddle/PaddleDetection/assets/49911294/e120ae19-d9a3-45be-b573-98e7b8983ed9)
其中数据读取yml文件如下
```
worker_num: 0
eval_height: &eval_height 640
eval_width: &eval_width 640
eval_size: &eval_size [*eval_height, *eval_width]

TrainReader:
  sample_transforms:
  - Decode: {}
  - Mosaic:
      prob: 1.0
      input_dim: [640, 640]
      degrees: [-10, 10]
      scale: [0.5, 1.5]
      shear: [-0.5, 0.5]
      translate: [-0.1, 0.1]
      enable_mixup: True
  - AutoAugment: {autoaug_type: 'v3'}
  - DebugVisibleImage: {output_dir: '../debug'}
  batch_transforms:
  - BatchRandomResize: {target_size: [576, 608, 640, 672, 704], random_size: True, random_interp: True, keep_ratio: False}
  - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
  - Permute: {}
  - PadGT: {}
  batch_size: 32
  shuffle: true
  mosaic_epoch: 10
  drop_last: true


EvalReader:
  sample_transforms:
  - Decode: {}
  - Resize: {interp: 2, target_size: *eval_size, keep_ratio: False}
  - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
  - Permute: {}
  batch_transforms:
  - PadBatch: {pad_to_stride: 32}
  batch_size: 8
  shuffle: false


TestReader:
  inputs_def:
    image_shape: [1, 3, *eval_height, *eval_width]
  sample_transforms:
  - Decode: {}
  - Resize: {interp: 2, target_size: *eval_size, keep_ratio: False}
  - NormalizeImage: {is_scale: true, mean: [0.485,0.456,0.406], std: [0.229, 0.224,0.225]}
  - Permute: {}
  batch_size: 1
```
