### PR TITLE
Add `curr_epoch` to input spec for AST dy2st

### DIFF
--- a/ppdet/engine/export_utils.py
+++ b/ppdet/engine/export_utils.py
@@ -71,6 +71,8 @@ TO_STATIC_SPEC = {
             name='gt_bbox', shape=[-1, 50, 4], dtype='float32'),
         'curr_iter': paddle.static.InputSpec(
             name='curr_iter', shape=[-1], dtype='float32'),
+        'curr_epoch': paddle.static.InputSpec(
+            name='curr_epoch', shape=[-1], dtype='int64'),
         'image': paddle.static.InputSpec(
             name='image', shape=[-1, 3, -1, -1], dtype='float32'),
         'im_shape': paddle.static.InputSpec(
@@ -107,6 +109,8 @@ TO_STATIC_SPEC = {
             name='im_id', shape=[-1, 1], dtype='float32'),
         'curr_iter': paddle.static.InputSpec(
             name='curr_iter', shape=[-1], dtype='float32'),
+        'curr_epoch': paddle.static.InputSpec(
+            name='curr_epoch', shape=[-1], dtype='int64'),
         'image': paddle.static.InputSpec(
             name='image', shape=[-1, 3, -1, -1], dtype='float32'),
         'im_shape': paddle.static.InputSpec(
@@ -155,6 +159,8 @@ TO_STATIC_SPEC = {
             name='gt_bbox', shape=[-1, -1, 4], dtype='float32'),
         'curr_iter': paddle.static.InputSpec(
             name='curr_iter', shape=[-1], dtype='float32'),
+        'curr_epoch': paddle.static.InputSpec(
+            name='curr_epoch', shape=[-1], dtype='int64'),
         'image': paddle.static.InputSpec(
             name='image', shape=[-1, 3, -1, -1], dtype='float32'),
         'im_shape': paddle.static.InputSpec(
@@ -175,6 +181,8 @@ TO_STATIC_SPEC = {
             name='gt_bbox', shape=[-1, -1, 4], dtype='float32'),
         'curr_iter': paddle.static.InputSpec(
             name='curr_iter', shape=[-1], dtype='float32'),
+        'curr_epoch': paddle.static.InputSpec(
+            name='curr_epoch', shape=[-1], dtype='int64'),
         'image': paddle.static.InputSpec(
             name='image', shape=[-1, 3, -1, -1], dtype='float32'),
         'im_shape': paddle.static.InputSpec(


### PR DESCRIPTION
同样是 #9073，因为输入加了 `curr_epoch`，但没在动转静 input spec 里加，导致数据错位进而挂掉
