### PR TITLE
Fix the RCNN export_onnx path under PIR

### DIFF
--- a/ppdet/modeling/post_process.py
+++ b/ppdet/modeling/post_process.py
@@ -160,6 +160,9 @@ class BBoxPostProcess(object):
         else:
             # simplify the computation for bs=1 when exporting onnx
             scale_y, scale_x = scale_factor[0][0], scale_factor[0][1]
+            # TODO(PIR): indexing yields 0-d tensors which concat rejects.
+            scale_y = paddle.unsqueeze(scale_y, 0)
+            scale_x = paddle.unsqueeze(scale_x, 0)
             scale = paddle.concat(
                 [scale_x, scale_y, scale_x, scale_y]).unsqueeze(0)
             self.origin_shape_list = paddle.expand(origin_shape,

--- a/ppdet/modeling/proposal_generator/rpn_head.py
+++ b/ppdet/modeling/proposal_generator/rpn_head.py
@@ -242,7 +242,7 @@ class RPNHead(nn.Layer):
 
         if self.export_onnx:
             output_rois = [onnx_topk_rois]
-            output_rois_num = paddle.shape(onnx_topk_rois)[0]
+            output_rois_num = paddle.shape(onnx_topk_rois)[0:1]
         else:
             output_rois = bs_rois_collect
             output_rois_num = bs_rois_num_collect


### PR DESCRIPTION
Two one-liners that make `export_onnx=True` work again on the PIR path.

`RPNHead` carries a `__shared__` config key `export_onnx`. With it set, the RCNN
family emits a straight-line, batch-size-1 graph — a Python loop over FPN
levels, then concat/topk/gather — instead of the batch loop with TensorArray
accumulation. That is what makes an ONNX export of a two-stage detector possible
at all, and it had simply never been run under PIR.

Each change restores consistency with code a few lines above it in the same
function:

- **`rpn_head.py`** — `paddle.shape(onnx_topk_rois)[0]` is a 0-d tensor under
  PIR and the caller indexes `rois_num[0]`, so the export fails with
  `IndexError: list index out of range`. The non-ONNX branch three lines up
  already slices `[0:1]`.

- **`post_process.py`** — `concat` rejects the 0-d scalars that indexing
  `scale_factor` now yields: `ValueError: The axis is expected to be in range of
  [0, 0)`. The non-ONNX branch already unsqueezes them, and carries a
  `TODO(PIR)` comment asking for exactly this fix.

Without these, `faster_rcnn` and friends export a graph containing `while` +
TensorArray + `slice_array_dense`, which no ONNX exporter can follow.

Verified on Paddle 3.3 with `FLAGS_enable_pir_api=1`: the whole two-stage family
exports, converts with paddle2onnx, and matches Paddle inference. For
`faster_rcnn_r50_fpn_1x_coco`, over 20 COCO images, 140 boxes compared, worst
pairwise IoU 0.999992 and worst score delta 2.7e-06.
