### PR TITLE
fix rtdetr generate anchor grid out of bound

### DIFF
--- a/ppdet/modeling/transformers/rtdetr_transformer.py
+++ b/ppdet/modeling/transformers/rtdetr_transformer.py
@@ -495,7 +495,7 @@ class RTDETRTransformer(nn.Layer):
                     end=w, dtype=dtype))
             grid_xy = paddle.stack([grid_x, grid_y], -1)
 
-            valid_WH = paddle.to_tensor([h, w]).astype(dtype)
+            valid_WH = paddle.to_tensor([w, h]).astype(dtype)
             grid_xy = (grid_xy.unsqueeze(0) + 0.5) / valid_WH
             wh = paddle.ones_like(grid_xy) * grid_size * (2.0**lvl)
             anchors.append(


### PR DESCRIPTION
rtdetr 在 _generate_anchors函数生成anchor过程中，valid_hw的顺序是[h,w]，与grid_xy的维度顺序不匹配，如果特征图宽高不相等，在导致二者相除之后，生成的结果出现短边越界、长边位置偏小的情况。