### PR TITLE
QOL update to requirement.txt for fixing minor issues during installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,10 +16,13 @@ packaging
 # for MOT evaluation and inference
 lapx
 motmetrics
-sklearn==0.0
+scikit-learn
 
 # for vehicleplate in deploy/pipeline/ppvehicle
 pyclipper
 
 # for culane data augumetation
 imgaug>=0.4.0
+
+# use numba in PP-Tracking
+numba


### PR DESCRIPTION
When running the test, `python3 ppdet/modeling/tests/test_architectures.py`, there is an import error for sklearn (`ModuleNotFoundError: No module named 'sklearn').
Updated the requirements from `sklearn==0.0` to `scikit-learn` solves this.

Additionally, a warning about `numba` being missing for PP-Tracking, so this too has now been added to requirements.txt