### PR TITLE
Fix shallow copy problem

### DIFF
--- a/ppdet/modeling/architectures/meta_arch.py
+++ b/ppdet/modeling/architectures/meta_arch.py
@@ -46,7 +46,7 @@ class BaseArch(nn.Layer):
             image = inputs['image']
             inputs['image'] = paddle.transpose(image, [0, 2, 3, 1])
 
-        self.inputs = inputs
+        self.inputs = {**inputs}
         if self.fuse_norm:
             self.inputs['image'] = inputs['image'] * self.scale + self.bias
 
@@ -63,9 +63,9 @@ class BaseArch(nn.Layer):
                 inputs_list.extend(inputs)
             outs = []
             for inp in inputs_list:
-                self.inputs = inp
+                self.inputs = {**inp}
                 if self.fuse_norm:
-                    self.inputs['image'] = self.inputs['image'] * self.scale + self.bias
+                    self.inputs['image'] = inp['image'] * self.scale + self.bias
                 outs.append(self.get_pred())
 
             # multi-scale test


### PR DESCRIPTION
[PR9375](https://github.com/PaddlePaddle/PaddleDetection/pull/9375) caused the exported models `PP-YOLOE_plus_SOD-L`, `PP-YOLOE_plus_SOD-S`, and `PP-YOLOE_plus_SOD-largesize-L` to perform the scaling transformation twice when `fuse_norm=True`. 

This issue was resolved by changing `self.inputs = inputs` to `self.inputs = {**inputs}`.

cc @SigureMo .