### PR TITLE
fix(visualizer): expand user path in visualizer.py (#9467)

### DIFF
--- a/ppdet/utils/visualizer.py
+++ b/ppdet/utils/visualizer.py
@@ -109,7 +109,7 @@ def draw_bbox(image, im_id, catid2name, bboxes, threshold):
         PIL.Image: Image with drawn bounding boxes and optional reading order lines.
     """
     font_url = "https://paddledet.bj.bcebos.com/simfang.ttf"
-    font_path, _ = get_path(font_url, "~/.cache/paddle/")
+    font_path, _ = get_path(font_url, os.path.expanduser("~/.cache/paddle/"))
     font_size = 18
     font = ImageFont.truetype(font_path, font_size, encoding="utf-8")
 


### PR DESCRIPTION
## 问题
修复 #9467：`ppdet/utils/visualizer.py` 第 112 行使用了未扩展的路径（如 `~`），运行推理时会在当前目录生成 `~` 文件夹，影响用户使用。

## 根因
`download.py` 中 `WEIGHTS_HOME = osp.expanduser("~/.cache/paddle/weights")` 已正确展开，
但 `visualizer.py` 第 112 行传了未展开的 `"~/.cache/paddle/"` 给 `get_path()`。

## 修复
使用 `os.path.expanduser()` 包裹路径变量，确保用户主目录路径被正确展开。

```diff
-    font_path, _ = get_path(font_url, "~/.cache/paddle/")
+    font_path, _ = get_path(font_url, os.path.expanduser("~/.cache/paddle/"))
```

## 测试
- [x] `python -m py_compile ppdet/utils/visualizer.py` 通过
- [x] 语法检查通过
- [ ] 本地推理可视化测试（待 manual 验证）

## 影响
- 风险：极低（仅修改 1 行）
- 兼容性：完全向后兼容
- 性能：无影响

## Checklist
- [x] 签 CLA（CLAassistant bot 自动检测）
- [x] 修复一个 issue
- [x] 单行修改，PR 标题用英文 + issue 编号