### PR TITLE
【Hackathon 8th No.38】在 PaddleDetection 中复现 RT-DETRv3 模型

### DIFF
--- a/configs/rtdetrv3/README.md
+++ b/configs/rtdetrv3/README.md
@@ -1,0 +1,137 @@
+## RT-DETRv3: Real-time End-to-End Object Detection with Hierarchical Dense Positive Supervision
+
+## 简介
+
+RTDETRv3采用了模块化的设计架构，充分继承和发展了RT-DETR系列的优势，最显著的创新点是引入了一对多(One-to-Many, O2M)分支策略，这是本模型的核心设计。该策略允许每个ground truth对象匹配多个预测框，这有助于增强模型对复杂场景和小目标的检测能力。RTDETRv3的另一个重要创新是结合了DETR和YOLO的优势，引入了辅助的PPYOLOEHead来提供额外的监督信号。
+若要了解更多细节，请参考论文[paper](https://arxiv.org/pdf/2409.08475).
+
+## 模型
+
+| Model | Epoch | Backbone  | Input shape | $AP^{val}$ | $AP^{val}_{50}$| Params(M) | FLOPs(G) |  T4 TensorRT FP16(FPS) | Weight | Config | Log
+|:--------------:|:-----:|:----------:| :-------:|:--------------------------:|:---------------------------:|:---------:|:--------:| :---------------------: |:------------------------------------------------------------------------------------:|:-------------------------------------------:|:---|
+| RT-DETRv3-R18 | 6x |  ResNet-18 | 640 | 48.1 | 66.2 | 20 | 60 | 217 | [download](https://bj.bcebos.com/v1/paddledet/models/rtdetrv3_r18vd_6x_coco.pdparams)| [config](./rtdetrv3_r18vd_6x_coco.yml) | 
+| RT-DETRv3-R34 | 6x |  ResNet-34 | 640 | 49.9 | 67.7 | 31 | 92 | 161 | [download](https://bj.bcebos.com/v1/paddledet/models/rtdetrv3_r34vd_6x_coco.pdparams)| [config](./rtdetrv3_r34vd_6x_coco.yml) | 
+| RT-DETRv3-R50 | 6x |  ResNet-50 | 640 | 53.4 | 71.7 | 42 | 136 | 108 | [download](https://bj.bcebos.com/v1/paddledet/models/rtdetrv3_r50vd_6x_coco.pdparams)| [config](./rtdetrv3_r50vd_6x_coco.yml) | 
+
+
+**注意事项:**
+
+- RT-DETRv3模型均使用4个GPU训练。
+- RT-DETRv3在COCO train2017上训练，并在val2017上评估。
+
+## 快速开始
+
+<details open>
+<summary>依赖包:</summary>
+
+- PaddlePaddle >= 2.4.1
+
+</details>
+
+<details>
+<summary>安装</summary>
+
+- [安装指导文档](https://github.com/PaddlePaddle/PaddleDetection/blob/develop/docs/tutorials/INSTALL.md)
+
+</details>
+
+<details>
+<summary>训练&评估</summary>
+
+- 单卡GPU上训练:
+
+```shell
+# training on single-GPU
+export CUDA_VISIBLE_DEVICES=0
+python tools/train.py -c configs/rtdetrv3/rtdetrv3_r18vd_6x_coco.yml --eval
+```
+
+- 多卡GPU上训练:
+
+```shell
+# training on multi-GPU
+export CUDA_VISIBLE_DEVICES=0,1,2,3
+python -m paddle.distributed.launch --gpus 0,1,2,3 tools/train.py -c configs/rtdetrv3/rtdetrv3_r18vd_6x_coco.yml --fleet --eval
+```
+
+- 评估:
+
+```shell
+python tools/eval.py -c configs/rtdetrv3/rtdetrv3_r18vd_6x_coco.yml \
+              -o weights=https://bj.bcebos.com/v1/paddledet/models/rtdetrv3_r18vd_6x_coco.pdparams
+```
+
+- 测试:
+
+```shell
+python tools/infer.py -c configs/rtdetrv3/rtdetrv3_r18vd_6x_coco.yml \
+              -o weights=https://bj.bcebos.com/v1/paddledet/models/rtdetrv3_r18vd_6x_coco.pdparams \
+              --infer_img=./demo/000000570688.jpg
+```
+
+详情请参考[快速开始文档](https://github.com/PaddlePaddle/PaddleDetection/blob/develop/docs/tutorials/GETTING_STARTED.md).
+
+</details>
+
+## 部署
+
+<details open>
+<summary>1. 导出模型 </summary>
+
+```shell
+cd PaddleDetection
+python tools/export_model.py -c configs/rtdetrv3/rtdetrv3_r18vd_6x_coco.yml \
+              -o weights=https://bj.bcebos.com/v1/paddledet/models/rtdetrv3_r18vd_6x_coco.pdparams trt=True \
+              --output_dir=output_inference
+```
+
+</details>
+
+<details>
+<summary>2. 转换模型至ONNX </summary>
+
+- 安装[Paddle2ONNX](https://github.com/PaddlePaddle/Paddle2ONNX) 和 ONNX
+
+```shell
+pip install onnx==1.13.0
+pip install paddle2onnx==1.0.5
+```
+
+- 转换模型:
+
+```shell
+paddle2onnx --model_dir=./output_inference/rtdetrv3_r18vd_6x_coco/ \
+            --model_filename model.pdmodel  \
+            --params_filename model.pdiparams \
+            --opset_version 16 \
+            --save_file rtdetrv3_r18vd_6x_coco.onnx
+```
+
+</details>
+
+<details>
+<summary>3. 转换成TensorRT（可选） </summary>
+
+- 基础模型请确保TensorRT的版本>=8.5.1，离散采样模型支持TensorRT的版本==8.4甚至一些更早的版本
+- TRT推理可以参考[RT-DETR](https://github.com/lyuwenyu/RT-DETR)的部分代码或者其他网络资源
+
+```shell
+trtexec --onnx=./rtdetrv3_r18vd_6x_coco.onnx \
+        --workspace=4096 \
+        --shapes=image:1x3x640x640 \
+        --saveEngine=rtdetrv3_r18vd_6x_coco.trt \
+        --avgRuns=100 \
+        --fp16
+```
+
+</details>
+
+## 引用
+
+```
+@article{wang2024rt,
+  title={RT-DETRv3: Real-time End-to-End Object Detection with Hierarchical Dense Positive Supervision},
+  author={Wang, Shuo and Xia, Chunlong and Lv, Feng and Shi, Yifeng},
+  journal={arXiv preprint arXiv:2409.08475},
+  year={2024}
+}

--- a/configs/rtdetrv3/README.md
+++ b/configs/rtdetrv3/README.md
@@ -7,11 +7,11 @@ RTDETRv3采用了模块化的设计架构，充分继承和发展了RT-DETR系�
 
 ## 模型
 
-| Model | Epoch | Backbone  | Input shape | $AP^{val}$ | $AP^{val}_{50}$| Params(M) | FLOPs(G) |  T4 TensorRT FP16(FPS) | Weight | Config | Log
-|:--------------:|:-----:|:----------:| :-------:|:--------------------------:|:---------------------------:|:---------:|:--------:| :---------------------: |:------------------------------------------------------------------------------------:|:-------------------------------------------:|:---|
-| RT-DETRv3-R18 | 6x |  ResNet-18 | 640 | 48.1 | 66.2 | 20 | 60 | 217 | [download](https://bj.bcebos.com/v1/paddledet/models/rtdetrv3_r18vd_6x_coco.pdparams)| [config](./rtdetrv3_r18vd_6x_coco.yml) | 
-| RT-DETRv3-R34 | 6x |  ResNet-34 | 640 | 49.9 | 67.7 | 31 | 92 | 161 | [download](https://bj.bcebos.com/v1/paddledet/models/rtdetrv3_r34vd_6x_coco.pdparams)| [config](./rtdetrv3_r34vd_6x_coco.yml) | 
-| RT-DETRv3-R50 | 6x |  ResNet-50 | 640 | 53.4 | 71.7 | 42 | 136 | 108 | [download](https://bj.bcebos.com/v1/paddledet/models/rtdetrv3_r50vd_6x_coco.pdparams)| [config](./rtdetrv3_r50vd_6x_coco.yml) | 
+| Model | Epoch | Backbone  | Input shape | $AP^{val}$ | $AP^{val}_{50}$| Params(M) | FLOPs(G) |  T4 TensorRT FP16(FPS) | Weight | Config |
+|:--------------:|:-----:|:----------:|:-------:|:--------------------------:|:---------------------------:|:---------:|:--------:|:---------------------:|:------------------------------------------------------------------------------------:|:-------------------------------------------:|
+| RT-DETRv3-R18 | 6x |  ResNet-18 | 640 | 48.1 | 65.6 | 20 | 60 | 217 | [download](https://paddledet.bj.bcebos.com/models/rtdetrv3_r18vd_6x.pdparams)| [config](./rtdetrv3_r18vd_6x_coco.yml) |
+| RT-DETRv3-R34 | 6x |  ResNet-34 | 640 | 49.9 | 67.7 | 31 | 92 | 161 | [download](https://paddledet.bj.bcebos.com/models/rtdetrv3_r34vd_6x.pdparams)| [config](./rtdetrv3_r34vd_6x_coco.yml) |
+| RT-DETRv3-R50 | 6x |  ResNet-50 | 640 | 52.8 | 71.1 | 42 | 136 | 108 | [download](https://paddledet.bj.bcebos.com/models/rtdetrv3_r50vd_6x.pdparams)| [config](./rtdetrv3_r50vd_6x_coco.yml) |
 
 
 **注意事项:**
@@ -58,14 +58,14 @@ python -m paddle.distributed.launch --gpus 0,1,2,3 tools/train.py -c configs/rtd
 
 ```shell
 python tools/eval.py -c configs/rtdetrv3/rtdetrv3_r18vd_6x_coco.yml \
-              -o weights=https://bj.bcebos.com/v1/paddledet/models/rtdetrv3_r18vd_6x_coco.pdparams
+              -o weights=https://paddledet.bj.bcebos.com/models/rtdetrv3_r18vd_6x.pdparams
 ```
 
 - 测试:
 
 ```shell
 python tools/infer.py -c configs/rtdetrv3/rtdetrv3_r18vd_6x_coco.yml \
-              -o weights=https://bj.bcebos.com/v1/paddledet/models/rtdetrv3_r18vd_6x_coco.pdparams \
+              -o weights=https://paddledet.bj.bcebos.com/models/rtdetrv3_r18vd_6x.pdparams \
               --infer_img=./demo/000000570688.jpg
 ```
 
@@ -81,7 +81,7 @@ python tools/infer.py -c configs/rtdetrv3/rtdetrv3_r18vd_6x_coco.yml \
 ```shell
 cd PaddleDetection
 python tools/export_model.py -c configs/rtdetrv3/rtdetrv3_r18vd_6x_coco.yml \
-              -o weights=https://bj.bcebos.com/v1/paddledet/models/rtdetrv3_r18vd_6x_coco.pdparams trt=True \
+              -o weights=https://paddledet.bj.bcebos.com/models/rtdetrv3_r18vd_6x.pdparams trt=True \
               --output_dir=output_inference
 ```
 

--- a/configs/rtdetrv3/_base_/optimizer_6x.yml
+++ b/configs/rtdetrv3/_base_/optimizer_6x.yml
@@ -1,0 +1,19 @@
+epoch: 72
+
+LearningRate:
+  base_lr: 0.0004
+  schedulers:
+  - !PiecewiseDecay
+    gamma: 1.0
+    milestones: [100]
+    use_warmup: true
+  - !LinearWarmup
+    start_factor: 0.001
+    steps: 2000
+
+OptimizerBuilder:
+  clip_grad_by_norm: 0.1
+  regularizer: false
+  optimizer:
+    type: AdamW
+    weight_decay: 0.0001

--- a/configs/rtdetrv3/_base_/rtdetr_reader.yml
+++ b/configs/rtdetrv3/_base_/rtdetr_reader.yml
@@ -1,0 +1,44 @@
+worker_num: 4
+TrainReader:
+  sample_transforms:
+    - Decode: {}
+    - RandomDistort: {prob: 0.8}
+    - RandomExpand: {fill_value: [123.675, 116.28, 103.53]}
+    - RandomCrop: {prob: 0.8}
+    - RandomFlip: {}
+  batch_transforms:
+    - BatchRandomResize: {target_size: [480, 512, 544, 576, 608, 640, 640, 640, 672, 704, 736, 768, 800], random_size: True, random_interp: True, keep_ratio: False}
+    - NormalizeImage: {mean: [0., 0., 0.], std: [1., 1., 1.], norm_type: none}
+    - NormalizeBox: {retain_origin_box: true}
+    - BboxXYXY2XYWH: {}
+    - Permute: {}
+    - PadGT: {only_origin_box: true}
+  batch_size: 16
+  shuffle: true
+  drop_last: true
+  collate_batch: false
+  use_shared_memory: true
+
+
+EvalReader:
+  sample_transforms:
+    - Decode: {}
+    - Resize: {target_size: [640, 640], keep_ratio: False, interp: 2}
+    - NormalizeImage: {mean: [0., 0., 0.], std: [1., 1., 1.], norm_type: none}
+    - Permute: {}
+  batch_size: 16
+  shuffle: false
+  drop_last: false
+
+
+TestReader:
+  inputs_def:
+    image_shape: [3, 640, 640]
+  sample_transforms:
+    - Decode: {}
+    - Resize: {target_size: [640, 640], keep_ratio: False, interp: 2}
+    - NormalizeImage: {mean: [0., 0., 0.], std: [1., 1., 1.], norm_type: none}
+    - Permute: {}
+  batch_size: 1
+  shuffle: false
+  drop_last: false

--- a/configs/rtdetrv3/_base_/rtdetrv3_r50vd.yml
+++ b/configs/rtdetrv3/_base_/rtdetrv3_r50vd.yml
@@ -1,0 +1,99 @@
+architecture: DETR
+pretrain_weights: https://paddledet.bj.bcebos.com/models/pretrained/ResNet50_vd_ssld_v2_pretrained.pdparams
+norm_type: sync_bn
+use_ema: True
+ema_decay: 0.9999
+ema_decay_type: "exponential"
+ema_filter_no_grad: True
+hidden_dim: 256
+use_focal_loss: True
+eval_size: [640, 640]
+
+
+DETR:
+  backbone: ResNet
+  neck: HybridEncoder
+  transformer: RTDETRTransformerv3
+  detr_head: RTDETRv3Head
+  aux_o2m_head: PPYOLOEHead
+  post_process: DETRPostProcess
+
+ResNet:
+  # index 0 stands for res2
+  depth: 50
+  variant: d
+  norm_type: bn
+  freeze_at: 0
+  return_idx: [1, 2, 3]
+  lr_mult_list: [0.1, 0.1, 0.1, 0.1]
+  num_stages: 4
+  freeze_stem_only: True
+
+HybridEncoder:
+  hidden_dim: 256
+  use_encoder_idx: [2]
+  num_encoder_layers: 1
+  encoder_layer:
+    name: TransformerLayer
+    d_model: 256
+    nhead: 8
+    dim_feedforward: 1024
+    dropout: 0.
+    activation: 'gelu'
+  expansion: 1.0
+
+
+RTDETRTransformerv3:
+  num_queries: 300
+  position_embed_type: sine
+  feat_strides: [8, 16, 32]
+  num_levels: 3
+  nhead: 8
+  num_decoder_layers: 6
+  dim_feedforward: 1024
+  dropout: 0.0
+  activation: relu
+  num_denoising: 100
+  label_noise_ratio: 0.5
+  box_noise_scale: 1.0
+  learnt_init_query: False
+  num_noises: 0
+  num_noise_queries: []
+  num_noise_denoising: 100
+
+
+RTDETRv3Head:
+  o2m: 4
+  loss:
+    name: RTDETRv3Loss
+    loss_coeff: {class: 1, bbox: 5, giou: 2}
+    aux_loss: True
+    use_vfl: True
+    matcher:
+      name: HungarianMatcher
+      matcher_coeff: {class: 2, bbox: 5, giou: 2}
+
+PPYOLOEHead:
+  fpn_strides: [8, 16, 32]
+  grid_cell_scale: 5.0
+  grid_cell_offset: 0.5
+  static_assigner_epoch: 30
+  use_varifocal_loss: True
+  loss_weight: {class: 1.0, iou: 2.5, dfl: 0.5}
+  static_assigner:
+    name: ATSSAssigner
+    topk: 9
+  assigner:
+    name: TaskAlignedAssigner
+    topk: 13
+    alpha: 1.0
+    beta: 6.0
+  nms:
+    name: MultiClassNMS
+    nms_top_k: 1000
+    keep_top_k: 300
+    score_threshold: 0.01
+    nms_threshold: 0.7
+
+DETRPostProcess:
+  num_top_queries: 300

--- a/configs/rtdetrv3/rtdetrv3_r18vd_6x_coco.yml
+++ b/configs/rtdetrv3/rtdetrv3_r18vd_6x_coco.yml
@@ -1,0 +1,43 @@
+_BASE_: [
+  '../datasets/coco_detection.yml',
+  '../runtime.yml',
+  '_base_/optimizer_6x.yml',
+  '_base_/rtdetrv3_r50vd.yml',
+  '_base_/rtdetr_reader.yml',
+]
+
+weights: output/rtdetrv3_r18vd_6x_coco/model_final
+find_unused_parameters: True
+log_iter: 200
+
+o2m_branch: True
+num_queries_o2m: 450
+
+pretrain_weights: https://paddledet.bj.bcebos.com/models/pretrained/ResNet18_vd_pretrained.pdparams
+ResNet:
+  depth: 18
+  variant: d
+  return_idx: [1, 2, 3]
+  freeze_at: -1
+  freeze_norm: false
+  norm_decay: 0.
+
+HybridEncoder:
+  hidden_dim: 256
+  use_encoder_idx: [2]
+  num_encoder_layers: 1
+  encoder_layer:
+    name: TransformerLayer
+    d_model: 256
+    nhead: 8
+    dim_feedforward: 1024
+    dropout: 0.
+    activation: 'gelu'
+  expansion: 0.5
+  depth_mult: 1.0
+
+RTDETRTransformerv3:
+  eval_idx: -1
+  num_decoder_layers: 3
+  num_noises: 3
+  num_noise_queries: [300, 300, 300]

--- a/configs/rtdetrv3/rtdetrv3_r34vd_6x_coco.yml
+++ b/configs/rtdetrv3/rtdetrv3_r34vd_6x_coco.yml
@@ -1,0 +1,43 @@
+_BASE_: [
+  '../datasets/coco_detection.yml',
+  '../runtime.yml',
+  '_base_/optimizer_6x.yml',
+  '_base_/rtdetrv3_r50vd.yml',
+  '_base_/rtdetr_reader.yml',
+]
+
+weights: output/rtdetrv3_r34vd_6x_coco/model_final
+find_unused_parameters: True
+log_iter: 200
+
+o2m_branch: True
+num_queries_o2m: 450
+
+pretrain_weights: https://bj.bcebos.com/v1/paddledet/models/pretrained/ResNet34_vd_pretrained.pdparams
+ResNet:
+  depth: 34
+  variant: d
+  return_idx: [1, 2, 3]
+  freeze_at: -1
+  freeze_norm: false
+  norm_decay: 0.
+
+HybridEncoder:
+  hidden_dim: 256
+  use_encoder_idx: [2]
+  num_encoder_layers: 1
+  encoder_layer:
+    name: TransformerLayer
+    d_model: 256
+    nhead: 8
+    dim_feedforward: 1024
+    dropout: 0.
+    activation: 'gelu'
+  expansion: 0.5
+  depth_mult: 1.0
+
+RTDETRTransformerv3:
+  eval_idx: -1
+  num_decoder_layers: 4
+  num_noises: 3
+  num_noise_queries: [300, 300, 300]

--- a/configs/rtdetrv3/rtdetrv3_r50vd_6x_coco.yml
+++ b/configs/rtdetrv3/rtdetrv3_r50vd_6x_coco.yml
@@ -1,0 +1,20 @@
+_BASE_: [
+  '../datasets/coco_detection.yml',
+  '../runtime.yml',
+  '_base_/optimizer_6x.yml',
+  '_base_/rtdetrv3_r50vd.yml',
+  '_base_/rtdetr_reader.yml',
+]
+
+weights: output/rtdetrv3_r50vd_6x_coco/model_final
+find_unused_parameters: True
+log_iter: 200
+
+o2m_branch: True
+num_queries_o2m: 450
+
+RTDETRTransformerv3:
+  eval_idx: -1
+  num_decoder_layers: 6
+  num_noises: 2
+  num_noise_queries: [300, 300]

--- a/ppdet/data/reader.py
+++ b/ppdet/data/reader.py
@@ -124,6 +124,8 @@ class BatchCompose(Compose):
                     tmp_data.append(data[i][k])
                 if not 'gt_' in k and not 'is_crowd' in k and not 'difficult' in k:
                     tmp_data = np.stack(tmp_data, axis=0)
+                if 'origin_' in k:
+                    tmp_data = np.stack(tmp_data, axis=0)
                 batch_data[k] = tmp_data
         return batch_data
 

--- a/ppdet/data/transform/batch_operators.py
+++ b/ppdet/data/transform/batch_operators.py
@@ -1093,11 +1093,12 @@ class PadGT(BaseOperator):
                                 1 means bbox, 0 means no bbox.
     """
 
-    def __init__(self, return_gt_mask=True, pad_img=False, minimum_gtnum=0):
+    def __init__(self, return_gt_mask=True, pad_img=False, minimum_gtnum=0, only_origin_box=False):
         super(PadGT, self).__init__()
         self.return_gt_mask = return_gt_mask
         self.pad_img = pad_img
         self.minimum_gtnum = minimum_gtnum
+        self.only_origin_box = only_origin_box
 
     def _impad(self,
                img: np.ndarray,
@@ -1198,64 +1199,87 @@ class PadGT(BaseOperator):
         num_max_boxes = max(self.minimum_gtnum, num_max_boxes)
         if self.pad_img:
             maxshape = self.checkmaxshape(samples)
-        for sample in samples:
-            if self.pad_img:
-                img = sample['image']
-                padimg = self._impad(img, shape=maxshape)
-                sample['image'] = padimg
-            if self.return_gt_mask:
-                sample['pad_gt_mask'] = np.zeros(
-                    (num_max_boxes, 1), dtype=np.float32)
-            if num_max_boxes == 0:
-                continue
 
-            num_gt = len(sample['gt_bbox'])
-            pad_gt_class = np.zeros((num_max_boxes, 1), dtype=np.int32)
-            pad_gt_bbox = np.zeros((num_max_boxes, 4), dtype=np.float32)
-            if num_gt > 0:
-                pad_gt_class[:num_gt] = sample['gt_class']
-                pad_gt_bbox[:num_gt] = sample['gt_bbox']
-            sample['gt_class'] = pad_gt_class
-            sample['gt_bbox'] = pad_gt_bbox
-            # pad_gt_mask
-            if 'pad_gt_mask' in sample:
-                sample['pad_gt_mask'][:num_gt] = 1
-            # gt_score
-            if 'gt_score' in sample:
-                pad_gt_score = np.zeros((num_max_boxes, 1), dtype=np.float32)
+        if self.only_origin_box:
+            for sample in samples:
+                if self.pad_img:
+                    img = sample['image']
+                    padimg = self._impad(img, shape=maxshape)
+                    sample['image'] = padimg
+                if self.return_gt_mask:
+                    sample['pad_origin_gt_mask'] = np.zeros(
+                        (num_max_boxes, 1), dtype=np.float32)
+                if num_max_boxes == 0:
+                    continue
+                num_gt = len(sample['origin_gt_bbox'])
+                pad_origin_gt_class = np.zeros((num_max_boxes, 1), dtype=np.int32)
+                pad_origin_gt_bbox = np.zeros((num_max_boxes, 4), dtype=np.float32)
                 if num_gt > 0:
-                    pad_gt_score[:num_gt] = sample['gt_score']
-                sample['gt_score'] = pad_gt_score
-            if 'is_crowd' in sample:
-                pad_is_crowd = np.zeros((num_max_boxes, 1), dtype=np.int32)
+                    pad_origin_gt_class[:num_gt] = sample['origin_gt_class']
+                    pad_origin_gt_bbox[:num_gt] = sample['origin_gt_bbox']
+                sample['origin_gt_class'] = pad_origin_gt_class
+                sample['origin_gt_bbox'] = pad_origin_gt_bbox
+                if 'pad_origin_gt_mask' in sample:
+                    sample['pad_origin_gt_mask'][:num_gt] = 1
+        else:
+            for sample in samples:
+                if self.pad_img:
+                    img = sample['image']
+                    padimg = self._impad(img, shape=maxshape)
+                    sample['image'] = padimg
+                if self.return_gt_mask:
+                    sample['pad_gt_mask'] = np.zeros(
+                        (num_max_boxes, 1), dtype=np.float32)
+                if num_max_boxes == 0:
+                    continue
+
+                num_gt = len(sample['gt_bbox'])
+                pad_gt_class = np.zeros((num_max_boxes, 1), dtype=np.int32)
+                pad_gt_bbox = np.zeros((num_max_boxes, 4), dtype=np.float32)
                 if num_gt > 0:
-                    pad_is_crowd[:num_gt] = sample['is_crowd']
-                sample['is_crowd'] = pad_is_crowd
-            if 'difficult' in sample:
-                pad_diff = np.zeros((num_max_boxes, 1), dtype=np.int32)
-                if num_gt > 0:
-                    pad_diff[:num_gt] = sample['difficult']
-                sample['difficult'] = pad_diff
-            if 'gt_joints' in sample:
-                num_joints = sample['gt_joints'].shape[1]
-                pad_gt_joints = np.zeros(
-                    (num_max_boxes, num_joints, 3), dtype=np.float32)
-                if num_gt > 0:
-                    pad_gt_joints[:num_gt] = sample['gt_joints']
-                sample['gt_joints'] = pad_gt_joints
-            if 'gt_areas' in sample:
-                pad_gt_areas = np.zeros((num_max_boxes, 1), dtype=np.float32)
-                if num_gt > 0:
-                    pad_gt_areas[:num_gt, 0] = sample['gt_areas']
-                sample['gt_areas'] = pad_gt_areas
-            # gt_segm
-            if 'gt_segm' in sample:
-                pad_gt_segm = np.zeros(
-                    (num_max_boxes, *sample['gt_segm'].shape[-2:]),
-                    dtype=np.uint8)
-                if num_gt > 0:
-                    pad_gt_segm[:num_gt] = sample['gt_segm']
-                sample['gt_segm'] = pad_gt_segm.astype(np.float32)
+                    pad_gt_class[:num_gt] = sample['gt_class']
+                    pad_gt_bbox[:num_gt] = sample['gt_bbox']
+                sample['gt_class'] = pad_gt_class
+                sample['gt_bbox'] = pad_gt_bbox
+                # pad_gt_mask
+                if 'pad_gt_mask' in sample:
+                    sample['pad_gt_mask'][:num_gt] = 1
+                # gt_score
+                if 'gt_score' in sample:
+                    pad_gt_score = np.zeros((num_max_boxes, 1), dtype=np.float32)
+                    if num_gt > 0:
+                        pad_gt_score[:num_gt] = sample['gt_score']
+                    sample['gt_score'] = pad_gt_score
+                if 'is_crowd' in sample:
+                    pad_is_crowd = np.zeros((num_max_boxes, 1), dtype=np.int32)
+                    if num_gt > 0:
+                        pad_is_crowd[:num_gt] = sample['is_crowd']
+                    sample['is_crowd'] = pad_is_crowd
+                if 'difficult' in sample:
+                    pad_diff = np.zeros((num_max_boxes, 1), dtype=np.int32)
+                    if num_gt > 0:
+                        pad_diff[:num_gt] = sample['difficult']
+                    sample['difficult'] = pad_diff
+                if 'gt_joints' in sample:
+                    num_joints = sample['gt_joints'].shape[1]
+                    pad_gt_joints = np.zeros(
+                        (num_max_boxes, num_joints, 3), dtype=np.float32)
+                    if num_gt > 0:
+                        pad_gt_joints[:num_gt] = sample['gt_joints']
+                    sample['gt_joints'] = pad_gt_joints
+                if 'gt_areas' in sample:
+                    pad_gt_areas = np.zeros((num_max_boxes, 1), dtype=np.float32)
+                    if num_gt > 0:
+                        pad_gt_areas[:num_gt, 0] = sample['gt_areas']
+                    sample['gt_areas'] = pad_gt_areas
+                # gt_segm
+                if 'gt_segm' in sample:
+                    pad_gt_segm = np.zeros(
+                        (num_max_boxes, *sample['gt_segm'].shape[-2:]),
+                        dtype=np.uint8)
+                    if num_gt > 0:
+                        pad_gt_segm[:num_gt] = sample['gt_segm']
+                    sample['gt_segm'] = pad_gt_segm.astype(np.float32)
         return samples
 
 

--- a/ppdet/data/transform/operators.py
+++ b/ppdet/data/transform/operators.py
@@ -2087,12 +2087,17 @@ class Mixup(BaseOperator):
 class NormalizeBox(BaseOperator):
     """Transform the bounding box's coornidates to [0,1]."""
 
-    def __init__(self):
+    def __init__(self, retain_origin_box=False):
         super(NormalizeBox, self).__init__()
+        self.retain_origin_box = retain_origin_box
 
     def apply(self, sample, context):
         im = sample['image']
         if 'gt_bbox' in sample.keys():
+            if self.retain_origin_box:
+                sample['origin_gt_bbox'] = sample['gt_bbox'].copy()
+                sample['origin_gt_class'] = sample['gt_class'].copy()
+
             gt_bbox = sample['gt_bbox']
             height, width, _ = im.shape
             for i in range(gt_bbox.shape[0]):

--- a/ppdet/modeling/architectures/detr.py
+++ b/ppdet/modeling/architectures/detr.py
@@ -35,6 +35,7 @@ class DETR(BaseArch):
                  transformer='DETRTransformer',
                  detr_head='DETRHead',
                  neck=None,
+                 aux_o2m_head=None,
                  post_process='DETRPostProcess',
                  post_process_semi=None,
                  with_mask=False,
@@ -44,6 +45,7 @@ class DETR(BaseArch):
         self.transformer = transformer
         self.detr_head = detr_head
         self.neck = neck
+        self.aux_o2m_head = aux_o2m_head
         self.post_process = post_process
         self.with_mask = with_mask
         self.exclude_post_process = exclude_post_process
@@ -69,11 +71,16 @@ class DETR(BaseArch):
         }
         detr_head = create(cfg['detr_head'], **kwargs)
 
+        if 'aux_o2m_head' in cfg:
+            kwargs = {'input_shape': neck.out_shape}
+            aux_o2m_head = create(cfg['aux_o2m_head'], **kwargs)
+
         return {
             'backbone': backbone,
             'transformer': transformer,
             "detr_head": detr_head,
-            "neck": neck
+            "neck": neck,
+            "aux_o2m_head": aux_o2m_head
         }
 
     def _forward(self):
@@ -96,6 +103,13 @@ class DETR(BaseArch):
                 'loss': paddle.add_n(
                     [v for k, v in detr_losses.items() if 'log' not in k])
             })
+            if self.aux_o2m_head is not None:
+                aux_o2m_losses = self.aux_o2m_head(body_feats, self.inputs)
+                for k, v in aux_o2m_losses.items():
+                    if k == 'loss':
+                        detr_losses[k] += v
+                    k = k + '_aux_o2m'
+                    detr_losses[k] = v
             return detr_losses
         else:
             preds = self.detr_head(out_transformer, body_feats)

--- a/ppdet/modeling/architectures/detr.py
+++ b/ppdet/modeling/architectures/detr.py
@@ -71,6 +71,7 @@ class DETR(BaseArch):
         }
         detr_head = create(cfg['detr_head'], **kwargs)
 
+        aux_o2m_head = None
         if 'aux_o2m_head' in cfg:
             kwargs = {'input_shape': neck.out_shape}
             aux_o2m_head = create(cfg['aux_o2m_head'], **kwargs)

--- a/ppdet/modeling/backbones/resnet.py
+++ b/ppdet/modeling/backbones/resnet.py
@@ -18,6 +18,7 @@ from numbers import Integral
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
+from paddle.distributed.fleet.utils import recompute
 from ppdet.core.workspace import register, serializable
 from paddle.regularizer import L2Decay
 from paddle.nn.initializer import Uniform
@@ -391,8 +392,10 @@ class Blocks(nn.Layer):
                  norm_decay=0.,
                  freeze_norm=True,
                  dcn_v2=False,
-                 std_senet=False):
+                 std_senet=False,
+                 with_cp=False):
         super(Blocks, self).__init__()
+        self.with_cp = with_cp
 
         self.blocks = []
         for i in range(count):
@@ -420,7 +423,10 @@ class Blocks(nn.Layer):
     def forward(self, inputs):
         block_out = inputs
         for block in self.blocks:
-            block_out = block(block_out)
+            if self.training and self.with_cp:
+                block_out = recompute(block, block_out)
+            else:
+                block_out = block(block_out)
         return block_out
 
 
@@ -444,7 +450,8 @@ class ResNet(nn.Layer):
                  dcn_v2_stages=[-1],
                  num_stages=4,
                  std_senet=False,
-                 freeze_stem_only=False):
+                 freeze_stem_only=False,
+                 with_cp=False):
         """
         Residual Network, see https://arxiv.org/abs/1512.03385
         
@@ -553,7 +560,8 @@ class ResNet(nn.Layer):
                     norm_decay=norm_decay,
                     freeze_norm=freeze_norm,
                     dcn_v2=(i in self.dcn_v2_stages),
-                    std_senet=std_senet))
+                    std_senet=std_senet,
+                    with_cp=with_cp))
             self.res_layers.append(res_layer)
             self.ch_in = self._out_channels[i]
 

--- a/ppdet/modeling/heads/detr_head.py
+++ b/ppdet/modeling/heads/detr_head.py
@@ -24,7 +24,7 @@ import pycocotools.mask as mask_util
 from ..initializer import linear_init_, constant_
 from ..transformers.utils import inverse_sigmoid
 
-__all__ = ['DETRHead', 'DeformableDETRHead', 'DINOHead', 'MaskDINOHead']
+__all__ = ['DETRHead', 'DeformableDETRHead', 'DINOHead', 'MaskDINOHead', 'RTDETRv3Head']
 
 
 class MLP(nn.Layer):
@@ -537,3 +537,108 @@ class MaskDINOHead(nn.Layer):
                 dn_meta=dn_meta)
         else:
             return (dec_out_bboxes[-1], dec_out_logits[-1], dec_out_masks[-1])
+
+@register
+class RTDETRv3Head(nn.Layer):
+    __inject__ = ['loss']
+    __shared__ = ['o2m_branch', 'num_queries_o2m']
+
+    def __init__(self, loss='DINOLoss', eval_idx=-1, o2m=4, o2m_branch=False, num_queries_o2m=450):
+        super(RTDETRv3Head, self).__init__()
+        self.loss = loss
+        self.eval_idx = eval_idx
+        self.o2m = o2m
+        self.o2m_branch = o2m_branch
+        self.num_queries_o2m = num_queries_o2m
+
+    def forward(self, out_transformer, body_feats, inputs=None):
+        (dec_out_bboxes, dec_out_logits, enc_topk_bboxes, enc_topk_logits,
+         dn_meta) = out_transformer
+        if self.training:
+            assert inputs is not None
+            assert 'gt_bbox' in inputs and 'gt_class' in inputs
+
+            if dn_meta is not None:
+                num_groups = len(dn_meta)
+                total_dec_queries = dec_out_bboxes.shape[2]
+                total_enc_queries = enc_topk_bboxes.shape[1]
+                loss = {}
+                if self.o2m_branch:
+                    dec_out_bboxes, dec_out_bboxes_o2m = paddle.split(dec_out_bboxes, [total_dec_queries - self.num_queries_o2m, self.num_queries_o2m], axis=2)
+                    dec_out_logits, dec_out_logits_o2m = paddle.split(dec_out_logits, [total_dec_queries - self.num_queries_o2m, self.num_queries_o2m], axis=2)
+                    enc_topk_bboxes, enc_topk_bboxes_o2m = paddle.split(enc_topk_bboxes, [total_enc_queries - self.num_queries_o2m, self.num_queries_o2m], axis=1)
+                    enc_topk_logits, enc_topk_logits_o2m = paddle.split(enc_topk_logits, [total_enc_queries - self.num_queries_o2m, self.num_queries_o2m], axis=1)
+
+                    out_bboxes_o2m = paddle.concat([enc_topk_bboxes_o2m.unsqueeze(0), dec_out_bboxes_o2m])
+                    out_logits_o2m = paddle.concat([enc_topk_logits_o2m.unsqueeze(0), dec_out_logits_o2m])
+                    loss_o2m = self.loss(
+                        out_bboxes_o2m,
+                        out_logits_o2m,
+                        inputs['gt_bbox'],
+                        inputs['gt_class'],
+                        dn_out_bboxes=None,
+                        dn_out_logits=None,
+                        dn_meta=None,
+                        o2m=self.o2m)
+                    for key, value in loss_o2m.items():
+                        key = key + '_o2m_branch'
+                        loss.update({
+                            key: loss.get(key, paddle.zeros([1])) + value
+                        })
+                
+                split_dec_num = [sum(dn['dn_num_split']) for dn in dn_meta]
+                split_enc_num = [dn['dn_num_split'][1] for dn in dn_meta]
+                dec_out_bboxes = paddle.split(dec_out_bboxes, split_dec_num, axis=2)
+                dec_out_logits = paddle.split(dec_out_logits, split_dec_num, axis=2)
+                enc_topk_bboxes = paddle.split(enc_topk_bboxes, split_enc_num, axis=1)
+                enc_topk_logits = paddle.split(enc_topk_logits, split_enc_num, axis=1)
+
+                for g_id in range(num_groups):
+                    dn_out_bboxes_gid, dec_out_bboxes_gid = paddle.split(
+                        dec_out_bboxes[g_id], dn_meta[g_id]['dn_num_split'], axis=2)
+                    dn_out_logits_gid, dec_out_logits_gid = paddle.split(
+                        dec_out_logits[g_id], dn_meta[g_id]['dn_num_split'], axis=2)
+                    out_bboxes_gid = paddle.concat([
+                        enc_topk_bboxes[g_id].unsqueeze(0), dec_out_bboxes_gid])
+                    out_logits_gid = paddle.concat([
+                        enc_topk_logits[g_id].unsqueeze(0), dec_out_logits_gid])
+                    
+                    loss_gid = self.loss(
+                        out_bboxes_gid,
+                        out_logits_gid,
+                        inputs['gt_bbox'],
+                        inputs['gt_class'],
+                        dn_out_bboxes=dn_out_bboxes_gid,
+                        dn_out_logits=dn_out_logits_gid,
+                        dn_meta=dn_meta[g_id])
+                    # sum loss
+                    for key, value in loss_gid.items():
+                        loss.update({
+                            key: loss.get(key, paddle.zeros([1])) + value
+                        })
+
+                # average across (dual_groups + 1)
+                for key, value in loss.items():
+                    if '_o2m_branch' not in key:
+                        loss.update({key: value / num_groups})
+                return loss
+            else:
+                dn_out_bboxes, dn_out_logits = None, None
+
+            out_bboxes = paddle.concat(
+                [enc_topk_bboxes.unsqueeze(0), dec_out_bboxes])
+            out_logits = paddle.concat(
+                [enc_topk_logits.unsqueeze(0), dec_out_logits])
+
+            return self.loss(
+                out_bboxes,
+                out_logits,
+                inputs['gt_bbox'],
+                inputs['gt_class'],
+                dn_out_bboxes=dn_out_bboxes,
+                dn_out_logits=dn_out_logits,
+                dn_meta=dn_meta,
+                gt_score=inputs.get('gt_score', None))
+        else:
+            return (dec_out_bboxes[self.eval_idx],
+                    dec_out_logits[self.eval_idx], None)

--- a/ppdet/modeling/heads/ppyoloe_head.py
+++ b/ppdet/modeling/heads/ppyoloe_head.py
@@ -397,9 +397,14 @@ class PPYOLOEHead(nn.Layer):
             pred_scores_aux = aux_pred[0]
             pred_bboxes_aux = self._bbox_decode(anchor_points_s, aux_pred[1])
 
-        gt_labels = gt_meta['gt_class']
-        gt_bboxes = gt_meta['gt_bbox']
-        pad_gt_mask = gt_meta['pad_gt_mask']
+        if 'origin_gt_class' in gt_meta:  # for RTDETRv3
+            gt_labels = gt_meta['origin_gt_class']
+            gt_bboxes = gt_meta['origin_gt_bbox']
+            pad_gt_mask = gt_meta['pad_origin_gt_mask']
+        else:
+            gt_labels = gt_meta['gt_class']
+            gt_bboxes = gt_meta['gt_bbox']
+            pad_gt_mask = gt_meta['pad_gt_mask']
         # label assignment
         if gt_meta['epoch_id'] < self.static_assigner_epoch:
             assigned_labels, assigned_bboxes, assigned_scores = \

--- a/ppdet/modeling/losses/detr_loss.py
+++ b/ppdet/modeling/losses/detr_loss.py
@@ -24,7 +24,7 @@ from .iou_loss import GIoULoss
 from ..transformers import bbox_cxcywh_to_xyxy, sigmoid_focal_loss, varifocal_loss_with_logits
 from ..bbox_utils import bbox_iou
 
-__all__ = ['DETRLoss', 'DINOLoss']
+__all__ = ['DETRLoss', 'DINOLoss', 'RTDETRv3Loss']
 
 
 @register
@@ -489,6 +489,102 @@ class DINOLoss(DETRLoss):
             # compute denoising training loss
             num_gts *= dn_num_group
             dn_loss = super(DINOLoss, self).forward(
+                dn_out_bboxes,
+                dn_out_logits,
+                gt_bbox,
+                gt_class,
+                postfix="_dn",
+                dn_match_indices=dn_match_indices,
+                num_gts=num_gts,
+                gt_score=gt_score)
+            total_loss.update(dn_loss)
+        else:
+            total_loss.update(
+                {k + '_dn': paddle.to_tensor([0.])
+                 for k in total_loss.keys()})
+
+        return total_loss
+
+    @staticmethod
+    def get_dn_match_indices(labels, dn_positive_idx, dn_num_group):
+        dn_match_indices = []
+        for i in range(len(labels)):
+            num_gt = len(labels[i])
+            if num_gt > 0:
+                gt_idx = paddle.arange(end=num_gt, dtype="int64")
+                gt_idx = gt_idx.tile([dn_num_group])
+                assert len(dn_positive_idx[i]) == len(gt_idx)
+                dn_match_indices.append((dn_positive_idx[i], gt_idx))
+            else:
+                dn_match_indices.append((paddle.zeros(
+                    [0], dtype="int64"), paddle.zeros(
+                        [0], dtype="int64")))
+        return dn_match_indices
+
+
+@register
+class RTDETRv3Loss(DETRLoss):
+    def forward(self,
+                boxes,
+                logits,
+                gt_bbox,
+                gt_class,
+                masks=None,
+                gt_mask=None,
+                postfix="",
+                dn_out_bboxes=None,
+                dn_out_logits=None,
+                dn_meta=None,
+                gt_score=None,
+                o2m=1,
+                **kwargs):
+        if o2m != 1:
+            gt_boxes_copy = [box.tile([o2m, 1]) for box in gt_bbox]
+            gt_class_copy = [label.tile([o2m, 1]) for label in gt_class]
+        else:
+            gt_boxes_copy = gt_bbox
+            gt_class_copy = gt_class
+        num_gts_copy = self._get_num_gts(gt_class_copy)
+        total_loss = self._get_prediction_loss(
+            boxes[-1],
+            logits[-1],
+            gt_boxes_copy,
+            gt_class_copy,
+            masks=masks[-1] if masks is not None else None,
+            gt_mask=gt_mask,
+            postfix=postfix,
+            dn_match_indices=None,
+            num_gts=num_gts_copy,
+            gt_score=gt_score if gt_score is not None else None)
+
+        if self.aux_loss:
+            total_loss.update(
+                self._get_loss_aux(
+                    boxes[:-1],
+                    logits[:-1],
+                    gt_boxes_copy,
+                    gt_class_copy,
+                    self.num_classes,
+                    num_gts_copy,
+                    dn_match_indices=None,
+                    postfix=postfix,
+                    masks=masks[:-1] if masks is not None else None,
+                    gt_mask=gt_mask,
+                    gt_score=gt_score if gt_score is not None else None))
+
+        if dn_meta is not None:
+            num_gts = self._get_num_gts(gt_class)
+            dn_positive_idx, dn_num_group = \
+                dn_meta["dn_positive_idx"], dn_meta["dn_num_group"]
+            assert len(gt_class) == len(dn_positive_idx)
+
+            # denoising match indices
+            dn_match_indices = self.get_dn_match_indices(
+                gt_class, dn_positive_idx, dn_num_group)
+
+            # compute denoising training loss
+            num_gts *= dn_num_group
+            dn_loss = super(RTDETRv3Loss, self).forward(
                 dn_out_bboxes,
                 dn_out_logits,
                 gt_bbox,

--- a/ppdet/modeling/transformers/__init__.py
+++ b/ppdet/modeling/transformers/__init__.py
@@ -26,6 +26,7 @@ from . import mask_rtdetr_transformer
 from . import rtdetr_transformerv2
 from . import co_deformable_detr_transformer
 from . import co_dino_transformer
+from . import rtdetr_transformerv3
 
 from .detr_transformer import *
 from .utils import *
@@ -42,3 +43,4 @@ from .mask_rtdetr_transformer import *
 from .rtdetr_transformerv2 import *
 from .co_deformable_detr_transformer import *
 from .co_dino_transformer import *
+from .rtdetr_transformerv3 import *

--- a/ppdet/modeling/transformers/detr_transformer.py
+++ b/ppdet/modeling/transformers/detr_transformer.py
@@ -22,6 +22,7 @@ from __future__ import print_function
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
+from paddle.distributed.fleet.utils import recompute
 
 from ppdet.core.workspace import register
 from ..layers import MultiHeadAttention, _convert_attention_mask
@@ -90,16 +91,22 @@ class TransformerEncoderLayer(nn.Layer):
 
 
 class TransformerEncoder(nn.Layer):
-    def __init__(self, encoder_layer, num_layers, norm=None):
+    def __init__(self, encoder_layer, num_layers, norm=None, with_rp=-1):
         super(TransformerEncoder, self).__init__()
         self.layers = _get_clones(encoder_layer, num_layers)
         self.num_layers = num_layers
         self.norm = norm
+        assert with_rp <= num_layers
+        self.with_rp = with_rp
 
     def forward(self, src, src_mask=None, pos_embed=None):
         output = src
-        for layer in self.layers:
-            output = layer(output, src_mask=src_mask, pos_embed=pos_embed)
+        for i, layer in enumerate(self.layers):
+            if self.training and i < self.with_rp:
+                output = recompute(layer, output, src_mask=src_mask, pos_embed=pos_embed,
+                                   **{"preserve_rng_state": True, "use_reentrant": False})
+            else:
+                output = layer(output, src_mask=src_mask, pos_embed=pos_embed)
 
         if self.norm is not None:
             output = self.norm(output)

--- a/ppdet/modeling/transformers/hybrid_encoder.py
+++ b/ppdet/modeling/transformers/hybrid_encoder.py
@@ -142,7 +142,8 @@ class HybridEncoder(nn.Layer):
                  depth_mult=1.0,
                  act='silu',
                  trt=False,
-                 eval_size=None):
+                 eval_size=None,
+                 with_rp=-1):
         super(HybridEncoder, self).__init__()
         self.in_channels = in_channels
         self.feat_strides = feat_strides
@@ -165,7 +166,7 @@ class HybridEncoder(nn.Layer):
                         bias_attr=ParamAttr(regularizer=L2Decay(0.0)))))
         # encoder transformer
         self.encoder = nn.LayerList([
-            TransformerEncoder(encoder_layer, num_encoder_layers)
+            TransformerEncoder(encoder_layer, num_encoder_layers, with_rp=with_rp)
             for _ in range(len(use_encoder_idx))
         ])
 

--- a/ppdet/modeling/transformers/rtdetr_transformerv3.py
+++ b/ppdet/modeling/transformers/rtdetr_transformerv3.py
@@ -28,6 +28,7 @@ import paddle.nn as nn
 import paddle.nn.functional as F
 from paddle import ParamAttr
 from paddle.regularizer import L2Decay
+from paddle.distributed.fleet.utils import recompute
 
 from ppdet.core.workspace import register
 from ..layers import MultiHeadAttention
@@ -203,12 +204,13 @@ class TransformerDecoderLayer(nn.Layer):
 
 
 class TransformerDecoder(nn.Layer):
-    def __init__(self, hidden_dim, decoder_layer, num_layers, eval_idx=-1):
+    def __init__(self, hidden_dim, decoder_layer, num_layers, eval_idx=-1, with_rp=-1):
         super(TransformerDecoder, self).__init__()
         self.layers = _get_clones(decoder_layer, num_layers)
         self.hidden_dim = hidden_dim
         self.num_layers = num_layers
         self.eval_idx = eval_idx if eval_idx >= 0 else num_layers + eval_idx
+        self.with_rp = with_rp
 
     def forward(self,
                 tgt,
@@ -234,9 +236,15 @@ class TransformerDecoder(nn.Layer):
                 query_pos_embed = query_pos_head(
                     inverse_sigmoid(ref_points_detach))
 
-            output = layer(output, ref_points_input, memory,
-                           memory_spatial_shapes, memory_level_start_index,
-                           attn_mask, memory_mask, query_pos_embed)
+            if self.training and i < self.with_rp:
+                output = recompute(layer, output, ref_points_input, memory,
+                            memory_spatial_shapes, memory_level_start_index,
+                            attn_mask, memory_mask, query_pos_embed,
+                            **{"preserve_rng_state": True, "use_reentrant": False})
+            else:
+                output = layer(output, ref_points_input, memory,
+                            memory_spatial_shapes, memory_level_start_index,
+                            attn_mask, memory_mask, query_pos_embed)
 
             inter_ref_bbox = F.sigmoid(bbox_head[i](output) + inverse_sigmoid(
                 ref_points_detach))
@@ -292,7 +300,8 @@ class RTDETRTransformerv3(nn.Layer):
                  num_noise_denoising=100,
                  o2m_branch=False,
                  num_queries_o2m=450,
-                 eps=1e-2):
+                 eps=1e-2,
+                 with_rp=-1):
         super(RTDETRTransformerv3, self).__init__()
         assert position_embed_type in ['sine', 'learned'], \
             f'ValueError: position_embed_type not supported {position_embed_type}!'
@@ -333,7 +342,7 @@ class RTDETRTransformerv3(nn.Layer):
             hidden_dim, nhead, dim_feedforward, dropout, activation, num_levels,
             num_decoder_points)
         self.decoder = TransformerDecoder(hidden_dim, decoder_layer,
-                                          num_decoder_layers, eval_idx)
+                                          num_decoder_layers, eval_idx, with_rp=with_rp)
 
         # denoising part
         self.denoising_class_embed = nn.Embedding(

--- a/ppdet/modeling/transformers/rtdetr_transformerv3.py
+++ b/ppdet/modeling/transformers/rtdetr_transformerv3.py
@@ -1,0 +1,654 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Modified from Deformable-DETR (https://github.com/fundamentalvision/Deformable-DETR)
+# Copyright (c) 2020 SenseTime. All Rights Reserved.
+# Modified from detrex (https://github.com/IDEA-Research/detrex)
+# Copyright 2022 The IDEA Authors. All rights reserved.
+# Copyed from RT-DETRv3 (https://github.com/clxia12/RT-DETRv3)
+# Copyright 2024 The RT-DETRv3 Authors. All rights reserved.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import paddle
+import paddle.nn as nn
+import paddle.nn.functional as F
+from paddle import ParamAttr
+from paddle.regularizer import L2Decay
+
+from ppdet.core.workspace import register
+from ..layers import MultiHeadAttention
+from ..heads.detr_head import MLP
+from .deformable_transformer import MSDeformableAttention
+from ..initializer import (linear_init_, constant_, xavier_uniform_, normal_,
+                           bias_init_with_prob)
+from .utils import (_get_clones, get_sine_pos_embed,
+                    get_contrastive_denoising_training_group, inverse_sigmoid)
+
+__all__ = ['RTDETRTransformerv3']
+
+
+class PPMSDeformableAttention(MSDeformableAttention):
+    def forward(self,
+                query,
+                reference_points,
+                value,
+                value_spatial_shapes,
+                value_level_start_index,
+                value_mask=None):
+        """
+        Args:
+            query (Tensor): [bs, query_length, C]
+            reference_points (Tensor): [bs, query_length, n_levels, 2], range in [0, 1], top-left (0,0),
+                bottom-right (1, 1), including padding area
+            value (Tensor): [bs, value_length, C]
+            value_spatial_shapes (List): [n_levels, 2], [(H_0, W_0), (H_1, W_1), ..., (H_{L-1}, W_{L-1})]
+            value_level_start_index (List): [n_levels], [0, H_0*W_0, H_0*W_0+H_1*W_1, ...]
+            value_mask (Tensor): [bs, value_length], True for non-padding elements, False for padding elements
+
+        Returns:
+            output (Tensor): [bs, Length_{query}, C]
+        """
+        bs, Len_q = query.shape[:2]
+        Len_v = value.shape[1]
+
+        value = self.value_proj(value)
+        if value_mask is not None:
+            value_mask = value_mask.astype(value.dtype).unsqueeze(-1)
+            value *= value_mask
+        value = value.reshape([bs, Len_v, self.num_heads, self.head_dim])
+
+        sampling_offsets = self.sampling_offsets(query).reshape(
+            [bs, Len_q, self.num_heads, self.num_levels, self.num_points, 2])
+        attention_weights = self.attention_weights(query).reshape(
+            [bs, Len_q, self.num_heads, self.num_levels * self.num_points])
+        attention_weights = F.softmax(attention_weights).reshape(
+            [bs, Len_q, self.num_heads, self.num_levels, self.num_points])
+
+        if reference_points.shape[-1] == 2:
+            offset_normalizer = paddle.to_tensor(value_spatial_shapes)
+            offset_normalizer = offset_normalizer.flip([1]).reshape(
+                [1, 1, 1, self.num_levels, 1, 2])
+            sampling_locations = reference_points.reshape([
+                bs, Len_q, 1, self.num_levels, 1, 2
+            ]) + sampling_offsets / offset_normalizer
+        elif reference_points.shape[-1] == 4:
+            sampling_locations = (
+                reference_points[:, :, None, :, None, :2] + sampling_offsets /
+                self.num_points * reference_points[:, :, None, :, None, 2:] *
+                0.5)
+        else:
+            raise ValueError(
+                "Last dim of reference_points must be 2 or 4, but get {} instead.".
+                format(reference_points.shape[-1]))
+
+        if not isinstance(query, paddle.Tensor):
+            from ppdet.modeling.transformers.utils import deformable_attention_core_func
+            output = deformable_attention_core_func(
+                value, value_spatial_shapes, value_level_start_index,
+                sampling_locations, attention_weights)
+        else:
+            value_spatial_shapes = paddle.to_tensor(value_spatial_shapes)
+            value_level_start_index = paddle.to_tensor(value_level_start_index)
+            output = self.ms_deformable_attn_core(
+                value, value_spatial_shapes, value_level_start_index,
+                sampling_locations, attention_weights)
+        output = self.output_proj(output)
+
+        return output
+
+
+class TransformerDecoderLayer(nn.Layer):
+    def __init__(self,
+                 d_model=256,
+                 n_head=8,
+                 dim_feedforward=1024,
+                 dropout=0.,
+                 activation="relu",
+                 n_levels=4,
+                 n_points=4,
+                 weight_attr=None,
+                 bias_attr=None):
+        super(TransformerDecoderLayer, self).__init__()
+
+        # self attention
+        self.self_attn = MultiHeadAttention(d_model, n_head, dropout=dropout)
+        self.dropout1 = nn.Dropout(dropout)
+        self.norm1 = nn.LayerNorm(
+            d_model,
+            weight_attr=ParamAttr(regularizer=L2Decay(0.0)),
+            bias_attr=ParamAttr(regularizer=L2Decay(0.0)))
+
+        # cross attention
+        self.cross_attn = PPMSDeformableAttention(d_model, n_head, n_levels,
+                                                  n_points, 1.0)
+        self.dropout2 = nn.Dropout(dropout)
+        self.norm2 = nn.LayerNorm(
+            d_model,
+            weight_attr=ParamAttr(regularizer=L2Decay(0.0)),
+            bias_attr=ParamAttr(regularizer=L2Decay(0.0)))
+
+        # ffn
+        self.linear1 = nn.Linear(d_model, dim_feedforward, weight_attr,
+                                 bias_attr)
+        self.activation = getattr(F, activation)
+        self.dropout3 = nn.Dropout(dropout)
+        self.linear2 = nn.Linear(dim_feedforward, d_model, weight_attr,
+                                 bias_attr)
+        self.dropout4 = nn.Dropout(dropout)
+        self.norm3 = nn.LayerNorm(
+            d_model,
+            weight_attr=ParamAttr(regularizer=L2Decay(0.0)),
+            bias_attr=ParamAttr(regularizer=L2Decay(0.0)))
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        linear_init_(self.linear1)
+        linear_init_(self.linear2)
+        xavier_uniform_(self.linear1.weight)
+        xavier_uniform_(self.linear2.weight)
+
+    def with_pos_embed(self, tensor, pos):
+        return tensor if pos is None else tensor + pos
+
+    def forward_ffn(self, tgt):
+        return self.linear2(self.dropout3(self.activation(self.linear1(tgt))))
+
+    def forward(self,
+                tgt,
+                reference_points,
+                memory,
+                memory_spatial_shapes,
+                memory_level_start_index,
+                attn_mask=None,
+                memory_mask=None,
+                query_pos_embed=None):
+        # self attention
+        q = k = self.with_pos_embed(tgt, query_pos_embed)
+        if attn_mask is not None:
+            attn_mask = paddle.where(
+                attn_mask.astype('bool'),
+                paddle.zeros(attn_mask.shape, tgt.dtype),
+                paddle.full(attn_mask.shape, float("-inf"), tgt.dtype))
+        tgt2 = self.self_attn(q, k, value=tgt, attn_mask=attn_mask)
+        tgt = tgt + self.dropout1(tgt2)
+        tgt = self.norm1(tgt)
+
+        # cross attention
+        tgt2 = self.cross_attn(
+            self.with_pos_embed(tgt, query_pos_embed), reference_points, memory,
+            memory_spatial_shapes, memory_level_start_index, memory_mask)
+        tgt = tgt + self.dropout2(tgt2)
+        tgt = self.norm2(tgt)
+
+        # ffn
+        tgt2 = self.forward_ffn(tgt)
+        tgt = tgt + self.dropout4(tgt2)
+        tgt = self.norm3(tgt)
+
+        return tgt
+
+
+class TransformerDecoder(nn.Layer):
+    def __init__(self, hidden_dim, decoder_layer, num_layers, eval_idx=-1):
+        super(TransformerDecoder, self).__init__()
+        self.layers = _get_clones(decoder_layer, num_layers)
+        self.hidden_dim = hidden_dim
+        self.num_layers = num_layers
+        self.eval_idx = eval_idx if eval_idx >= 0 else num_layers + eval_idx
+
+    def forward(self,
+                tgt,
+                ref_points_unact,
+                memory,
+                memory_spatial_shapes,
+                memory_level_start_index,
+                bbox_head,
+                score_head,
+                query_pos_head,
+                attn_mask=None,
+                memory_mask=None,
+                query_pos_head_inv_sig=False):
+        output = tgt
+        dec_out_bboxes = []
+        dec_out_logits = []
+        ref_points_detach = F.sigmoid(ref_points_unact)
+        for i, layer in enumerate(self.layers):
+            ref_points_input = ref_points_detach.unsqueeze(2)
+            if not query_pos_head_inv_sig:
+                query_pos_embed = query_pos_head(ref_points_detach)
+            else:
+                query_pos_embed = query_pos_head(
+                    inverse_sigmoid(ref_points_detach))
+
+            output = layer(output, ref_points_input, memory,
+                           memory_spatial_shapes, memory_level_start_index,
+                           attn_mask, memory_mask, query_pos_embed)
+
+            inter_ref_bbox = F.sigmoid(bbox_head[i](output) + inverse_sigmoid(
+                ref_points_detach))
+
+            if self.training:
+                dec_out_logits.append(score_head[i](output))
+                if i == 0:
+                    dec_out_bboxes.append(inter_ref_bbox)
+                else:
+                    dec_out_bboxes.append(
+                        F.sigmoid(bbox_head[i](output) + inverse_sigmoid(
+                            ref_points)))
+            elif i == self.eval_idx:
+                dec_out_logits.append(score_head[i](output))
+                dec_out_bboxes.append(inter_ref_bbox)
+                break
+
+            ref_points = inter_ref_bbox
+            ref_points_detach = inter_ref_bbox.detach(
+            ) if self.training else inter_ref_bbox
+
+        return paddle.stack(dec_out_bboxes), paddle.stack(dec_out_logits)
+
+
+@register
+class RTDETRTransformerv3(nn.Layer):
+    __shared__ = ['num_classes', 'hidden_dim', 'eval_size',
+                  'o2m_branch', 'num_queries_o2m']
+
+    def __init__(self,
+                 num_classes=80,
+                 hidden_dim=256,
+                 num_queries=300,
+                 position_embed_type='sine',
+                 backbone_feat_channels=[512, 1024, 2048],
+                 feat_strides=[8, 16, 32],
+                 num_levels=3,
+                 num_decoder_points=4,
+                 nhead=8,
+                 num_decoder_layers=6,
+                 dim_feedforward=1024,
+                 dropout=0.,
+                 activation="relu",
+                 num_denoising=100,
+                 label_noise_ratio=0.5,
+                 box_noise_scale=1.0,
+                 learnt_init_query=True,
+                 query_pos_head_inv_sig=False,
+                 eval_size=None,
+                 eval_idx=-1,
+                 num_noises=0,
+                 num_noise_queries=[],
+                 num_noise_denoising=100,
+                 o2m_branch=False,
+                 num_queries_o2m=450,
+                 eps=1e-2):
+        super(RTDETRTransformerv3, self).__init__()
+        assert position_embed_type in ['sine', 'learned'], \
+            f'ValueError: position_embed_type not supported {position_embed_type}!'
+        assert len(backbone_feat_channels) <= num_levels
+        assert len(feat_strides) == len(backbone_feat_channels)
+        assert len(num_noise_queries) == num_noises
+        for _ in range(num_levels - len(feat_strides)):
+            feat_strides.append(feat_strides[-1] * 2)
+
+        self.hidden_dim = hidden_dim
+        self.nhead = nhead
+        self.feat_strides = feat_strides
+        self.num_levels = num_levels
+        self.num_classes = num_classes
+        self.num_queries = [num_queries]
+        self.eps = eps
+        self.num_decoder_layers = num_decoder_layers
+        self.eval_size = eval_size
+
+        self.num_noises = num_noises
+        self.num_noise_denoising = num_noise_denoising
+        self.num_groups = 1
+        if num_noises > 0:
+            self.num_queries.extend(num_noise_queries)
+            self.num_groups += num_noises
+        
+        self.o2m_branch = o2m_branch
+        self.num_queries_o2m = num_queries_o2m
+        if o2m_branch:
+            self.num_queries.append(num_queries_o2m)
+            self.num_groups += 1
+
+        # backbone feature projection
+        self._build_input_proj_layer(backbone_feat_channels)
+
+        # Transformer module
+        decoder_layer = TransformerDecoderLayer(
+            hidden_dim, nhead, dim_feedforward, dropout, activation, num_levels,
+            num_decoder_points)
+        self.decoder = TransformerDecoder(hidden_dim, decoder_layer,
+                                          num_decoder_layers, eval_idx)
+
+        # denoising part
+        self.denoising_class_embed = nn.Embedding(
+            num_classes,
+            hidden_dim,
+            weight_attr=ParamAttr(initializer=nn.initializer.Normal()))
+        self.num_denoising = num_denoising
+        self.label_noise_ratio = label_noise_ratio
+        self.box_noise_scale = box_noise_scale
+
+        # decoder embedding
+        self.learnt_init_query = learnt_init_query
+        if learnt_init_query:
+            self.tgt_embed = nn.Embedding(num_queries, hidden_dim)
+        self.query_pos_head = MLP(4, 2 * hidden_dim, hidden_dim, num_layers=2)
+        self.query_pos_head_inv_sig = query_pos_head_inv_sig
+
+        # encoder head
+        self.enc_output = nn.LayerList([
+            nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim),
+                nn.LayerNorm(
+                    hidden_dim,
+                    weight_attr=ParamAttr(regularizer=L2Decay(0.0)),
+                    bias_attr=ParamAttr(regularizer=L2Decay(0.0))))
+            for _ in range(self.num_groups)
+        ])
+        self.enc_score_head = nn.LayerList([
+            nn.Linear(hidden_dim, num_classes)
+            for _ in range(self.num_groups)
+        ])
+        self.enc_bbox_head = nn.LayerList([
+            MLP(hidden_dim, hidden_dim, 4, num_layers=3)
+            for _ in range(self.num_groups)
+        ])
+
+        self.map_memory = nn.Sequential(
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.LayerNorm(
+                hidden_dim,
+                weight_attr=ParamAttr(regularizer=L2Decay(0.0)),
+                bias_attr=ParamAttr(regularizer=L2Decay(0.0)))
+            )
+
+        # decoder head
+        self.dec_score_head = nn.LayerList([
+            nn.Linear(hidden_dim, num_classes)
+            for _ in range(num_decoder_layers)
+        ])
+        self.dec_bbox_head = nn.LayerList([
+            MLP(hidden_dim, hidden_dim, 4, num_layers=3)
+            for _ in range(num_decoder_layers)
+        ])
+
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        # class and bbox head init
+        bias_cls = bias_init_with_prob(0.01)
+        for enc_score_head in self.enc_score_head:
+            linear_init_(enc_score_head)
+            constant_(enc_score_head.bias, bias_cls)
+        for enc_bbox_head in self.enc_bbox_head:
+            constant_(enc_bbox_head.layers[-1].weight)
+            constant_(enc_bbox_head.layers[-1].bias)
+        for cls_, reg_ in zip(self.dec_score_head, self.dec_bbox_head):
+            linear_init_(cls_)
+            constant_(cls_.bias, bias_cls)
+            constant_(reg_.layers[-1].weight)
+            constant_(reg_.layers[-1].bias)
+
+        for enc_output in self.enc_output:
+            linear_init_(enc_output[0])
+            xavier_uniform_(enc_output[0].weight)
+        linear_init_(self.map_memory[0])
+        xavier_uniform_(self.map_memory[0].weight)
+
+        if self.learnt_init_query:
+            xavier_uniform_(self.tgt_embed.weight)
+        xavier_uniform_(self.query_pos_head.layers[0].weight)
+        xavier_uniform_(self.query_pos_head.layers[1].weight)
+        for l in self.input_proj:
+            xavier_uniform_(l[0].weight)
+
+        # init encoder output anchors and valid_mask
+        if self.eval_size:
+            self.anchors, self.valid_mask = self._generate_anchors()
+
+    @classmethod
+    def from_config(cls, cfg, input_shape):
+        return {'backbone_feat_channels': [i.channels for i in input_shape]}
+
+    def _build_input_proj_layer(self, backbone_feat_channels):
+        self.input_proj = nn.LayerList()
+        for in_channels in backbone_feat_channels:
+            self.input_proj.append(
+                nn.Sequential(
+                    ('conv', nn.Conv2D(
+                        in_channels,
+                        self.hidden_dim,
+                        kernel_size=1,
+                        bias_attr=False)), ('norm', nn.BatchNorm2D(
+                            self.hidden_dim,
+                            weight_attr=ParamAttr(regularizer=L2Decay(0.0)),
+                            bias_attr=ParamAttr(regularizer=L2Decay(0.0))))))
+        in_channels = backbone_feat_channels[-1]
+        for _ in range(self.num_levels - len(backbone_feat_channels)):
+            self.input_proj.append(
+                nn.Sequential(
+                    ('conv', nn.Conv2D(
+                        in_channels,
+                        self.hidden_dim,
+                        kernel_size=3,
+                        stride=2,
+                        padding=1,
+                        bias_attr=False)), ('norm', nn.BatchNorm2D(
+                            self.hidden_dim,
+                            weight_attr=ParamAttr(regularizer=L2Decay(0.0)),
+                            bias_attr=ParamAttr(regularizer=L2Decay(0.0))))))
+            in_channels = self.hidden_dim
+
+    def _get_encoder_input(self, feats):
+        # get projection features
+        proj_feats = [self.input_proj[i](feat) for i, feat in enumerate(feats)]
+        if self.num_levels > len(proj_feats):
+            len_srcs = len(proj_feats)
+            for i in range(len_srcs, self.num_levels):
+                if i == len_srcs:
+                    proj_feats.append(self.input_proj[i](feats[-1]))
+                else:
+                    proj_feats.append(self.input_proj[i](proj_feats[-1]))
+
+        # get encoder inputs
+        feat_flatten = []
+        spatial_shapes = []
+        level_start_index = [0, ]
+        for i, feat in enumerate(proj_feats):
+            _, _, h, w = feat.shape
+            # [b, c, h, w] -> [b, h*w, c]
+            feat_flatten.append(feat.flatten(2).transpose([0, 2, 1]))
+            # [num_levels, 2]
+            spatial_shapes.append([h, w])
+            # [l], start index of each level
+            level_start_index.append(h * w + level_start_index[-1])
+
+        # [b, l, c]
+        feat_flatten = paddle.concat(feat_flatten, 1)
+        level_start_index.pop()
+        return (feat_flatten, spatial_shapes, level_start_index)
+
+    def forward(self, feats, pad_mask=None, gt_meta=None, is_teacher=False):
+        # input projection and embedding
+        (memory, spatial_shapes,
+         level_start_index) = self._get_encoder_input(feats)
+
+        # prepare denoising training
+        if self.training:
+            denoising_classes, denoising_bbox_unacts, attn_masks, dn_metas = [], [], [], []
+            for g_id in range(self.num_noises + 1):
+                if g_id == 0:
+                    num_denoising = self.num_denoising
+                else:
+                    num_denoising = self.num_noise_denoising
+                denoising_class, denoising_bbox_unact, attn_mask, dn_meta = \
+                    get_contrastive_denoising_training_group(gt_meta,
+                                                self.num_classes,
+                                                self.num_queries[g_id],
+                                                self.denoising_class_embed.weight,
+                                                num_denoising,
+                                                self.label_noise_ratio,
+                                                self.box_noise_scale)
+                denoising_classes.append(denoising_class)
+                denoising_bbox_unacts.append(denoising_bbox_unact)
+                attn_masks.append(attn_mask)
+                dn_metas.append(dn_meta)
+        else:
+            denoising_classes, denoising_bbox_unacts, attn_masks, dn_metas = None, None, None, None
+
+        target, init_ref_points_unact, enc_topk_bboxes, enc_topk_logits = \
+            self._get_decoder_input(
+                memory, spatial_shapes, denoising_classes, denoising_bbox_unacts, is_teacher)
+
+        # multi group noise attention
+        if self.training:
+            new_size = target.shape[1]
+            new_attn_mask = paddle.ones([new_size, new_size]) < 0
+            begin, end = 0, 0
+            mask = None
+            for g_id in range(self.num_groups):
+                new_mask = paddle.rand([self.num_queries[g_id], self.num_queries[g_id]])
+                if self.o2m_branch and g_id == self.num_groups - 1:
+                    end = end + self.num_queries_o2m
+                    new_mask = new_mask >= 0.0
+                    new_attn_mask[begin: end, begin: end] = new_mask
+                else:
+                    end = end + attn_masks[g_id].shape[1]
+                    dn_size, q_size = dn_metas[g_id]['dn_num_split']
+                    if g_id > 0:
+                        new_mask = new_mask > 0.1
+                    else:
+                        new_mask = new_mask >= 0.0
+                    attn_masks[g_id][dn_size: dn_size + q_size, dn_size: dn_size + q_size] = new_mask
+                    new_attn_mask[begin: end, begin: end] = attn_masks[g_id]
+                begin = end
+            attn_masks = new_attn_mask
+
+        # decoder
+        out_bboxes, out_logits = self.decoder(
+            target,
+            init_ref_points_unact,
+            memory,
+            spatial_shapes,
+            level_start_index,
+            self.dec_bbox_head,
+            self.dec_score_head,
+            self.query_pos_head,
+            attn_mask=attn_masks,
+            memory_mask=None,
+            query_pos_head_inv_sig=self.query_pos_head_inv_sig)
+        return (out_bboxes, out_logits, enc_topk_bboxes, enc_topk_logits,
+                dn_metas)
+
+    def _generate_anchors(self,
+                          spatial_shapes=None,
+                          grid_size=0.05,
+                          dtype="float32"):
+        if spatial_shapes is None:
+            spatial_shapes = [
+                [int(self.eval_size[0] / s), int(self.eval_size[1] / s)]
+                for s in self.feat_strides
+            ]
+        anchors = []
+        for lvl, (h, w) in enumerate(spatial_shapes):
+            grid_y, grid_x = paddle.meshgrid(
+                paddle.arange(
+                    end=h, dtype=dtype),
+                paddle.arange(
+                    end=w, dtype=dtype))
+            grid_xy = paddle.stack([grid_x, grid_y], -1)
+
+            valid_WH = paddle.to_tensor([h, w]).astype(dtype)
+            grid_xy = (grid_xy.unsqueeze(0) + 0.5) / valid_WH
+            wh = paddle.ones_like(grid_xy) * grid_size * (2.0**lvl)
+            anchors.append(
+                paddle.concat([grid_xy, wh], -1).reshape([-1, h * w, 4]))
+
+        anchors = paddle.concat(anchors, 1)
+        valid_mask = ((anchors > self.eps) *
+                      (anchors < 1 - self.eps)).all(-1, keepdim=True)
+        anchors = paddle.log(anchors / (1 - anchors))
+        anchors = paddle.where(valid_mask, anchors,
+                               paddle.to_tensor(float("inf")))
+        return anchors, valid_mask
+
+    def _get_decoder_input(self,
+                           memory,
+                           spatial_shapes,
+                           denoising_classes=None,
+                           denoising_bbox_unacts=None,
+                           is_teacher=False):
+        bs, _, _ = memory.shape
+        # prepare input for decoder
+        if self.training or self.eval_size is None or is_teacher:
+            anchors, valid_mask = self._generate_anchors(spatial_shapes)
+        else:
+            anchors, valid_mask = self.anchors, self.valid_mask
+        memory = paddle.where(valid_mask, memory, paddle.to_tensor(0.))
+        map_memory = self.map_memory(memory.detach())
+        targets, reference_points_unacts, enc_topk_bboxes, enc_topk_logits = [], [], [], []
+
+        for g_id in range(self.num_groups):
+            output_memory = self.enc_output[g_id](memory)
+            enc_outputs_class = self.enc_score_head[g_id](output_memory)
+            enc_outputs_coord_unact = self.enc_bbox_head[g_id](output_memory) + anchors
+
+            _, topk_ind = paddle.topk(
+                enc_outputs_class.max(-1), self.num_queries[g_id], axis=1)
+            # extract region proposal boxes
+            batch_ind = paddle.arange(end=bs, dtype=topk_ind.dtype)
+            batch_ind = batch_ind.unsqueeze(-1).tile([1, self.num_queries[g_id]])
+            topk_ind = paddle.stack([batch_ind, topk_ind], axis=-1)
+
+            reference_points_unact = paddle.gather_nd(enc_outputs_coord_unact, topk_ind)  # unsigmoided.
+            enc_topk_bbox = F.sigmoid(reference_points_unact)
+            enc_topk_logit = paddle.gather_nd(enc_outputs_class, topk_ind)
+
+            if denoising_bbox_unacts is not None and not (self.o2m_branch and g_id == self.num_groups - 1):
+                reference_points_unact = paddle.concat(
+                    [denoising_bbox_unacts[g_id], reference_points_unact], 1)
+            if self.training:
+                reference_points_unact = reference_points_unact.detach()
+
+            # extract region features
+            if self.learnt_init_query:
+                target = self.tgt_embed.weight.unsqueeze(0).tile([bs, 1, 1])
+            else:
+                if g_id == 0:
+                    target = paddle.gather_nd(output_memory, topk_ind)
+                    if self.training:
+                        target = target.detach()
+                else:
+                    target = paddle.gather_nd(map_memory, topk_ind)
+            if denoising_classes is not None and not (self.o2m_branch and g_id == self.num_groups - 1):
+                target = paddle.concat([denoising_classes[g_id], target], 1)
+            
+            if not self.training:
+                return target, reference_points_unact, enc_topk_bbox, enc_topk_logit
+            
+            targets.append(target)
+            reference_points_unacts.append(reference_points_unact)
+            enc_topk_bboxes.append(enc_topk_bbox)
+            enc_topk_logits.append(enc_topk_logit)
+
+        targets = paddle.concat(targets, 1)
+        reference_points_unacts = paddle.concat(reference_points_unacts, 1)
+        enc_topk_bboxes = paddle.concat(enc_topk_bboxes, 1)
+        enc_topk_logits = paddle.concat(enc_topk_logits, 1)
+        return targets, reference_points_unacts, enc_topk_bboxes, enc_topk_logits


### PR DESCRIPTION
* https://github.com/PaddlePaddle/Paddle/issues/71310
* No.38：[在 PaddleDetection 中复现 RT-DETRv3 模型](https://github.com/PaddlePaddle/community/blob/master/hackathon/hackathon_8th/%E3%80%90Hackathon_8th%E3%80%91%E4%B8%AA%E4%BA%BA%E6%8C%91%E6%88%98%E8%B5%9B%E2%80%94%E5%A5%97%E4%BB%B6%E5%BC%80%E5%8F%91%E4%BB%BB%E5%8A%A1%E5%90%88%E9%9B%86.md#no38-rt-detrv3-%E6%A8%A1%E5%9E%8B%E5%A4%8D%E7%8E%B0)
* RFC: https://github.com/PaddlePaddle/community/pull/1094

本次复现基于官方repo：https://github.com/clxia12/RT-DETRv3

鉴于官方repo基于`PaddleDetection 2.8.1`实现，本次复现尽可能采用官方repo的代码，只做了少量细微改动：
- 将`RTDETRv3`合并到`DETR`中，通过配置`aux_o2m_head`来实现RTDETRv3
- 将`DINOv3Head`重命名为`RTDETRv3Head`，将`DINOv3Loss`重命名为`RTDETRv3Loss`
- 修正了config文件中的小错误
- 本次复现不包含lvis相关代码、模型及文件

### 变动
- 修改`PadGT`，增加参数`only_origin_box`。当`only_origin_box`为`False`时，功能与原先一样，默认为`False`
- 修改`NormalizeBox`，增加参数`retain_origin_box`。当`retain_origin_box`为`False`时，功能与原先一样，默认为`False`
- 修改`BatchCompose`，增加对`origin_gt_bbox`和`origin_gt_class`的支持
- 修改`PPYOLOEHead.get_loss`，当`origin_gt_bbox`、`origin_gt_class`、`pad_origin_gt_mask`存在时，替代`gt_bbox`、`gt_class`、`pad_gt_mask`
- 修改`DETR`，增加参数`aux_o2m_head`。当`aux_o2m_head`为`None`时，功能与原先一样，默认为`None`