### PR TITLE
Fix no attribute 'inputs' error when training and exporting

### DIFF
--- a/ppdet/modeling/architectures/meta_arch.py
+++ b/ppdet/modeling/architectures/meta_arch.py
@@ -46,13 +46,9 @@ class BaseArch(nn.Layer):
             image = inputs['image']
             inputs['image'] = paddle.transpose(image, [0, 2, 3, 1])
 
+        self.inputs = inputs
         if self.fuse_norm:
-            image = inputs['image']
-            self.inputs['image'] = image * self.scale + self.bias
-            self.inputs['im_shape'] = inputs['im_shape']
-            self.inputs['scale_factor'] = inputs['scale_factor']
-        else:
-            self.inputs = inputs
+            self.inputs['image'] = inputs['image'] * self.scale + self.bias
 
         self.model_arch()
 
@@ -67,12 +63,9 @@ class BaseArch(nn.Layer):
                 inputs_list.extend(inputs)
             outs = []
             for inp in inputs_list:
+                self.inputs = inp
                 if self.fuse_norm:
-                    self.inputs['image'] = inp['image'] * self.scale + self.bias
-                    self.inputs['im_shape'] = inp['im_shape']
-                    self.inputs['scale_factor'] = inp['scale_factor']
-                else:
-                    self.inputs = inp
+                    self.inputs['image'] = self.inputs['image'] * self.scale + self.bias
                 outs.append(self.get_pred())
 
             # multi-scale test


