### PR TITLE
Revised document

### DIFF
--- a/docs/tutorials/QUICK_STARTED.md
+++ b/docs/tutorials/QUICK_STARTED.md
@@ -13,6 +13,8 @@ export CUDA_VISIBLE_DEVICES=0
 ## Inference Demo with Pre-trained Models
 
 ```
+# download the COCO dataset
+python dataset/coco/download_coco.py
 # predict an image using PP-YOLO
 python tools/infer.py -c configs/ppyolo/ppyolo_r50vd_dcn_1x_coco.yml -o use_gpu=true weights=https://paddledet.bj.bcebos.com/models/ppyolo_r50vd_dcn_1x_coco.pdparams --infer_img=demo/000000014439.jpg
 ```

--- a/docs/tutorials/QUICK_STARTED_cn.md
+++ b/docs/tutorials/QUICK_STARTED_cn.md
@@ -10,6 +10,8 @@ export CUDA_VISIBLE_DEVICES=0
 
 ## 一、快速体验
 ```
+# 下载COCO数据集
+python dataset/coco/download_coco.py
 # 用PP-YOLO算法在COCO数据集上预训练模型预测一张图片
 python tools/infer.py -c configs/ppyolo/ppyolo_r50vd_dcn_1x_coco.yml -o use_gpu=true weights=https://paddledet.bj.bcebos.com/models/ppyolo_r50vd_dcn_1x_coco.pdparams --infer_img=demo/000000014439.jpg
 ```


### PR DESCRIPTION
In the original QuickStart documentation, the COCO dataset was included locally by default, but not in the repository, requiring the user to execute download_coco.py to download it on their own. I've added this step to the documentation.