### PR TITLE
pre copy pinned data to gpu

### DIFF
--- a/ppdet/engine/trainer.py
+++ b/ppdet/engine/trainer.py
@@ -520,14 +520,16 @@ class Trainer(object):
             model.train()
             iter_tic = time.time()
             for step_id, data in enumerate(self.loader):
-                for key, value in data.items():
-                    if isinstance(value, paddle.Tensor):
-                        data[key] = value.cuda(blocking=False)
-                    elif isinstance(value, list):
-                        new_value = []
-                        for t in value:
-                            new_value.append(t.cuda(blocking=False))
-                        data[key] = new_value
+                def deep_pin(blob, blocking):
+                    if isinstance(blob, paddle.Tensor):
+                        return blob.cuda(blocking=blocking)
+                    elif isinstance(blob, dict):
+                        return {k: deep_pin(v, blocking) for k, v in blob.items()}
+                    elif isinstance(blob, (list, tuple)):
+                        return type(blob)([deep_pin(x, blocking) for x in blob])
+                    else:
+                        return blob
+                data = deep_pin(data, False)
 
                 self.status['data_time'].update(time.time() - iter_tic)
                 self.status['step_id'] = step_id

--- a/ppdet/engine/trainer.py
+++ b/ppdet/engine/trainer.py
@@ -523,7 +523,7 @@ class Trainer(object):
                 for key, value in data.items():
                     if isinstance(value, paddle.Tensor):
                         data[key] = value.cuda(blocking=False)
-                    else if isinstance(value, list):
+                    elif isinstance(value, list):
                         new_value = []
                         for t in value:
                             new_value.append(t.cuda(blocking=False))

--- a/ppdet/engine/trainer.py
+++ b/ppdet/engine/trainer.py
@@ -520,6 +520,15 @@ class Trainer(object):
             model.train()
             iter_tic = time.time()
             for step_id, data in enumerate(self.loader):
+                for key, value in data.items():
+                    if isinstance(value, paddle.Tensor):
+                        data[key] = value.cuda(blocking=False)
+                    else if isinstance(value, list):
+                        new_value = []
+                        for t in value:
+                            new_value.append(t.cuda(blocking=False))
+                        data[key] = new_value
+
                 self.status['data_time'].update(time.time() - iter_tic)
                 self.status['step_id'] = step_id
                 profiler.add_profiler_step(profiler_options)


### PR DESCRIPTION
DataLoader产生的Tensor有很多pinned memory的，在模型训练过程中，每使用一次Dataloader的Tensor就会发生一次同步H2D拷贝，造成CPU打断，进而影响性能。
本PR集中、异步将pinned Tensor转到GPU上。