### PR TITLE
Fixed upper limit for num_id in json_results.py

### DIFF
--- a/ppdet/metrics/json_results.py
+++ b/ppdet/metrics/json_results.py
@@ -25,7 +25,7 @@ def get_det_res(bboxes, bbox_nums, image_id, label_to_cat_id_map, bias=0):
             dt = bboxes[k]
             k = k + 1
             num_id, score, xmin, ymin, xmax, ymax = dt.tolist()
-            if int(num_id) < 0:
+            if int(num_id) < 0 or int(num_id) >= len(label_to_cat_id_map):
                 continue
             category_id = label_to_cat_id_map[int(num_id)]
             w = xmax - xmin + bias
@@ -51,7 +51,7 @@ def get_det_poly_res(bboxes, bbox_nums, image_id, label_to_cat_id_map, bias=0):
             dt = bboxes[k]
             k = k + 1
             num_id, score, x1, y1, x2, y2, x3, y3, x4, y4 = dt.tolist()
-            if int(num_id) < 0:
+            if int(num_id) < 0 or int(num_id) >= len(label_to_cat_id_map):
                 continue
             category_id = label_to_cat_id_map[int(num_id)]
             rbox = [x1, y1, x2, y2, x3, y3, x4, y4]


### PR DESCRIPTION
修改内容：对num_id的取值上限进行检查，避免在进行eval的时候报错

对应的issues：[issue 6553](https://github.com/PaddlePaddle/PaddleDetection/issues/6553); [issue 7938](https://github.com/PaddlePaddle/PaddleDetection/issues/7938); [issue 6524](https://github.com/PaddlePaddle/PaddleDetection/issues/6524); [issue 8272](https://github.com/PaddlePaddle/PaddleDetection/issues/8272)