### PR DESCRIPTION
The previous [PR9365](https://github.com/PaddlePaddle/PaddleDetection/pull/9365) primarily addressed the issue of encountering `pir.Value` cannot be pickled during **AST** single-GPU training.

However, it has also led to the following models (`FCOS-ResNet50`, `PP-YOLOE_plus_SOD-L`, `PP-YOLOE_plus_SOD-S`, and `PP-YOLOE_plus_SOD-largesize-L`) encountering an error with no attribute 'inputs' when performing **SOT** single-GPU training and direct model export.

Commands to reproduce the error (training):

```shell
ENABLE_FALL_BACK=False ENABLE_CINN_IN_DY2ST=0 python main.py -c paddlex/configs/modules/object_detection/FCOS-ResNet50.yaml \
-o Global.mode=train \
-o Global.dataset_dir=./dataset/det_coco_examples \
-o Global.output='./output/object_detection/FCOS-ResNet50' \
-o Global.device=gpu:0 \
-o Train.batch_size=2 \
-o Train.epochs_iters=2 -o Train.dy2st=True

ENABLE_FALL_BACK=False ENABLE_CINN_IN_DY2ST=0 python main.py -c paddlex/configs/modules/small_object_detection/PP-YOLOE_plus_SOD-L.yaml \
-o Global.mode=train \
-o Global.dataset_dir=./dataset/small_det_examples \
-o Global.output='./output/small_object_detection/PP-YOLOE_plus_SOD-L' \
-o Global.device=gpu:0 \
-o Train.epochs_iters=2 -o Train.dy2st=True

ENABLE_FALL_BACK=False ENABLE_CINN_IN_DY2ST=0 python main.py -c paddlex/configs/modules/small_object_detection/PP-YOLOE_plus_SOD-S.yaml \
-o Global.mode=train \
-o Global.dataset_dir=./dataset/small_det_examples \
-o Global.output='./output/small_object_detection/PP-YOLOE_plus_SOD-S' \
-o Global.device=gpu:0 \
-o Train.epochs_iters=2 -o Train.dy2st=True
```

> `ENABLE_FALL_BACK=False` When it is True, it is SOT training, and False is AST training
> `ENABLE_CINN_IN_DY2ST=0` The default is 1, when it is 0, CINN training is disabled

Error traceback:

```python
[05/11 22:43:44] ppdet.utils.checkpoint INFO: Save checkpoint: /PaddleX/output/object_detection/FCOS-ResNet50/0
Traceback (most recent call last):
  File "/PaddleX/paddlex/repo_manager/repos/PaddleDetection/tools/train.py", line 212, in <module>
    main()
  File "/PaddleX/paddlex/repo_manager/repos/PaddleDetection/tools/train.py", line 208, in main
    run(FLAGS, cfg)
  File "/PaddleX/paddlex/repo_manager/repos/PaddleDetection/tools/train.py", line 161, in run
    trainer.train(FLAGS.eval)
  File "/PaddleX/paddlex/repo_manager/repos/PaddleDetection/ppdet/engine/trainer.py", line 665, in train
    self._compose_callback.on_epoch_end(self.status)
  File "/PaddleX/paddlex/repo_manager/repos/PaddleDetection/ppdet/engine/callbacks.py", line 93, in on_epoch_end
    c.on_epoch_end(status)
  File "/PaddleX/paddlex/repo_manager/repos/PaddleDetection/ppdet/engine/callbacks.py", line 273, in on_epoch_end
    self.model.export(output_dir=os.path.join(self.save_dir, save_name, "inference"), for_fd=True)
  File "/PaddleX/paddlex/repo_manager/repos/PaddleDetection/ppdet/engine/trainer.py", line 1413, in export
    static_model, pruned_input_spec, input_spec = self._get_infer_cfg_and_input_spec(
  File "/PaddleX/paddlex/repo_manager/repos/PaddleDetection/ppdet/engine/trainer.py", line 1357, in _get_infer_cfg_and_input_spec
    static_model, pruned_input_spec = self._model_to_static(model, input_spec, prune_input)
  File "/PaddleX/paddlex/repo_manager/repos/PaddleDetection/ppdet/engine/trainer.py", line 1272, in _model_to_static
    input_spec, static_model.forward.main_program,
  File "/usr/local/lib/python3.10/dist-packages/paddle/jit/dy2static/program_translator.py", line 1107, in main_program
    concrete_program = self.concrete_program
  File "/usr/local/lib/python3.10/dist-packages/paddle/jit/dy2static/program_translator.py", line 991, in concrete_program
    return self.concrete_program_specify_input_spec(input_spec=None)
  File "/usr/local/lib/python3.10/dist-packages/paddle/jit/dy2static/program_translator.py", line 1035, in concrete_program_specify_input_spec
    concrete_program, _ = self.get_concrete_program(
  File "/usr/local/lib/python3.10/dist-packages/paddle/jit/dy2static/program_translator.py", line 924, in get_concrete_program
    concrete_program, partial_program_layer = self._program_cache[
  File "/usr/local/lib/python3.10/dist-packages/paddle/jit/dy2static/program_translator.py", line 1708, in __getitem__
    self._caches[item_id] = self._build_once(item)
  File "/usr/local/lib/python3.10/dist-packages/paddle/jit/dy2static/program_translator.py", line 1645, in _build_once
    concrete_program = ConcreteProgram.pir_from_func_spec(
  File "/usr/local/lib/python3.10/dist-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/usr/local/lib/python3.10/dist-packages/paddle/base/wrapped_decorator.py", line 40, in __impl__
    return wrapped_func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/paddle/base/dygraph/base.py", line 101, in __impl__
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/paddle/jit/dy2static/program_translator.py", line 1316, in pir_from_func_spec
    error_data.raise_new_exception()
  File "/usr/local/lib/python3.10/dist-packages/paddle/jit/dy2static/error.py", line 454, in raise_new_exception
    raise new_exception from None
AttributeError: In transformed code:

    File "/PaddleX/paddlex/repo_manager/repos/PaddleDetection/ppdet/modeling/architectures/meta_arch.py", line 49, in forward
	if self.fuse_norm:
    File "/PaddleX/paddlex/repo_manager/repos/PaddleDetection/ppdet/modeling/architectures/meta_arch.py", line 51, in forward
        if self.fuse_norm:
            image = inputs['image']
            self.inputs['image'] = image * self.scale + self.bias
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
            self.inputs['im_shape'] = inputs['im_shape']
            self.inputs['scale_factor'] = inputs['scale_factor']

    File "/usr/local/lib/python3.10/dist-packages/paddle/nn/layer/layers.py", line 1789, in __getattr__
BreakGraphReasonInfo (breakgraph_reason):
	return object.__getattribute__(self, name)

    AttributeError: 'FCOS' object has no attribute 'inputs'
```

Commands to reproduce the error (export):

```shell
python main.py -c paddlex/configs/modules/object_detection/FCOS-ResNet50.yaml -o Global.mode=export
python main.py -c paddlex/configs/modules/small_object_detection/PP-YOLOE_plus_SOD-S.yaml -o Global.mode=export
python main.py -c paddlex/configs/modules/small_object_detection/PP-YOLOE_plus_SOD-L.yaml -o Global.mode=export
python main.py -c paddlex/configs/modules/small_object_detection/PP-YOLOE_plus_SOD-largesize-L.yaml -o Global.mode=export
```

Specifically, during the export process, the issue arises in the following code:

```shell
    def export(self, output_dir='output_inference', for_fd=False):
		...
        if hasattr(self.model, 'inputs'):
            self.model.__delattr__('inputs')
        self.model.eval()
        model = copy.deepcopy(self.model)
		...
        if not os.path.exists(save_dir):
            os.makedirs(save_dir)

		# ------ Exporting the static graph model, which involves running a forward pass ------
        static_model, pruned_input_spec, input_spec = self._get_infer_cfg_and_input_spec(
            save_dir, yaml_name=yaml_name, model=model)
```

The error `no attribute "inputs"` arises because the line `self.model.__delattr__('inputs')` attempts to delete an attribute that might not have been initialized, leading to an attribute access error. 

Therefore, to avoid this issue, we should directly specify `self.inputs = inputs` within the `forward` pass, rather than relying on the initialization of `self.inputs = {}` within the `__init__` method.


---

This issue was discovered and resolved in collaboration with @SigureMo .