### PR TITLE
Add nhwc for maskrcnn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ coverage.xml
 dataset/coco/annotations
 dataset/coco/train2017
 dataset/coco/val2017
+dataset/coco/labels
 dataset/voc/VOCdevkit
 dataset/fruit/fruit-detection/
 dataset/voc/test.txt

--- a/configs/mask_rcnn/_base_/mask_rcnn_r50_nhwc.yml
+++ b/configs/mask_rcnn/_base_/mask_rcnn_r50_nhwc.yml
@@ -1,0 +1,98 @@
+architecture: MaskRCNN
+pretrain_weights: https://paddledet.bj.bcebos.com/models/pretrained/ResNet50_cos_pretrained.pdparams
+
+MaskRCNN:
+  backbone: ResNet
+  rpn_head: RPNHead
+  bbox_head: BBoxHead
+  mask_head: MaskHead
+  # post process
+  bbox_post_process: BBoxPostProcess
+  mask_post_process: MaskPostProcess
+  data_format: NHWC
+
+ResNet:
+  # index 0 stands for res2
+  depth: 50
+  norm_type: bn
+  freeze_at: 0
+  return_idx: [2]
+  num_stages: 3
+  data_format: NHWC
+
+RPNHead:
+  anchor_generator:
+    aspect_ratios: [0.5, 1.0, 2.0]
+    anchor_sizes: [32, 64, 128, 256, 512]
+    strides: [16]
+    data_format: NHWC
+  rpn_target_assign:
+    batch_size_per_im: 256
+    fg_fraction: 0.5
+    negative_overlap: 0.3
+    positive_overlap: 0.7
+    use_random: True
+  train_proposal:
+    min_size: 0.0
+    nms_thresh: 0.7
+    pre_nms_top_n: 12000
+    post_nms_top_n: 2000
+    topk_after_collect: False
+  test_proposal:
+    min_size: 0.0
+    nms_thresh: 0.7
+    pre_nms_top_n: 6000
+    post_nms_top_n: 1000
+  data_format: NHWC
+
+
+BBoxHead:
+  head: Res5Head
+  roi_extractor:
+    resolution: 14
+    sampling_ratio: 0
+    aligned: True
+    data_format: NHWC
+  bbox_assigner: BBoxAssigner
+  with_pool: true
+  data_format: NHWC
+  
+Res5Head:
+  data_format: NHWC
+
+BBoxAssigner:
+  batch_size_per_im: 512
+  bg_thresh: 0.5
+  fg_thresh: 0.5
+  fg_fraction: 0.25
+  use_random: True
+
+
+BBoxPostProcess:
+  decode: RCNNBox
+  nms:
+    name: MultiClassNMS
+    keep_top_k: 100
+    score_threshold: 0.05
+    nms_threshold: 0.5
+
+MaskHead:
+  head: MaskFeat
+  roi_extractor:
+    resolution: 14
+    sampling_ratio: 0
+    aligned: True
+  mask_assigner: MaskAssigner
+  share_bbox_feat: true
+  data_format: NHWC
+
+MaskFeat:
+  num_convs: 0
+  out_channel: 256
+  data_format: NHWC
+
+MaskAssigner:
+  mask_resolution: 14
+
+MaskPostProcess:
+  binary_thresh: 0.5

--- a/configs/mask_rcnn/mask_rcnn_r50_1x_coco_nhwc.yml
+++ b/configs/mask_rcnn/mask_rcnn_r50_1x_coco_nhwc.yml
@@ -1,0 +1,10 @@
+# use with FLAGS_cudnn_batchnorm_spatial_persistent=1 to speedup training
+_BASE_: [
+  '../datasets/coco_instance.yml',
+  '../runtime.yml',
+  '_base_/optimizer_1x.yml',
+  '_base_/mask_rcnn_r50_nhwc.yml',
+  '_base_/mask_reader.yml',
+]
+weights: output/mask_rcnn_r50_1x_coco/model_final
+amp: true

