### PR TITLE
fix the bug in export_model

### DIFF
--- a/ppdet/modeling/layers.py
+++ b/ppdet/modeling/layers.py
@@ -740,7 +740,7 @@ class TTFBox(object):
         Select top k scores and decode to get xy coordinates.
         """
         k = self.max_per_img
-        shape_fm = scores.shape
+        shape_fm = paddle.shape(scores)
         shape_fm.stop_gradient = True
         cat, height, width = shape_fm[1], shape_fm[2], shape_fm[3]
         # batch size is 1

--- a/ppdet/modeling/post_process.py
+++ b/ppdet/modeling/post_process.py
@@ -369,7 +369,7 @@ class CenterNetPostProcess(object):
     def _topk(self, scores):
         """ Select top k scores and decode to get xy coordinates. """
         k = self.max_per_img
-        shape_fm = scores.shape
+        shape_fm = paddle.shape(scores)
         shape_fm.stop_gradient = True
         cat, height, width = shape_fm[1], shape_fm[2], shape_fm[3]
         # batch size is 1


### PR DESCRIPTION
fix the bug of tensor.shape in export_model:

![image](https://github.com/user-attachments/assets/ac7869e1-83da-42c1-9c86-8c1da24d51c4)

![image](https://github.com/user-attachments/assets/a3937264-7bf3-4286-92b2-83804e9d1fbc)

paddle.shape():
- Returns a Tensor containing the sizes of each dimension of the scores tensor. This method works in both dynamic and static graph modes, and the return value can be computed dynamically at runtime.