### PR TITLE
Compare `Optional[Tensor]` by using `is None` to avoid introduce control flow in Dy2St

### DIFF
--- a/ppdet/modeling/backbones/cspresnet.py
+++ b/ppdet/modeling/backbones/cspresnet.py
@@ -88,7 +88,7 @@ class RepVggBlock(nn.Layer):
         if hasattr(self, 'conv'):
             y = self.conv(x)
         else:
-            if self.alpha:
+            if self.alpha is not None:
                 y = self.conv1(x) + self.alpha * self.conv2(x)
             else:
                 y = self.conv1(x) + self.conv2(x)
@@ -113,7 +113,7 @@ class RepVggBlock(nn.Layer):
     def get_equivalent_kernel_bias(self):
         kernel3x3, bias3x3 = self._fuse_bn_tensor(self.conv1)
         kernel1x1, bias1x1 = self._fuse_bn_tensor(self.conv2)
-        if self.alpha:
+        if self.alpha is not None:
             return kernel3x3 + self.alpha * self._pad_1x1_to_3x3_tensor(
                 kernel1x1), bias3x3 + self.alpha * bias1x1
         else:


### PR DESCRIPTION
`self.alpha` 类型是稳定的，不会在训练过程中修改，要么一直是 None，要么一直是 Tensor，因此这里不需要控制流，而当前写法会引入控制流，在 SOT 下发生大量打断而降低性能

这里代码中使用的 `if self.alpha` 即便在动态图也是有风险的，一旦 `self.alpha` 是 `Tensor(0)`，那么就会走错分支