### PR TITLE
fix: replace bare except with ImportError in core modules

### DIFF
--- a/ppdet/metrics/mot_metrics.py
+++ b/ppdet/metrics/mot_metrics.py
@@ -31,11 +31,10 @@ from .munkres import Munkres
 try:
     import motmetrics as mm
     mm.lap.default_solver = 'lap'
-except:
+except ImportError:
     print(
         'Warning: Unable to use MOT metric, please install motmetrics, for example: `pip install motmetrics`, see https://github.com/longcw/py-motmetrics'
     )
-    pass
 
 from ppdet.utils.logger import setup_logger
 logger = setup_logger(__name__)

--- a/ppdet/modeling/ops.py
+++ b/ppdet/modeling/ops.py
@@ -19,13 +19,13 @@ from paddle import ParamAttr
 from paddle.regularizer import L2Decay
 try:
     import paddle._legacy_C_ops as C_ops
-except:
+except ImportError:
     import paddle._C_ops as C_ops
 
 try:
     from paddle.framework import in_dynamic_or_pir_mode
     HAVE_PIR = True
-except:
+except ImportError:
     HAVE_PIR = False
 
 from paddle import in_dynamic_mode


### PR DESCRIPTION
## Motivation

The \ops.py\ and \mot_metrics.py\ files contain bare except clauses (\except:\) which catch all exceptions including \SystemExit\ and \KeyboardInterrupt\. These are all import fallback patterns that should only catch \ImportError\.

## Changes

- \ppdet/modeling/ops.py\: Replace 2 bare except with \except ImportError:\
  - paddle._legacy_C_ops import fallback
  - in_dynamic_or_pir_mode import fallback
- \ppdet/metrics/mot_metrics.py\: Replace 1 bare except with \except ImportError:\
  - motmetrics import fallback
- Also removed redundant \pass\ statement after print in mot_metrics.py

## Testing

- No functional changes - only exception handling improvement
- Import fallback behavior is preserved
- Local environment limitations - relying on CI/CD automated testing

## Checklist

- [x] Code follows the project's coding standards
- [x] No new dependencies added
- [x] Commit messages follow conventional format