### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ setuptools
 # for MOT evaluation and inference
 lap
 motmetrics
-sklearn==0.0
+scikit-learn
 
 # for vehicleplate in deploy/pipeline/ppvehicle
 pyclipper


### PR DESCRIPTION
解决安装sklearn报错
Collecting sklearn
  Downloading sklearn-0.0.post4.tar.gz (3.6 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
error: metadata-generation-failed

× Encountered error while generating package metadata. ╰─> See above for output.