### PR TITLE
Revert "dino dataloader use_shared_memory=true"

### DIFF
--- a/configs/dino/_base_/dino_reader.yml
+++ b/configs/dino/_base_/dino_reader.yml
@@ -19,7 +19,7 @@ TrainReader:
   shuffle: true
   drop_last: true
   collate_batch: false
-  use_shared_memory: true
+  use_shared_memory: false
 
 
 EvalReader:


### PR DESCRIPTION
Reverts PaddlePaddle/PaddleDetection#8967
该PR导致模型在多卡崩溃，花了一些时间没能定位原因，只能暂时revert掉。