### PR TITLE
撤销allow_empty=True时对use_shared_memory的支持

### DIFF
--- a/configs/deim/_base_/deim_reader.yml
+++ b/configs/deim/_base_/deim_reader.yml
@@ -78,7 +78,3 @@ TestReader:
   batch_size: 1
   shuffle: false
   drop_last: false
-
-
-TrainDataset:
-  allow_empty: True

--- a/configs/deim/deim_dfine/deim_hgnetv2_l_58e_coco.yml
+++ b/configs/deim/deim_dfine/deim_hgnetv2_l_58e_coco.yml
@@ -51,6 +51,7 @@ OptimizerBuilder:
         weight_decay: 0.
 
 TrainReader:
+  use_shared_memory: false
   batch_size: 8
   mosaic_epoch: 29
   batch_transforms:
@@ -70,3 +71,6 @@ TrainReader:
     - Resize: {start_epoch: 50}
     - BatchRandomResize: {stop_epoch: 50}
     - MixupBatch: {start_epoch: 4, stop_epoch: 29}
+
+TrainDataset:
+  allow_empty: True

--- a/configs/deim/deim_dfine/deim_hgnetv2_m_102e_coco.yml
+++ b/configs/deim/deim_dfine/deim_hgnetv2_m_102e_coco.yml
@@ -38,6 +38,7 @@ OptimizerBuilder:
         weight_decay: 0.
 
 TrainReader:
+  use_shared_memory: false
   batch_size: 8
   mosaic_epoch: 49
   batch_transforms:
@@ -57,3 +58,6 @@ TrainReader:
     - Resize: {start_epoch: 90}
     - BatchRandomResize: {stop_epoch: 90}
     - MixupBatch: {start_epoch: 4, stop_epoch: 49}
+
+TrainDataset:
+  allow_empty: True

--- a/configs/deim/deim_dfine/deim_hgnetv2_n_160e_coco.yml
+++ b/configs/deim/deim_dfine/deim_hgnetv2_n_160e_coco.yml
@@ -61,6 +61,7 @@ OptimizerBuilder:
         weight_decay: 0.
 
 TrainReader:
+  use_shared_memory: false
   batch_size: 32
   mosaic_epoch: 78
   batch_transforms:
@@ -74,3 +75,6 @@ TrainReader:
     - RandomSelect: {start_epoch: 4, stop_epoch: 78}
     - RandomSelects: {start_epoch: 78, stop_epoch: 148}
     - MixupBatch: {start_epoch: 4, stop_epoch: 78}
+
+TrainDataset:
+  allow_empty: True

--- a/configs/deim/deim_dfine/deim_hgnetv2_s_132e_coco.yml
+++ b/configs/deim/deim_dfine/deim_hgnetv2_s_132e_coco.yml
@@ -48,6 +48,7 @@ OptimizerBuilder:
         weight_decay: 0.
 
 TrainReader:
+  use_shared_memory: false
   batch_size: 8
   mosaic_epoch: 64
   batch_transforms:
@@ -67,3 +68,6 @@ TrainReader:
     - Resize: {start_epoch: 120}
     - BatchRandomResize: {stop_epoch: 120}
     - MixupBatch: {start_epoch: 4, stop_epoch: 64}
+
+TrainDataset:
+  allow_empty: True

--- a/configs/deim/deim_dfine/deim_hgnetv2_x_58e_coco.yml
+++ b/configs/deim/deim_dfine/deim_hgnetv2_x_58e_coco.yml
@@ -56,6 +56,7 @@ OptimizerBuilder:
         weight_decay: 0.
 
 TrainReader:
+  use_shared_memory: false
   batch_size: 8
   mosaic_epoch: 29
   batch_transforms:
@@ -75,3 +76,6 @@ TrainReader:
     - Resize: {start_epoch: 50}
     - BatchRandomResize: {stop_epoch: 50}
     - MixupBatch: {start_epoch: 4, stop_epoch: 29}
+
+TrainDataset:
+  allow_empty: True

--- a/configs/deim/deim_rtdetrv2/deim_r101vd_60e_coco.yml
+++ b/configs/deim/deim_rtdetrv2/deim_r101vd_60e_coco.yml
@@ -40,3 +40,9 @@ OptimizerBuilder:
         weight_decay: 0.
       - params: ['^neck\.input_proj\.\d+\.1.*$', '^transformer\.enc_output\.1.*$']
         weight_decay: 0.
+
+TrainReader:
+  use_shared_memory: false
+
+TrainDataset:
+  allow_empty: True

