### PR TITLE
Check `reset_norm_param_attr` before access

### DIFF
--- a/ppdet/engine/trainer.py
+++ b/ppdet/engine/trainer.py
@@ -125,7 +125,7 @@ class Trainer(object):
                     m._momentum = 0.97  # 0.03 in pytorch
 
         # reset norm param attr for setting them in optimizer
-        if cfg['reset_norm_param_attr']:
+        if 'reset_norm_param_attr' in cfg and cfg['reset_norm_param_attr']:
             self.model = self.reset_norm_param_attr(
                 self.model, weight_attr=None, bias_attr=None)
 


### PR DESCRIPTION
#9073 合入后导致基本上所有模型都挂掉了，因为并不是所有模型配置都有 `reset_norm_param_attr` 字段，因此访问前加了检查

```
Traceback (most recent call last):
  File "/paddle/jelly/PaddleDetection/tools/train.py", line 209, in <module>
loading annotations into memory...
    main()
Done (t=0.02s)
  File "/paddle/jelly/PaddleDetection/tools/train.py", line 205, in main
creating index...
    run(FLAGS, cfg)
index created!
  File "/paddle/jelly/PaddleDetection/tools/train.py", line 145, in run
[07/30 10:45:19] ppdet.data.source.coco INFO: Load [64 samples valid, 0 samples invalid] in file dataset/coco/annotations/instances_train2017.json.
    trainer = Trainer(cfg, mode='train')
  File "/paddle/jelly/PaddleDetection/ppdet/engine/trainer.py", line 128, in __init__
    if cfg['reset_norm_param_attr']:
KeyError: 'reset_norm_param_attr'
```