### PR TITLE
Add explicit assign to avoid inplace write a view tensor cause inconsistency between dygraph and static graph

### DIFF
--- a/ppdet/modeling/transformers/utils.py
+++ b/ppdet/modeling/transformers/utils.py
@@ -248,8 +248,8 @@ def get_denoising_training_group(targets,
     num_denoising = int(max_gt_num * num_group)
 
     if label_noise_ratio > 0:
-        input_query_class = input_query_class.flatten()
-        pad_gt_mask = pad_gt_mask.flatten()
+        input_query_class = paddle.assign(input_query_class.flatten())
+        pad_gt_mask = paddle.assign(pad_gt_mask.flatten())
         # half of bbox prob, cast mask from bool to float bacause dtype promotaion
         # between bool and float is not supported in static mode.
         mask = paddle.cast(
@@ -356,8 +356,8 @@ def get_contrastive_denoising_training_group(targets,
     num_denoising = int(max_gt_num * 2 * num_group)
 
     if label_noise_ratio > 0:
-        input_query_class = input_query_class.flatten()
-        pad_gt_mask = pad_gt_mask.flatten()
+        input_query_class = paddle.assign(input_query_class.flatten())
+        pad_gt_mask = paddle.assign(pad_gt_mask.flatten())
         # half of bbox prob
         mask = paddle.rand(input_query_class.shape) < (label_noise_ratio * 0.5)
         chosen_idx = paddle.nonzero(mask.cast(pad_gt_mask.dtype) *


### PR DESCRIPTION
动转静最近改动导致转静能力提升后暴露的问题

这里 `input_query_class = input_query_class.flatten()` 是 view 的，接下来，`input_query_class.scatter_(chosen_idx, new_label)` 是有可能对上游的 view 之前的 `input_query_class` 产生修改的，而目前静态图机制是无法将这里的行为对齐的，因此，view 机制会报如下错误，以确保用户知道自己在做什么，用户根据自身需求来决定是否加 assign

```
paddle.jit.sot.utils.exceptions.InnerError: In simulate execution:

    File "/paddle/jelly/PaddleX/paddlex/repo_manager/repos/PaddleDetection/ppdet/modeling/transformers/mask_rtdetr_transformer.py", line 359, in forward
            return out_logits, out_bboxes, out_masks, enc_out, init_out, dn_meta
    ValueError: In transformed code:


    File "/usr/local/lib/python3.10/dist-packages/paddle/jit/sot/symbolic/interpreter.py", line 187, in wrapper
	return interpreter.run_sir(name, state)
    File "/usr/local/lib/python3.10/dist-packages/paddle/jit/sot/symbolic/interpreter.py", line 121, in run_sir
	outs = getattr(self, stmt.type)(stmt, inputs)
    File "/usr/local/lib/python3.10/dist-packages/paddle/jit/sot/symbolic/interpreter.py", line 155, in method
	return getattr(var, stmt.method)(*args[1:], **kwargs)
    File "/usr/local/lib/python3.10/dist-packages/decorator.py", line 232, in fun
	return caller(func, *(extras + args), **kw)
    File "/usr/local/lib/python3.10/dist-packages/paddle/base/wrapped_decorator.py", line 40, in __impl__
	return wrapped_func(*args, **kwargs)
    File "/usr/local/lib/python3.10/dist-packages/paddle/utils/inplace_utils.py", line 75, in __impl__
	raise ValueError(

    ValueError: Sorry about what's happened. In to_static mode, scatter_'s output variable is a viewed Tensor in dygraph. This will result in inconsistent calculation behavior between dynamic and static graphs. You must find the location of the strided API be called, and call paddle.assign() before inplace input.
BreakGraphReasonInfo (breakgraph_reason):
```

这里和 @wanghuancoder 讨论目前还是修改代码，添加 `assign` 来确保动静行为一致，和套件里其他模型使用同样的策略，通过加 assign 来避免产生难以定位的精度问题