### PR TITLE
PPYOLOEHead.post_process returns 3 values, the caller unpacks 2

### DIFF
--- a/ppdet/modeling/architectures/ppyoloe.py
+++ b/ppdet/modeling/architectures/ppyoloe.py
@@ -237,7 +237,7 @@ class PPYOLOEWithAuxHead(BaseArch):
                     yolo_head_outs, self.yolo_head.mask_anchors,
                     self.inputs['im_shape'], self.inputs['scale_factor'])
             else:
-                bbox, bbox_num = self.yolo_head.post_process(
+                bbox, bbox_num, _ = self.yolo_head.post_process(
                     yolo_head_outs, self.inputs['scale_factor'])
             output = {'bbox': bbox, 'bbox_num': bbox_num}
 


### PR DESCRIPTION
Exporting any of the `ppyoloe_plus_crn_t_auxhead_*` configs fails with

```
ValueError: too many values to unpack (expected 2)
```

`PPYOLOEHead.post_process` returns `(bbox, bbox_num, nms_keep_idx)`, but this
call site unpacks two. Only the auxhead variants take this branch — the other
PP-YOLOE configs go through `BBoxPostProcess`, which returns two — which is why
it went unnoticed.

Not PIR-related. Unblocks four configs:

- `ppyoloe_plus_crn_t_auxhead_300e_coco`
- `ppyoloe_plus_crn_t_auxhead_320_300e_coco`
- `ppyoloe_plus_crn_t_auxhead_relu_300e_coco`
- `ppyoloe_plus_crn_t_auxhead_relu_320_300e_coco`

All four then export, convert to ONNX, and match Paddle inference on 20 COCO
images.
