### PR TITLE
Fix `cannot pickle 'Value' object` by removing `inputs`

### DIFF
--- a/ppdet/engine/trainer.py
+++ b/ppdet/engine/trainer.py
@@ -1388,6 +1388,8 @@ class Trainer(object):
             self.model.__delattr__('aux_neck')
         if hasattr(self.model, 'aux_head'):
             self.model.__delattr__('aux_head')
+        if hasattr(self.model, 'inputs'):
+            self.model.__delattr__('inputs')
         self.model.eval()
         model = copy.deepcopy(self.model)
         convert_bn(model)


### PR DESCRIPTION
## Issue Description

Currently, exporting models such as `PicoDet-S` and `PP-YOLOE_plus` fails with a `TypeError` during the deepcopy operation in the export process. The error occurs because the `self.inputs` dictionary contains `paddle.base.libpaddle.pir.Value` objects which cannot be pickled.

```shell
# This is the command to reproduce the problem with paddlex
ENABLE_CINN_IN_DY2ST=0 ENABLE_FALL_BACK=False FLAGS_json_format_model=1 python main.py -c paddlex/configs/modules/object_detection/PicoDet-S.yaml \
-o Global.mode=train \
-o Global.dataset_dir=./dataset/det_coco_examples \
-o Global.output='./output/object_detection/PicoDet-S' \
-o Global.device=gpu:0 \
-o Train.epochs_iters=2 -o Train.dy2st=True
```

## Root Cause

The error occurs in the `export` method of the trainer when attempting to create a deep copy of the model:

```python
    def export(self, output_dir='output_inference', for_fd=False):
        if hasattr(self.model, 'aux_neck'):
            self.model.__delattr__('aux_neck')
        if hasattr(self.model, 'aux_head'):
            self.model.__delattr__('aux_head')
        self.model.eval()
        model = copy.deepcopy(self.model)  # <----------- Error occurs here
        convert_bn(model)
```

During training, the `BaseArch` class stores input values in `self.inputs`, which includes `pir.Value` objects that cannot be serialized by Python's pickle mechanism.

```python
class BaseArch(nn.Layer):
    def forward(self, inputs):
        self.inputs[...] = ...
		...
```

When `deepcopy` attempts to copy these objects during export, it fails with the error:

```
Traceback (most recent call last):
  File "/tmp/PaddleX/paddlex/repo_manager/repos/PaddleDetection/tools/train.py", line 212, in <module>
    main()
  File "/tmp/PaddleX/paddlex/repo_manager/repos/PaddleDetection/tools/train.py", line 208, in main
    run(FLAGS, cfg)
  File "/tmp/PaddleX/paddlex/repo_manager/repos/PaddleDetection/tools/train.py", line 161, in run
    trainer.train(FLAGS.eval)
  File "/tmp/PaddleX/paddlex/repo_manager/repos/PaddleDetection/ppdet/engine/trainer.py", line 665, in train
    self._compose_callback.on_epoch_end(self.status)
  File "/tmp/PaddleX/paddlex/repo_manager/repos/PaddleDetection/ppdet/engine/callbacks.py", line 93, in on_epoch_end
    c.on_epoch_end(status)
  File "/tmp/PaddleX/paddlex/repo_manager/repos/PaddleDetection/ppdet/engine/callbacks.py", line 273, in on_epoch_end
    self.model.export(output_dir=os.path.join(self.save_dir, save_name, "inference"), for_fd=True)
  File "/tmp/PaddleX/paddlex/repo_manager/repos/PaddleDetection/ppdet/engine/trainer.py", line 1392, in export
    model = copy.deepcopy(self.model)
  File "/usr/lib/python3.10/copy.py", line 172, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/lib/python3.10/copy.py", line 271, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib/python3.10/copy.py", line 146, in deepcopy
    y = copier(x, memo)
  File "/usr/lib/python3.10/copy.py", line 231, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib/python3.10/copy.py", line 146, in deepcopy
    y = copier(x, memo)
  File "/usr/lib/python3.10/copy.py", line 231, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib/python3.10/copy.py", line 161, in deepcopy
    rv = reductor(4)
TypeError: cannot pickle 'paddle.base.libpaddle.pir.Value' object
```

## Proposed Solution

Since the `self.inputs` dictionary is not required during the export process, we can safely delete this attribute before performing the deep copy operation. This prevents the pickling error while maintaining all necessary functionality for model export.

The fix involves clearing or deleting the `inputs` attribute from the model before the deep copy operation in the export method.

---

This issue was discovered and resolved in collaboration with @SigureMo .