### PR TITLE
Use right dtype for 0 size `gt_class` and `is_crowd`

### DIFF
--- a/ppdet/data/transform/operators.py
+++ b/ppdet/data/transform/operators.py
@@ -3165,7 +3165,7 @@ class RandomSizeCrop(BaseOperator):
                     [0, 4], dtype=np.float32)
             sample['gt_class'] = sample['gt_class'][keep_index] if len(
                 keep_index) > 0 else np.zeros(
-                    [0, 1], dtype=np.float32)
+                    [0, 1], dtype=np.int32)
             if 'gt_score' in sample:
                 sample['gt_score'] = sample['gt_score'][keep_index] if len(
                     keep_index) > 0 else np.zeros(
@@ -3173,7 +3173,7 @@ class RandomSizeCrop(BaseOperator):
             if 'is_crowd' in sample:
                 sample['is_crowd'] = sample['is_crowd'][keep_index] if len(
                     keep_index) > 0 else np.zeros(
-                        [0, 1], dtype=np.float32)
+                        [0, 1], dtype=np.int32)
             if 'gt_areas' in sample:
                 sample['gt_areas'] = np.take(
                     sample['gt_areas'], keep_index, axis=0)


### PR DESCRIPTION
目前在遇到 0 size 的 `gt_class` 时候，`RandomSizeCrop` 会使用创建 `float32` 的数据，但是实际上这个数据是 `int32` 的，在和其他数据 concat 的时候就会因为 dtype 检查挂掉，目前还是随机挂，当遇到这种数据的时候才会挂，而且这个问题动态图就会出现，与动转静无关

另外检查了下，这里 `is_crowd` 应该也有一样的问题，顺带修复了