### PR TITLE
Fix a tiny bug when converting from VOC to coco

### DIFF
--- a/tools/x2coco.py
+++ b/tools/x2coco.py
@@ -194,7 +194,7 @@ def voc_get_label_anno(ann_dir_path, ann_ids_path, labels_path):
     labels_ids = list(range(1, len(labels_str) + 1))
 
     with open(ann_ids_path, 'r') as f:
-        ann_ids = [lin.strip().split(' ')[-1] for lin in f.readlines()]
+        ann_ids = [lin.strip() for lin in f.readlines()]
 
     ann_paths = []
     for aid in ann_ids:


### PR DESCRIPTION
When there exists **an annotation_id which holds one or more SPACE inside**, it will be incorrectly split and the last segment taken out as an unseen annotation_id. Which leads to the following **FileNotFoundError**
```Start converting !
  3%|█████▏                                                                                                                                               | 2/58 [00:00<00:00, 12464.50it/s]
Traceback (most recent call last):
  File "tools/x2coco.py", line 542, in <module>
    main()
  File "tools/x2coco.py", line 431, in main
    voc_xmls_to_cocojson(
  File "tools/x2coco.py", line 262, in voc_xmls_to_cocojson
    ann_tree = ET.parse(a_path)
  File "/home/pminimd/miniconda3/envs/kfxd/lib/python3.8/xml/etree/ElementTree.py", line 1202, in parse
    tree.parse(source, parser)
  File "/home/pminimd/miniconda3/envs/kfxd/lib/python3.8/xml/etree/ElementTree.py", line 584, in parse
    source = open(source, "rb")
FileNotFoundError: [Errno 2] No such file or directory: '/home/pminimd/dataset/Hand_Det/Annotations/hand```