--- a/configs/deim/deim_rtdetrv2/deim_r18vd_120e_coco.yml
+++ b/configs/deim/deim_rtdetrv2/deim_r18vd_120e_coco.yml
@@ -52,6 +52,7 @@ OptimizerBuilder:
         weight_decay: 0.
 
 TrainReader:
+  use_shared_memory: false
   mosaic_epoch: 64
   batch_transforms:
     - NormalizeImage: {mean: [0., 0., 0.], std: [1., 1., 1.], norm_type: none}
@@ -64,3 +65,6 @@ TrainReader:
     - RandomSelect: {start_epoch: 4, stop_epoch: 64}
     - RandomSelects: {start_epoch: 64, stop_epoch: 117}
     - MixupBatch: {start_epoch: 4, stop_epoch: 64}
+
+TrainDataset:
+  allow_empty: True

--- a/configs/deim/deim_rtdetrv2/deim_r34vd_120e_coco.yml
+++ b/configs/deim/deim_rtdetrv2/deim_r34vd_120e_coco.yml
@@ -54,6 +54,7 @@ OptimizerBuilder:
         weight_decay: 0.
 
 TrainReader:
+  use_shared_memory: false
   mosaic_epoch: 64
   transform_schedulers:
     # [start_epoch, stop_epoch) | [0, stop_epoch) | [start_epoch, inf)
@@ -62,3 +63,6 @@ TrainReader:
     - Resize: {start_epoch: 117}
     - BatchRandomResize: {stop_epoch: 117}
     - MixupBatch: {start_epoch: 4, stop_epoch: 64}
+
+TrainDataset:
+  allow_empty: True

--- a/configs/deim/deim_rtdetrv2/deim_r50vd_60e_coco.yml
+++ b/configs/deim/deim_rtdetrv2/deim_r50vd_60e_coco.yml
@@ -19,3 +19,9 @@ DINOHead:
   loss:
     use_vfl: False
     use_mal: True
+
+TrainReader:
+  use_shared_memory: false
+
+TrainDataset:
+  allow_empty: True

--- a/configs/deim/deim_rtdetrv2/deim_r50vd_m_60e_coco.yml
+++ b/configs/deim/deim_rtdetrv2/deim_r50vd_m_60e_coco.yml
@@ -23,3 +23,9 @@ DINOHead:
   loss:
     use_vfl: False
     use_mal: True
+
+TrainReader:
+  use_shared_memory: false
+
+TrainDataset:
+  allow_empty: True

--- a/ppdet/data/reader.py
+++ b/ppdet/data/reader.py
@@ -115,17 +115,6 @@ class BatchCompose(Compose):
                 if k in sample:
                     sample.pop(k)
 
-        for d in data:
-            empty_fields = []
-            for k in d:
-                if isinstance(d[k], np.ndarray) and d[k].size == 0:
-                    d[k] = np.empty((1, *d[k].shape[1:]), dtype=d[k].dtype)
-                    empty_fields.append(k)
-            d['__empty_fields'] = empty_fields
-        if all(not d['__empty_fields'] for d in data):
-            for d in data:
-                d.pop('__empty_fields')
-
         # batch data, if user-define batch function needed
         # use user-defined here
         if self.collate_batch:
@@ -136,7 +125,7 @@ class BatchCompose(Compose):
                 tmp_data = []
                 for i in range(len(data)):
                     tmp_data.append(data[i][k])
-                if k != '__empty_fields' and not 'gt_' in k and not 'is_crowd' in k and not 'difficult' in k:
+                if not 'gt_' in k and not 'is_crowd' in k and not 'difficult' in k:
                     tmp_data = np.stack(tmp_data, axis=0)
                 batch_data[k] = tmp_data
         return batch_data
@@ -261,15 +250,6 @@ class TrainReader(BaseDataLoader):
         super(TrainReader, self).__init__(sample_transforms, batch_transforms,
                                           batch_size, shuffle, drop_last,
                                           num_classes, collate_batch, **kwargs)
-
-    def __iter__(self):
-        for data in self.dataloader:
-            if '__empty_fields' in data:
-                empty_fields = data.pop('__empty_fields')
-                for i, fields in enumerate(empty_fields):
-                    for k in fields:
-                        data[k][i] = data[k][i][:0]
-            yield data
 
 
 @register


### PR DESCRIPTION
该支持由此引入： https://github.com/PaddlePaddle/PaddleDetection/pull/9381
会造成solo_v2模型的训练错误，先revert该支持

allow_empty和use_shared_memory不能同时打开，参考：https://github.com/PaddlePaddle/PaddleDetection/issues/7797

### 影响：
- 会使deim系列模型训练时间大幅增加，但对精度无影响
