### PR TITLE
ensures that the `root_dir` is expanded to the user's home directory

### DIFF
--- a/ppdet/utils/download.py
+++ b/ppdet/utils/download.py
@@ -255,7 +255,7 @@ def map_path(url, root_dir, path_depth=1):
     zip_formats = ['.zip', '.tar', '.gz']
     for zip_format in zip_formats:
         fpath = fpath.replace(zip_format, '')
-    return osp.join(root_dir, fpath)
+    return osp.join(osp.expanduser(root_dir), fpath)
 
 
 def get_path(url, root_dir, md5sum=None, check_exist=True):


### PR DESCRIPTION
This pull request includes a change to the `map_path` function in the `ppdet/utils/download.py` file. The change ensures that the `root_dir` is expanded to the user's home directory before joining it with `fpath`.

* [`ppdet/utils/download.py`](diffhunk://#diff-ca5e1204956f400a927385c53a5ac0b27975c03e54ec50310a0ee24f7bacacd2L258-R258): Modified the `map_path` function to use `osp.expanduser` on `root_dir` before joining it with `fpath`.

fix:

![image](https://github.com/user-attachments/assets/53636c5c-db46-4cc3-86d8-69ed6fd7d1f7)
