### PR TITLE
【修改】执行voc预测时每次都需要加载COCO解析文件异常

### DIFF
--- a/ppdet/data/source/dataset.py
+++ b/ppdet/data/source/dataset.py
@@ -217,16 +217,17 @@ class ImageFolder(DetDataset):
         images = self._parse()
         ct = 0
         records = []
-        anno_file = self.get_anno()
-        coco = COCO(anno_file)
         for image in images:
             assert image != '' and os.path.isfile(image), \
                     "Image {} not found".format(image)
             if self.sample_num > 0 and ct >= self.sample_num:
                 break
             if do_eval:
+                anno_file = self.get_anno()
+                coco = COCO(anno_file)
                 image_id = self.get_image_id(image, coco)
                 ct = image_id
+            
             rec = {'im_id': np.array([ct]), 'im_file': image}
             self._imid2path[ct] = image
             ct += 1


### PR DESCRIPTION
问题描述 Please describe your issue
从快速入门开始的，训练完成，在进行预测时： python tools/infer.py -c configs/yolov3/yolov3_mobilenet_v1_roadsign.yml -o use_gpu=true --infer_img=demo/road554.png ；有报错：