### PR TITLE
Update numpy version to support Python 3.12

### DIFF
--- a/deploy/python/clrnet_postprocess.py
+++ b/deploy/python/clrnet_postprocess.py
@@ -142,7 +142,7 @@ class CLRNetPostProcess(object):
             if start > 0:
                 mask = ((lane_xs[:start] >= 0.) &
                         (lane_xs[:start] <= 1.)).cpu().detach().numpy()[::-1]
-                mask = ~((mask.cumprod()[::-1]).astype(np.bool))
+                mask = ~((mask.cumprod()[::-1]).astype(np.bool_))
                 lane_xs[:start][mask] = -2
             if end < len(self.prior_ys) - 1:
                 lane_xs[end + 1:] = -2

--- a/ppdet/modeling/heads/clrnet_head.py
+++ b/ppdet/modeling/heads/clrnet_head.py
@@ -286,7 +286,7 @@ class CLRHead(nn.Layer):
             if start > 0:
                 mask = ((lane_xs[:start] >= 0.) &
                         (lane_xs[:start] <= 1.)).cpu().detach().numpy()[::-1]
-                mask = ~((mask.cumprod()[::-1]).astype(np.bool))
+                mask = ~((mask.cumprod()[::-1]).astype(np.bool_))
                 lane_xs[:start][mask] = -2
             if end < len(self.prior_ys) - 1:
                 lane_xs[end + 1:] = -2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy < 1.24
+numpy < 2.0
 tqdm
 typeguard
 visualdl>=2.2.0
@@ -13,7 +13,7 @@ setuptools
 Pillow
 
 # for MOT evaluation and inference
-lap
+lapx
 motmetrics
 sklearn==0.0
 


### PR DESCRIPTION
在 Python 3.12 下 `numpy < 1.24` 在安装时就会挂掉，因此修改为 `numpy < 2.0`，替换 `np.bool` 为 `np.bool_`，为新版本已经移除的 alias

此外使用仍在维护的 [lapx](https://github.com/rathaROG/lapx) 替换掉 [lap](https://github.com/gatagat/lap)