### PR TITLE
dino dataloader use_shared_memory=true

### DIFF
--- a/configs/dino/_base_/dino_reader.yml
+++ b/configs/dino/_base_/dino_reader.yml
@@ -19,7 +19,7 @@ TrainReader:
   shuffle: true
   drop_last: true
   collate_batch: false
-  use_shared_memory: false
+  use_shared_memory: true
 
 
 EvalReader:


### PR DESCRIPTION
use_shared_memory=false，会造成Dataloader线程和主线程竞争GIL锁，进而导致性能下降。