### PR TITLE
Support cuda13 search path

### DIFF
--- a/ppdet/ext_op/setup.py
+++ b/ppdet/ext_op/setup.py
@@ -22,7 +22,7 @@ def get_extensions():
 
     if paddle.device.is_compiled_with_cuda():
         extension = CUDAExtension(
-            sources, extra_compile_args={'cxx': ['-DPADDLE_WITH_CUDA']})
+            sources, include_dirs=['/usr/local/cuda/include/cccl'], extra_compile_args={'cxx': ['-DPADDLE_WITH_CUDA']})
     else:
         extension = CppExtension(sources)
 


### PR DESCRIPTION
cuda13 include目录下多了一级cccl目录，导致很多头文件找不到
￼￼
![75b1d19a884131340ab4f6b0d6a1faec](https://github.com/user-attachments/assets/2bc9eafa-0a3f-4a36-86d2-405ae16be070)

<img width="670" height="266" alt="2f77c1aedd3557c4a254322be7c1344d" src="https://github.com/user-attachments/assets/b96ad330-59c1-4a6c-8e3d-33ccfde39cb7" />