--- a/ppdet/modeling/architectures/mask_rcnn.py
+++ b/ppdet/modeling/architectures/mask_rcnn.py
@@ -51,8 +51,9 @@ class MaskRCNN(BaseArch):
                  mask_head,
                  bbox_post_process,
                  mask_post_process,
-                 neck=None):
-        super(MaskRCNN, self).__init__()
+                 neck=None,
+                 data_format="NCHW"):
+        super(MaskRCNN, self).__init__(data_format=data_format)
         self.backbone = backbone
         self.neck = neck
         self.rpn_head = rpn_head

--- a/ppdet/modeling/backbones/resnet.py
+++ b/ppdet/modeling/backbones/resnet.py
@@ -464,7 +464,7 @@ class ResNet(nn.Layer):
                  num_stages=4,
                  std_senet=False,
                  freeze_stem_only=False,
-                 data_format='NHWC'):
+                 data_format='NCHW'):
         """
         Residual Network, see https://arxiv.org/abs/1512.03385
         

--- a/ppdet/modeling/proposal_generator/anchor_generator.py
+++ b/ppdet/modeling/proposal_generator/anchor_generator.py
@@ -51,7 +51,8 @@ class AnchorGenerator(nn.Layer):
                  aspect_ratios=[0.5, 1.0, 2.0],
                  strides=[16.0],
                  variance=[1.0, 1.0, 1.0, 1.0],
-                 offset=0.):
+                 offset=0.,
+                 data_format='NCHW'):
         super(AnchorGenerator, self).__init__()
         self.anchor_sizes = anchor_sizes
         self.aspect_ratios = aspect_ratios
@@ -59,6 +60,7 @@ class AnchorGenerator(nn.Layer):
         self.variance = variance
         self.cell_anchors = self._calculate_anchors(len(strides))
         self.offset = offset
+        self.data_format = data_format
 
     def _broadcast_params(self, params, num_features):
         if not isinstance(params[0], (list, tuple)):  # list[float]
@@ -117,7 +119,14 @@ class AnchorGenerator(nn.Layer):
         return anchors
 
     def forward(self, input):
-        grid_sizes = [paddle.shape(feature_map)[-2:] for feature_map in input]
+        if self.data_format == 'NHWC':
+            start_index = 1
+            end_index = 3
+        else:
+            start_index = 2
+            end_index = 4
+
+        grid_sizes = [paddle.shape(feature_map)[start_index:end_index] for feature_map in input]
         anchors_over_all_feature_maps = self._grid_anchors(grid_sizes)
         return anchors_over_all_feature_maps
 


### PR DESCRIPTION
为 MaskRCNN 添加 nhwc 数据类型输入的支持

运行命令：

```bash
# amp + nhwc
FLAGS_cudnn_batchnorm_spatial_persistent=1 python tools/train.py -c configs/mask_rcnn/mask_rcnn_r50_1x_coco_nhwc.yml -o LearningRate.base_lr=0.0001 log_iter=1 use_gpu=True save_dir=./test_tipc/output/mask_rcnn_r50_1x_coco/benchmark_train/norm_train_gpus_0_autocast_fp32 epoch=1  TrainReader.batch_size=2 amp=True filename=mask_rcnn_r50_1x_coco TrainReader.shuffle=False   --enable_ce=True

# baseline
python tools/train.py -c configs/mask_rcnn/mask_rcnn_r50_1x_coco.yml -o LearningRate.base_lr=0.0001 log_iter=1 use_gpu=True save_dir=./test_tipc/output/mask_rcnn_r50_1x_coco/benchmark_train/norm_train_gpus_0_autocast_fp32 epoch=1 TrainReader.batch_size=2 filename=mask_rcnn_r50_1x_coco TrainReader.shuffle=False   --enable_ce=True
```

相同配置下对比训练精度可得，使用 amp + nhwc 和 Baseline 版本的模型基本不存在精度误差：

![image](https://github.com/PaddlePaddle/PaddleDetection/assets/55493212/aad4dfa5-53e3-4f2f-9253-39cfc7f8d653)


相关Issue:

- https://github.com/PaddlePaddle/Paddle/issues/55907