### PR TITLE
[PIR]Fix bug in pir

### DIFF
--- a/ppdet/engine/export_utils.py
+++ b/ppdet/engine/export_utils.py
@@ -212,10 +212,10 @@ def _prune_input_spec(input_spec, program, targets):
     pruned_input_spec = [{}]
     program = program.clone()
     program = program._prune(targets=targets)
-    global_block = program.global_block()
+    global_scope = paddle.base.global_scope()
     for name, spec in input_spec[0].items():
         try:
-            v = global_block.var(name)
+            v = global_scope.find_var(name)
             pruned_input_spec[0][name] = spec
         except Exception:
             pass

--- a/ppdet/modeling/post_process.py
+++ b/ppdet/modeling/post_process.py
@@ -129,7 +129,8 @@ class BBoxPostProcess(object):
                 else:
                     bboxes_i = bboxes[id_start:id_start + bbox_num[i], :]
                     bbox_num_i = bbox_num[i:i + 1]
-                    id_start += bbox_num[i:i + 1]
+                    # id_start: 0-dim, bbox_num: 1-dim. Use bbox_num[i] instead of bbox_num[i:i+1] in pir.
+                    id_start += bbox_num[i]
                 bboxes_list.append(bboxes_i)
                 bbox_num_list.append(bbox_num_i)
             bboxes = paddle.concat(bboxes_list)
@@ -143,8 +144,11 @@ class BBoxPostProcess(object):
             # scale_factor: scale_y, scale_x
             for i in range(bbox_num.shape[0]):
                 expand_shape = paddle.expand(origin_shape[i:i + 1, :],
-                                             [bbox_num[i:i + 1], 2])
-                scale_y, scale_x = scale_factor[i, 0:1], scale_factor[i, 1:2]
+                                             [bbox_num[i:i + 1], 2])                          
+                scale_y, scale_x = scale_factor[i, 0], scale_factor[i, 1]
+                # TODO(PIR): something wrong with slice op, remove unsqueeze in the future.
+                scale_y = paddle.unsqueeze(scale_y, 0)
+                scale_x = paddle.unsqueeze(scale_x, 0)
                 scale = paddle.concat([scale_x, scale_y, scale_x, scale_y])
                 expand_scale = paddle.expand(scale, [bbox_num[i:i + 1], 4])
                 origin_shape_list.append(expand_shape)

--- a/ppdet/modeling/proposal_generator/rpn_head.py
+++ b/ppdet/modeling/proposal_generator/rpn_head.py
@@ -225,12 +225,18 @@ class RPNHead(nn.Layer):
                     else:
                         topk_rois = rpn_rois
                         topk_prob = rpn_prob
+                        topk_inds = paddle.zeros(shape=[post_nms_top_n], dtype="int64")
                 else:
                     topk_rois = rpn_rois_list[0]
                     topk_prob = rpn_prob_list[0].flatten()
 
                 bs_rois_collect.append(topk_rois)
                 bs_rois_num_collect.append(paddle.shape(topk_rois)[0:1])
+
+                # TODO(PIR): remove this after pir bug fixed
+                rpn_rois_list = None
+                rpn_prob_list = None
+                rpn_rois_num_list = None
 
             bs_rois_num_collect = paddle.concat(bs_rois_num_collect)
 


### PR DESCRIPTION
Fix bug in pir:
PIR下升级了关于0维tensor的定义，因此部分slice操作代码需要修改，保证变量维度一致。
遗留部分TODO暂时绕过pir中的bug，保证模型正常运行，待修复后可以删除。