### PR TITLE
Make LCPAN also pass the activator to DepthwiseSeparable

### DIFF
--- a/ppdet/modeling/necks/lc_pan.py
+++ b/ppdet/modeling/necks/lc_pan.py
@@ -87,7 +87,8 @@ class LCPAN(nn.Layer):
                         num_filters=out_c,
                         dw_size=k,
                         stride=s,
-                        use_se=se)
+                        use_se=se,
+                        act=act)
                     for i, (k, in_c, out_c, s, se) in enumerate(NET_CONFIG[
                         "block1"])
                 ]))
@@ -110,7 +111,8 @@ class LCPAN(nn.Layer):
                         num_filters=out_c,
                         dw_size=k,
                         stride=s,
-                        use_se=se)
+                        use_se=se,
+                        act=act)
                     for i, (k, in_c, out_c, s, se) in enumerate(NET_CONFIG[
                         "block2"])
                 ]))


### PR DESCRIPTION
Without this, nn.Hardswish() will be selected in ConvBNLayer, which causes the opset version to be bumped to 14, in turn, and in my case, breaks ESP-DL ONNX quantization, which only  supports 13.  

I would also suspect that this is more correct also in other cases as one would not be likely to not want to use a specific activation function everywhere, would one supply it.  

Also, it aligns with how the act-parameter is handled in other cases.