### PR TITLE
Fix PP-YOLOE-SEG export bug

### DIFF
--- a/ppdet/engine/trainer.py
+++ b/ppdet/engine/trainer.py
@@ -1276,7 +1276,7 @@ class Trainer(object):
         convert_bn(model)
 
         # add `export_mode` attr for all layers
-        for layer in self.model.sublayers(include_self=True):
+        for layer in model.sublayers(include_self=True):
             layer.export_mode = True
 
         model_name = os.path.splitext(os.path.split(self.cfg.filename)[-1])[0]


### PR DESCRIPTION
Fixed the problem of failure to export the PP-YOLOE-SEG model. The original code set attributes for the wrong object, so it did not take effect.