### PR TITLE
[PIR] Fix -1 channel error when inferring PPYOLOFPN in pir mode

### DIFF
--- a/ppdet/modeling/necks/yolo_fpn.py
+++ b/ppdet/modeling/necks/yolo_fpn.py
@@ -26,7 +26,7 @@ __all__ = ['YOLOv3FPN', 'PPYOLOFPN', 'PPYOLOTinyFPN', 'PPYOLOPAN', 'YOLOCSPPAN']
 
 
 def add_coord(x, data_format):
-    b = paddle.shape(x)[0]
+    b = x.shape[0]
     if data_format == 'NCHW':
         h, w = x.shape[2], x.shape[3]
     else:


### PR DESCRIPTION
在 PIR 模式下推理 `PPYOLOFPN` 时，会出现下面的报错：
```
ValueError: (InvalidArgument) The number of input's channels should be equal to filter's channels * groups for Op(Conv). But received: the input's channels is -1, the input's shape is [1, -1, 16, 16]; the filter's channels is 98, the filter's shape is [256, 98, 1, 1]; the groups is 1, the data_format is NCHW. The error may come from wrong data_format setting.
  [Hint: Expected input_channels == filter_dims[1] * groups, but received input_channels:-1 != filter_dims[1] * groups:98.] (at ../paddle/phi/infermeta/binary.cc:587)
```
具体问题定位到了 `add_coord` 函数中的 `paddle.shape` 算子， 由于在 pir 下 `b = paddle.shape(x)[0]` 返回的是一个 Value，而将包含 Value 的 `[b, h, w, 1]` 作为 `expand` 的 shape 参数会导致返回 Value 的 shape 出现 -1：
```
Value(define_op_name=pd_op.expand, index=0, dtype=pd_op.tensor<-1x-1x-1x-1xf32>, stop_gradient=True)
```
因此本次 PR 将 `paddle.shape(x)[0]` 改为了 `x.shape[0]`（`Value.shape` 不是一个 op，返回的是 int 值）