### PR TITLE
修复#8528 bug

### DIFF
--- a/deploy/pipeline/pphuman/mtmct.py
+++ b/deploy/pipeline/pphuman/mtmct.py
@@ -35,7 +35,7 @@ warnings.filterwarnings("ignore")
 
 
 def gen_restxt(output_dir_filename, map_tid, cid_tid_dict):
-    pattern = re.compile(r'c(\d)_t(\d)')
+    pattern = re.compile(r'c(\d+)_t(\d+)')
     f_w = open(output_dir_filename, 'w')
     for key, res in cid_tid_dict.items():
         cid, tid = pattern.search(key).groups()


### PR DESCRIPTION
pattern = re.compile(r'c(\d)_t(\d)')
f_w = open(output_dir_filename, 'w')
for key, res in cid_tid_dict.items():
cid, tid = pattern.search(key).groups()
这个写法错误，如c0_t110 表示视频1，跟踪标签110，但是提取到的cid为0，tid为1，而不是完整的跟踪id，导致输出文件错误。
下文在匹配其他视角视频做reid时结果错误。
建议修改表达式为：
pattern = re.compile(r'c(\d+)_t(\d+)')