### PR TITLE
Update infer_demo.py

### DIFF
--- a/deploy/third_engine/demo_onnxruntime/infer_demo.py
+++ b/deploy/third_engine/demo_onnxruntime/infer_demo.py
@@ -172,6 +172,7 @@ class PicoDet():
 
             srcimg = net.detect(img)
             save_path = str(result_path / img_path.name.replace(".png", ".jpg"))
+            srcimg = cv2.cvtColor(srcimg, cv2.COLOR_RGB2BGR)
             cv2.imwrite(save_path, srcimg)
 
 


### PR DESCRIPTION
修复ONNXRuntime部署示例颜色错误 

Bug组件 Bug Component
Deploy

Bug描述 Describe the Bug
PaddleDetection\deploy\third_engine\demo_onnxruntime\infer_demo.py进行ONNX推理，得到的图片结果颜色错误。原因是在保存图片之前没有将RGB转为OpenCV默认的颜色格式，应该在174与175行之间添加以下代码：srcimg = cv2.cvtColor(srcimg, cv2.COLOR_RGB2BGR)

复现环境 Environment
PaddleDetection2.7