### PR TITLE
refine dataloader

### DIFF
--- a/ppdet/engine/trainer.py
+++ b/ppdet/engine/trainer.py
@@ -529,7 +529,8 @@ class Trainer(object):
                         return type(blob)([deep_pin(x, blocking) for x in blob])
                     else:
                         return blob
-                data = deep_pin(data, False)
+                if paddle.base.core.is_compiled_with_cuda():
+                    data = deep_pin(data, False)
 
                 self.status['data_time'].update(time.time() - iter_tic)
                 self.status['step_id'] = step_id


### PR DESCRIPTION
修复因https://github.com/PaddlePaddle/PaddleDetection/pull/8959 导致的NPU崩溃问题