### PR TITLE
Fix incorrect handling of camera in pipeline.py and incorrect parse of shared memory value

### DIFF
--- a/deploy/pipeline/pipeline.py
+++ b/deploy/pipeline/pipeline.py
@@ -815,7 +815,7 @@ class PipePredictor(object):
                             pushstream.pipe.stdin.write(im.tobytes())
                         else:
                             writer.write(im)
-                            if self.file_name is None:  # use camera_id
+                            if type(self.file_name) == int:  # use camera_id
                                 cv2.imshow('Paddle-Pipeline', im)
                                 if cv2.waitKey(1) & 0xFF == ord('q'):
                                     break
@@ -1087,7 +1087,7 @@ class PipePredictor(object):
                     pushstream.pipe.stdin.write(im.tobytes())
                 else:
                     writer.write(im)
-                    if self.file_name is None:  # use camera_id
+                    if type(self.file_name) == int:  # use camera_id
                         cv2.imshow('Paddle-Pipeline', im)
                         if cv2.waitKey(1) & 0xFF == ord('q'):
                             break

--- a/deploy/pipeline/pipeline.py
+++ b/deploy/pipeline/pipeline.py
@@ -637,10 +637,12 @@ class PipePredictor(object):
             if self.cfg['visual']:
                 self.visualize_image(batch_file, batch_input, self.pipeline_res)
 
-    def capturevideo(self, capture, queue):
+    def capturevideo(self, capture, queue, capture_end):
         frame_id = 0
         while (1):
-            if queue.full():
+            if capture_end.is_set():
+                return
+            elif queue.full():
                 time.sleep(0.1)
             else:
                 ret, frame = capture.read()
@@ -728,9 +730,10 @@ class PipePredictor(object):
         cars_count = 0
         retrograde_traj_len = 0
         framequeue = queue.Queue(10)
+        capture_end = threading.Event()
 
         thread = threading.Thread(
-            target=self.capturevideo, args=(capture, framequeue))
+            target=self.capturevideo, args=(capture, framequeue, capture_end))
         thread.start()
         time.sleep(1)
 
@@ -1089,6 +1092,7 @@ class PipePredictor(object):
                         if cv2.waitKey(1) & 0xFF == ord('q'):
                             break
 
+        capture_end.set()
         if self.cfg['visual'] and len(self.pushurl) == 0:
             writer.release()
             print('save result to {}'.format(out_path))

--- a/ppdet/data/shm_utils.py
+++ b/ppdet/data/shm_utils.py
@@ -40,7 +40,8 @@ def _parse_size_in_M(size_str):
         num, unit = size_str[:-1], size_str[-1]
     assert unit in SIZE_UNIT, \
             "unknown shm size unit {}".format(unit)
-    return float(num) * \
+    num_dot = num.replace(',', '.') # To handle cases where the integer part is separated from the floating point part by a comma
+    return float(num_dot) * \
             (1024 ** (SIZE_UNIT.index(unit) - 1))
 
 


### PR DESCRIPTION
Fix incorrect handling of camera in pipeline.py:
- commit: "Fixes hang when exiting using a camera"
- commit: "Fix video window not opening when using camera"

Fix incorrect parse of shared memory value in some cases:
- commit "Fix incorrect parse of shared memory when the integer part is separated from the floating point part by a comma"